### PR TITLE
skill-creator: note about hidden dirs

### DIFF
--- a/skills/.system/skill-creator/SKILL.md
+++ b/skills/.system/skill-creator/SKILL.md
@@ -371,3 +371,7 @@ After testing the skill, users may request improvements. Often this happens righ
 2. Notice struggles or inefficiencies
 3. Identify how SKILL.md or bundled resources should be updated
 4. Implement changes and test again
+
+### Notes
+
+- Search hidden dirs when locating skill scripts.


### PR DESCRIPTION
I noticed that when that when using $skill-creator (on wsl at least) that codex struggled to find the init_skill.py because it is .system (hidden) directory.  This one line addition to the SKILL.md is helping codex find the scripts faster and with less token usage.