### PR TITLE
Make GitHub CLI auth guidance public-friendly in curated skills

### DIFF
--- a/skills/.curated/gh-address-comments/SKILL.md
+++ b/skills/.curated/gh-address-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-address-comments
-description: Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to run oai_gh if not logged in.
+description: Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to authenticate if not logged in.
 metadata:
   short-description: Address comments in a GitHub PR review
 ---
@@ -9,7 +9,7 @@ metadata:
 
 Guide to find the open PR for the current branch and address its comments with gh CLI. Run all `gh` commands with elevated network access.
 
-Prereq: run `oai_gh` once to authenticate, then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
+Prereq: ensure `gh` is authenticated (for example, run `gh auth login` once), then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
 
 ## 1) Inspect comments needing attention
 - Run scripts/fetch_comments.py which will print out all the comments and review threads on the PR
@@ -22,4 +22,4 @@ Prereq: run `oai_gh` once to authenticate, then run `gh auth status` with escala
 - Apply fixes for the selected comments
 
 Notes:
-- If gh hits auth/rate issues mid-run, prompt the user to re-run `oai_gh`, then retry.
+- If gh hits auth/rate issues mid-run, prompt the user to re-authenticate with `gh auth login`, then retry.

--- a/skills/.curated/gh-address-comments/scripts/fetch_comments.py
+++ b/skills/.curated/gh-address-comments/scripts/fetch_comments.py
@@ -111,8 +111,8 @@ def _ensure_gh_authenticated() -> None:
     try:
         _run(["gh", "auth", "status"])
     except RuntimeError:
-        print("use oai_gh to authenticate gh cli", file=sys.stderr)
-        raise RuntimeError("gh auth status failed; use oai_gh to authenticate gh cli") from None
+        print("run `gh auth login` to authenticate the GitHub CLI", file=sys.stderr)
+        raise RuntimeError("gh auth status failed; run `gh auth login` to authenticate the GitHub CLI") from None
 
 
 def gh_pr_view_json(fields: str) -> dict[str, Any]:

--- a/skills/.curated/gh-fix-ci/SKILL.md
+++ b/skills/.curated/gh-fix-ci/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 Use gh to locate failing PR checks, fetch GitHub Actions logs for actionable failures, summarize the failure snippet, then propose a fix plan and implement after explicit approval.
 - Depends on the `plan` skill for drafting and approving the fix plan.
 
-Prereq: run `oai_gh` once to authenticate, then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
+Prereq: ensure `gh` is authenticated (for example, run `gh auth login` once), then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
 
 ## Inputs
 
@@ -28,7 +28,7 @@ Prereq: run `oai_gh` once to authenticate, then run `gh auth status` with escala
 ## Workflow
 
 1. Verify gh authentication.
-   - Run `gh auth status` in the repo with escalated scopes (workflow/repo) after running `oai_gh`.
+   - Run `gh auth status` in the repo with escalated scopes (workflow/repo) after running `gh auth login`.
    - If sandboxed auth status fails, rerun the command with `sandbox_permissions=require_escalated` to allow network/keyring access.
    - If unauthenticated, ask the user to log in before proceeding.
 2. Resolve the PR.


### PR DESCRIPTION
This PR removes references to oai_gh from the curated GitHub skills and replaces them with standard GitHub CLI auth guidance (gh auth login). The goal is to avoid assuming internal tooling in a public repo.

That said, I'm not sure whether oai_gh is actually a built-in Codex helper. If it is, feel free to close this PR.

I also did a sweep of .curated for other internal-only helpers and didn't find any additional ones.