### PR TITLE
Fix skill-creator on Windows

### DIFF
--- a/skills/.system/skill-creator/scripts/init_skill.py
+++ b/skills/.system/skill-creator/scripts/init_skill.py
@@ -37,23 +37,23 @@ description: [TODO: Complete and informative explanation of what the skill does 
 
 **1. Workflow-Based** (best for sequential processes)
 - Works well when there are clear step-by-step procedures
-- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
-- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+- Example: DOCX skill with "Workflow Decision Tree" -> "Reading" -> "Creating" -> "Editing"
+- Structure: ## Overview -> ## Workflow Decision Tree -> ## Step 1 -> ## Step 2...
 
 **2. Task-Based** (best for tool collections)
 - Works well when the skill offers different operations/capabilities
-- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
-- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+- Example: PDF skill with "Quick Start" -> "Merge PDFs" -> "Split PDFs" -> "Extract Text"
+- Structure: ## Overview -> ## Quick Start -> ## Task Category 1 -> ## Task Category 2...
 
 **3. Reference/Guidelines** (best for standards or specifications)
 - Works well for brand guidelines, coding standards, or requirements
-- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
-- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+- Example: Brand styling with "Brand Guidelines" -> "Colors" -> "Typography" -> "Features"
+- Structure: ## Overview -> ## Guidelines -> ## Specifications -> ## Usage...
 
 **4. Capabilities-Based** (best for integrated systems)
 - Works well when the skill provides multiple interrelated features
-- Example: Product Management with "Core Capabilities" → numbered capability list
-- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+- Example: Product Management with "Core Capabilities" -> numbered capability list
+- Structure: ## Overview -> ## Core Capabilities -> ### 1. Feature -> ### 2. Feature...
 
 Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
 
@@ -212,7 +212,7 @@ def parse_resources(raw_resources):
     invalid = sorted({item for item in resources if item not in ALLOWED_RESOURCES})
     if invalid:
         allowed = ", ".join(sorted(ALLOWED_RESOURCES))
-        print(f"❌ Error: Unknown resource type(s): {', '.join(invalid)}")
+        print(f"[ERROR] Unknown resource type(s): {', '.join(invalid)}")
         print(f"   Allowed: {allowed}")
         sys.exit(1)
     deduped = []
@@ -233,23 +233,23 @@ def create_resource_dirs(skill_dir, skill_name, skill_title, resources, include_
                 example_script = resource_dir / "example.py"
                 example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
                 example_script.chmod(0o755)
-                print("✅ Created scripts/example.py")
+                print("[OK] Created scripts/example.py")
             else:
-                print("✅ Created scripts/")
+                print("[OK] Created scripts/")
         elif resource == "references":
             if include_examples:
                 example_reference = resource_dir / "api_reference.md"
                 example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
-                print("✅ Created references/api_reference.md")
+                print("[OK] Created references/api_reference.md")
             else:
-                print("✅ Created references/")
+                print("[OK] Created references/")
         elif resource == "assets":
             if include_examples:
                 example_asset = resource_dir / "example_asset.txt"
                 example_asset.write_text(EXAMPLE_ASSET)
-                print("✅ Created assets/example_asset.txt")
+                print("[OK] Created assets/example_asset.txt")
             else:
-                print("✅ Created assets/")
+                print("[OK] Created assets/")
 
 
 def init_skill(skill_name, path, resources, include_examples):
@@ -270,15 +270,15 @@ def init_skill(skill_name, path, resources, include_examples):
 
     # Check if directory already exists
     if skill_dir.exists():
-        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        print(f"[ERROR] Skill directory already exists: {skill_dir}")
         return None
 
     # Create skill directory
     try:
         skill_dir.mkdir(parents=True, exist_ok=False)
-        print(f"✅ Created skill directory: {skill_dir}")
+        print(f"[OK] Created skill directory: {skill_dir}")
     except Exception as e:
-        print(f"❌ Error creating directory: {e}")
+        print(f"[ERROR] Error creating directory: {e}")
         return None
 
     # Create SKILL.md from template
@@ -288,9 +288,9 @@ def init_skill(skill_name, path, resources, include_examples):
     skill_md_path = skill_dir / "SKILL.md"
     try:
         skill_md_path.write_text(skill_content)
-        print("✅ Created SKILL.md")
+        print("[OK] Created SKILL.md")
     except Exception as e:
-        print(f"❌ Error creating SKILL.md: {e}")
+        print(f"[ERROR] Error creating SKILL.md: {e}")
         return None
 
     # Create resource directories if requested
@@ -298,11 +298,11 @@ def init_skill(skill_name, path, resources, include_examples):
         try:
             create_resource_dirs(skill_dir, skill_name, skill_title, resources, include_examples)
         except Exception as e:
-            print(f"❌ Error creating resource directories: {e}")
+            print(f"[ERROR] Error creating resource directories: {e}")
             return None
 
     # Print next steps
-    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print(f"\n[OK] Skill '{skill_name}' initialized successfully at {skill_dir}")
     print("\nNext steps:")
     print("1. Edit SKILL.md to complete the TODO items and update the description")
     if resources:
@@ -338,11 +338,11 @@ def main():
     raw_skill_name = args.skill_name
     skill_name = normalize_skill_name(raw_skill_name)
     if not skill_name:
-        print("❌ Error: Skill name must include at least one letter or digit.")
+        print("[ERROR] Skill name must include at least one letter or digit.")
         sys.exit(1)
     if len(skill_name) > MAX_SKILL_NAME_LENGTH:
         print(
-            f"❌ Error: Skill name '{skill_name}' is too long ({len(skill_name)} characters). "
+            f"[ERROR] Skill name '{skill_name}' is too long ({len(skill_name)} characters). "
             f"Maximum is {MAX_SKILL_NAME_LENGTH} characters."
         )
         sys.exit(1)
@@ -351,12 +351,12 @@ def main():
 
     resources = parse_resources(args.resources)
     if args.examples and not resources:
-        print("❌ Error: --examples requires --resources to be set.")
+        print("[ERROR] --examples requires --resources to be set.")
         sys.exit(1)
 
     path = args.path
 
-    print(f"🚀 Initializing skill: {skill_name}")
+    print(f"Initializing skill: {skill_name}")
     print(f"   Location: {path}")
     if resources:
         print(f"   Resources: {', '.join(resources)}")

--- a/skills/.system/skill-creator/scripts/package_skill.py
+++ b/skills/.system/skill-creator/scripts/package_skill.py
@@ -32,27 +32,27 @@ def package_skill(skill_path, output_dir=None):
 
     # Validate skill folder exists
     if not skill_path.exists():
-        print(f"❌ Error: Skill folder not found: {skill_path}")
+        print(f"[ERROR] Skill folder not found: {skill_path}")
         return None
 
     if not skill_path.is_dir():
-        print(f"❌ Error: Path is not a directory: {skill_path}")
+        print(f"[ERROR] Path is not a directory: {skill_path}")
         return None
 
     # Validate SKILL.md exists
     skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
-        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        print(f"[ERROR] SKILL.md not found in {skill_path}")
         return None
 
     # Run validation before packaging
-    print("🔍 Validating skill...")
+    print("Validating skill...")
     valid, message = validate_skill(skill_path)
     if not valid:
-        print(f"❌ Validation failed: {message}")
+        print(f"[ERROR] Validation failed: {message}")
         print("   Please fix the validation errors before packaging.")
         return None
-    print(f"✅ {message}\n")
+    print(f"[OK] {message}\n")
 
     # Determine output location
     skill_name = skill_path.name
@@ -75,11 +75,11 @@ def package_skill(skill_path, output_dir=None):
                     zipf.write(file_path, arcname)
                     print(f"  Added: {arcname}")
 
-        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        print(f"\n[OK] Successfully packaged skill to: {skill_filename}")
         return skill_filename
 
     except Exception as e:
-        print(f"❌ Error creating .skill file: {e}")
+        print(f"[ERROR] Error creating .skill file: {e}")
         return None
 
 
@@ -94,7 +94,7 @@ def main():
     skill_path = sys.argv[1]
     output_dir = sys.argv[2] if len(sys.argv) > 2 else None
 
-    print(f"📦 Packaging skill: {skill_path}")
+    print(f"Packaging skill: {skill_path}")
     if output_dir:
         print(f"   Output directory: {output_dir}")
     print()


### PR DESCRIPTION
- Replace non-ASCII output and template characters to avoid cp1252 encoding errors.