### PR TITLE
Add desktop-notify skill (macOS/Linux)

### DIFF
--- a/skills/.experimental/desktop-notify/LICENSE.txt
+++ b/skills/.experimental/desktop-notify/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.experimental/desktop-notify/SKILL.md
+++ b/skills/.experimental/desktop-notify/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: desktop-notify
+description: Send desktop notifications on macOS/Linux (terminal-notifier / notify-send) with an optional project-title wrapper.
+metadata:
+  short-description: Desktop notifications (macOS/Linux)
+---
+
+# Desktop Notify
+
+Send a short status update to the user via a desktop notification.
+
+This skill bundles two scripts:
+
+- `scripts/desktop-notify.sh`: Send a notification with an explicit title.
+- `scripts/project-notify.sh`: Derive a project title (basename) then send a notification.
+
+## Quick start
+
+Project-title wrapper (recommended):
+
+```bash
+bash "<path-to-skill>/scripts/project-notify.sh" "Done" --level success
+```
+
+Custom title:
+
+```bash
+bash "<path-to-skill>/scripts/desktop-notify.sh" \
+  --title "my-project" \
+  --message "Done" \
+  --level info
+```
+
+## Behavior
+
+- macOS: uses `terminal-notifier` when installed.
+- Linux: uses `notify-send` (libnotify) when installed.
+- Missing backend: silent no-op by default.
+- Unsupported OS: silent no-op.
+
+## Environment
+
+- `CODEX_DESKTOP_NOTIFY=0`: disable notifications (default: enabled)
+- `CODEX_DESKTOP_NOTIFY_HINTS=1`: print a one-line install hint when backend is missing (default: disabled)
+- `PROJECT_PATH`: used by `scripts/project-notify.sh` to derive the project title (fallback: git root, then `$PWD`)
+
+## Install hints
+
+- macOS: `brew install terminal-notifier`
+- Linux (Debian/Ubuntu): `sudo apt-get install libnotify-bin`
+- Linux (Fedora): `sudo dnf install libnotify`

--- a/skills/.experimental/desktop-notify/scripts/desktop-notify.sh
+++ b/skills/.experimental/desktop-notify/scripts/desktop-notify.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  echo "desktop-notify: $1" >&2
+  exit 2
+}
+
+trim() {
+  local s="${1:-}"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf "%s" "$s"
+}
+
+to_lower() {
+  printf "%s" "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  desktop-notify.sh --title <title> --message <message> [--level <info|success|warn|error>]
+
+Behavior:
+  - macOS: uses terminal-notifier (if installed)
+  - Linux: uses notify-send (libnotify) (if installed)
+  - Missing backend: no-op (optional one-line install hint to stderr)
+
+Environment:
+  CODEX_DESKTOP_NOTIFY=0   Disable notifications (default: enabled)
+  CODEX_DESKTOP_NOTIFY_HINTS=1  Print install hints when backend missing (default: disabled)
+
+Install hints:
+  - macOS: brew install terminal-notifier
+  - Linux (Debian/Ubuntu): sudo apt-get install libnotify-bin
+  - Linux (Fedora): sudo dnf install libnotify
+EOF
+}
+
+is_disabled_by_env() {
+  local v
+  v="$(to_lower "$(trim "${CODEX_DESKTOP_NOTIFY:-1}")")"
+  case "$v" in
+    0|false|no|off)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+are_hints_enabled() {
+  local v
+  v="$(to_lower "$(trim "${CODEX_DESKTOP_NOTIFY_HINTS:-0}")")"
+  case "$v" in
+    1|true|yes|on)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+title=""
+message=""
+level="info"
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --title)
+      title="${2:-}"
+      [[ -n "$title" ]] || die "Missing value for --title"
+      shift 2
+      ;;
+    --message)
+      message="${2:-}"
+      [[ -n "$message" ]] || die "Missing value for --message"
+      shift 2
+      ;;
+    --level)
+      level="$(to_lower "$(trim "${2:-}")")"
+      [[ -n "$level" ]] || die "Missing value for --level"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: ${1}"
+      ;;
+  esac
+done
+
+[[ -n "$title" ]] || die "Missing --title"
+[[ -n "$message" ]] || die "Missing --message"
+
+case "$level" in
+  info|success|warn|warning|error)
+    ;;
+  *)
+    die "Invalid --level: $level (expected info|success|warn|error)"
+    ;;
+esac
+
+if is_disabled_by_env; then
+  exit 0
+fi
+
+os="$(uname -s 2>/dev/null || true)"
+
+if [[ "$os" == "Darwin" ]]; then
+  if command -v terminal-notifier >/dev/null 2>&1; then
+    if terminal-notifier -title "$title" -message "$message" >/dev/null 2>&1; then
+      exit 0
+    fi
+    exit 0
+  fi
+
+  if are_hints_enabled; then
+    echo "desktop-notify: terminal-notifier not found (install: brew install terminal-notifier)" >&2
+  fi
+  exit 0
+fi
+
+if [[ "$os" == "Linux" ]]; then
+  if command -v notify-send >/dev/null 2>&1; then
+    urgency="normal"
+    case "$level" in
+      error)
+        urgency="critical"
+        ;;
+      warn|warning)
+        urgency="normal"
+        ;;
+    esac
+
+    if notify-send -u "$urgency" "$title" "$message" >/dev/null 2>&1; then
+      exit 0
+    fi
+    exit 0
+  fi
+
+  if are_hints_enabled; then
+    echo "desktop-notify: notify-send not found (install: libnotify; e.g. apt-get install libnotify-bin)" >&2
+  fi
+  exit 0
+fi
+
+exit 0

--- a/skills/.experimental/desktop-notify/scripts/project-notify.sh
+++ b/skills/.experimental/desktop-notify/scripts/project-notify.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  echo "project-notify: $1" >&2
+  exit 2
+}
+
+trim() {
+  local s="${1:-}"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf "%s" "$s"
+}
+
+to_lower() {
+  printf "%s" "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  project-notify.sh <message> [--level <info|success|warn|error>]
+  project-notify.sh --message <message> [--level <info|success|warn|error>]
+
+Behavior:
+  - Derives title from PROJECT_PATH basename (preferred), else git root, else PWD basename.
+  - Delegates to scripts/desktop-notify.sh.
+
+Environment:
+  PROJECT_PATH                  Used to derive the title (preferred)
+  CODEX_DESKTOP_NOTIFY=0        Disable notifications (default: enabled)
+  CODEX_DESKTOP_NOTIFY_HINTS=1  Print install hints when backend missing (default: disabled)
+EOF
+}
+
+message=""
+level="success"
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --message)
+      message="${2:-}"
+      [[ -n "$message" ]] || die "Missing value for --message"
+      shift 2
+      ;;
+    --level)
+      level="$(to_lower "$(trim "${2:-}")")"
+      [[ -n "$level" ]] || die "Missing value for --level"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      if [[ -z "$message" ]]; then
+        message="$1"
+        shift
+      else
+        die "Unexpected argument: $1"
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$message" && $# -gt 0 ]]; then
+  message="$1"
+  shift || true
+fi
+
+message="$(trim "$message")"
+[[ -n "$message" ]] || die "Missing message"
+
+case "$level" in
+  info|success|warn|warning|error)
+    ;;
+  *)
+    die "Invalid --level: $level (expected info|success|warn|error)"
+    ;;
+esac
+
+self_path="${BASH_SOURCE[0]:-$0}"
+self_dir="$(cd "$(dirname "$self_path")" >/dev/null 2>&1 && pwd -P || true)"
+[[ -n "$self_dir" ]] || die "Unable to resolve script directory"
+
+desktop_notify_abs=""
+declare -a desktop_notify_candidates=()
+
+desktop_notify_candidates+=("${self_dir%/}/desktop-notify.sh")
+
+if [[ -n "${CODEX_HOME:-}" ]]; then
+  desktop_notify_candidates+=("${CODEX_HOME%/}/skills/desktop-notify/scripts/desktop-notify.sh")
+  desktop_notify_candidates+=("${CODEX_HOME%/}/scripts/desktop-notify.sh")
+fi
+
+for candidate in "${desktop_notify_candidates[@]}"; do
+  if [[ -f "$candidate" ]]; then
+    desktop_notify_abs="$candidate"
+    break
+  fi
+done
+
+[[ -n "$desktop_notify_abs" ]] || die "Missing desktop notifier (expected next to project-notify.sh)"
+
+resolve_project_path_for_title() {
+  local candidate
+  candidate="$(trim "${PROJECT_PATH:-}")"
+  if [[ -n "$candidate" ]]; then
+    printf "%s" "$candidate"
+    return 0
+  fi
+
+  if command -v git >/dev/null 2>&1; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      git rev-parse --show-toplevel 2>/dev/null || true
+      return 0
+    fi
+  fi
+
+  printf "%s" "${PWD:-.}"
+}
+
+project_path="$(resolve_project_path_for_title)"
+title="$(basename "$project_path")"
+title="$(trim "$title")"
+if [[ -z "$title" || "$title" == "/" || "$title" == "." ]]; then
+  title="project"
+fi
+
+if [[ -x "$desktop_notify_abs" ]]; then
+  "$desktop_notify_abs" --title "$title" --message "$message" --level "$level" >/dev/null || true
+else
+  bash "$desktop_notify_abs" --title "$title" --message "$message" --level "$level" >/dev/null || true
+fi


### PR DESCRIPTION
## Summary

This PR adds a new experimental skill: `desktop-notify`, which lets Codex (or any agent workflow) send a short desktop notification on macOS and Linux. I use this when Codex runs long tasks so I can see completion status immediately.

## External dependencies / Install hints

This skill relies on OS-specific notification utilities:

- macOS: `brew install terminal-notifier`
- Linux (Debian/Ubuntu): `sudo apt-get install libnotify-bin`
- Linux (Fedora): `sudo dnf install libnotify`

If the backend is missing, the scripts default to a silent no-op.

## What’s included

- `scripts/desktop-notify.sh`
  - Sends a notification with an explicit `--title`, `--message`, and `--level` (`info|success|warn|error`).
  - macOS backend: `terminal-notifier` (if installed)
  - Linux backend: `notify-send` (if installed)
- `scripts/project-notify.sh`
  - Derives a project title from `PROJECT_PATH` basename (preferred), otherwise git root basename, otherwise `$PWD` basename.
  - Delegates to `scripts/desktop-notify.sh`.
- `LICENSE.txt` (Apache 2.0)

## Behavior notes

- Default: enabled.
- Missing backend: silent no-op by default (no extra stderr noise).
- Optional install hint: set `CODEX_DESKTOP_NOTIFY_HINTS=1` to print a one-line hint to stderr.
- Disable notifications entirely: set `CODEX_DESKTOP_NOTIFY=0`.
- Unsupported OS: silent no-op.

## Usage

Recommended (project-title wrapper):

```bash
bash "<path-to-skill>/scripts/project-notify.sh" "Done" --level success
```

Custom title:

```bash
bash "<path-to-skill>/scripts/desktop-notify.sh" --title "my-project" --message "Done" --level info
```

## Testing

- `bash -n scripts/desktop-notify.sh scripts/project-notify.sh`
- Manual smoke tests:
  - `CODEX_DESKTOP_NOTIFY=0` to verify no-op path
  - `CODEX_DESKTOP_NOTIFY_HINTS=1` to verify install hint output when backend is missing

## Checklist

- [x] I have read the CLA and will sign via the CLA-Assistant PR comment
- [x] Added `LICENSE.txt` for the new skill
- [x] Scripts default to safe, silent behavior when dependencies are missing
- [x] Documentation includes install hints and environment flags
