### PR TITLE
Fix CLA document path

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-document: https://github.com/openai/skills/blob/main/docs/CLA.md
+          path-to-document: https://github.com/openai/skills/blob/main/CLA.md
           path-to-signatures: signatures/cla.json
           branch: cla-signatures
           allowlist: codex,dependabot,dependabot[bot],github-actions[bot]


### PR DESCRIPTION
## Summary

This PR corrects the path to the CLA document referenced in the GitHub Actions workflow. The CLA document is located at the root of the repository, not in a docs/ subdirectory.