### PR TITLE
Add CLI tool for `render-deploy` skill

### DIFF
--- a/skills/.curated/render-deploy/agents/openai.yaml
+++ b/skills/.curated/render-deploy/agents/openai.yaml
@@ -11,3 +11,6 @@ dependencies:
       description: "Render MCP server"
       transport: "streamable_http"
       url: "https://mcp.render.com/mcp"
+    - type: "cli"
+      value: "render"
+      description: "Render CLI"


### PR DESCRIPTION
This declares the Render CLI as an available tool, from [#65](https://github.com/openai/skills/pull/65/changes#diff-03729e755592548c69f8e71c0a3087f0ff6811df621fadc0ef9c907e8bffc9b9R18-R20)