### PR TITLE
Add metadata short-instruction to display placeholder text.

### DIFF
--- a/skills/.system/skill-creator/SKILL.md
+++ b/skills/.system/skill-creator/SKILL.md
@@ -3,6 +3,7 @@ name: skill-creator
 description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations.
 metadata:
   short-description: Create or update a skill
+  short-instruction: Describe the skill you want to create
 ---
 
 # Skill Creator

--- a/skills/.system/skill-installer/SKILL.md
+++ b/skills/.system/skill-installer/SKILL.md
@@ -3,6 +3,7 @@ name: skill-installer
 description: Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos).
 metadata:
   short-description: Install curated skills from openai/skills or other repos
+  short-instruction: Describe the skill you want to install
 ---
 
 # Skill Installer


### PR DESCRIPTION
It's unclear to a new user what to prompt when a skill is selected, adding a `short-instruction` field so it can be rendered as a placeholder instruction text next to the activated skill.

<img width="1924" height="596" alt="CleanShot 2026-01-12 at 15 06 02@2x" src="https://github.com/user-attachments/assets/845008b3-83b1-4657-9abf-5a6296c3284b" />
