### PR TITLE
Add prerequisites and troubleshooting to deploy skills

### DIFF
--- a/skills/.curated/cloudflare-deploy/SKILL.md
+++ b/skills/.curated/cloudflare-deploy/SKILL.md
@@ -7,6 +7,11 @@ description: Deploy applications and infrastructure to Cloudflare using Workers,
 
 Consolidated skill for building on the Cloudflare platform. Use decision trees below to find the right product, then load detailed references.
 
+## Prerequisites
+
+- When sandboxing blocks the deployment network calls, rerun with `sandbox_permissions=require_escalated`.
+- The deployment might take a few minutes. Use appropriate timeout values.
+
 ## Authentication (Required Before Deploy)
 
 Verify auth before `wrangler deploy`, `wrangler pages deploy`, or `npm run deploy`:
@@ -205,3 +210,15 @@ Need IaC? → pulumi/ (Pulumi), terraform/ (Terraform), or api/ (REST API)
 | Static Assets | `references/static-assets/` |
 | Bindings | `references/bindings/` |
 | Cache Reserve | `references/cache-reserve/` |
+
+## Troubleshooting
+
+### Escalated Network Access
+
+If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the deploy with escalated permissions (use `sandbox_permissions=require_escalated`). The deploy requires escalated network access when sandbox networking blocks outbound requests.
+
+Example guidance to the user:
+
+```
+The deploy needs escalated network access to deploy to Cloudflare. I can rerun the command with escalated permissions—want me to proceed?
+```

--- a/skills/.curated/netlify-deploy/SKILL.md
+++ b/skills/.curated/netlify-deploy/SKILL.md
@@ -20,6 +20,8 @@ This skill automates Netlify deployments by:
 - **Netlify CLI**: Installed via npx (no global install required)
 - **Authentication**: Netlify account with active login session
 - **Project**: Valid web project in current directory
+- When sandboxing blocks the deployment network calls, rerun with `sandbox_permissions=require_escalated`.
+- The deployment might take a few minutes. Use appropriate timeout values.
 
 ## Authentication Pattern
 
@@ -205,6 +207,18 @@ Common issues and solutions:
 **"Publish directory not found"**
 → Verify build command ran successfully
 → Check publish directory path is correct
+
+## Troubleshooting
+
+### Escalated Network Access
+
+If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the deploy with escalated permissions (use `sandbox_permissions=require_escalated`). The deploy requires escalated network access when sandbox networking blocks outbound requests.
+
+Example guidance to the user:
+
+```
+The deploy needs escalated network access to deploy to Netlify. I can rerun the command with escalated permissions—want me to proceed?
+```
 
 ## Environment Variables
 

--- a/skills/.curated/render-deploy/SKILL.md
+++ b/skills/.curated/render-deploy/SKILL.md
@@ -17,6 +17,11 @@ If there is no Git remote, stop and ask the user to either:
 - Create/push a Git remote (can be minimal if only the Blueprint is needed), or
 - Use the Render Dashboard/API to deploy a prebuilt Docker image (MCP cannot create image-backed services).
 
+## Prerequisites
+
+- When sandboxing blocks the deployment network calls, rerun with `sandbox_permissions=require_escalated`.
+- The deployment might take a few minutes. Use appropriate timeout values.
+
 ## When to Use This Skill
 
 Activate this skill when users want to:
@@ -457,6 +462,18 @@ Detailed checklist and commands: [references/post-deploy-checks.md](references/p
 
 If the service fails to start or health checks time out, use the basic triage guide:
 [references/troubleshooting-basics.md](references/troubleshooting-basics.md)
+
+## Troubleshooting
+
+### Escalated Network Access
+
+If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the deploy with escalated permissions (use `sandbox_permissions=require_escalated`). The deploy requires escalated network access when sandbox networking blocks outbound requests.
+
+Example guidance to the user:
+
+```
+The deploy needs escalated network access to deploy to Render. I can rerun the command with escalated permissions—want me to proceed?
+```
 
 Optional: If you need deeper diagnostics (metrics/DB checks/error catalog), suggest installing the
 `render-debug` skill. It is not required for the core deploy flow.


### PR DESCRIPTION
**Summary**
- aligned the Cloudflare, Netlify, and Render deploy skills with the prereqs and escalation guidance from the Vercel skill
- documented requirement to rerun deployments with `sandbox_permissions=require_escalated` when sandboxing blocks networking and reminded that deployments may take several minutes
- added a Troubleshooting section that describes when to request escalated network access and sample messaging for Cloudflare, Netlify, and Render

**Testing**
- Not run (not requested)