### PR TITLE
Add Twist CLI skill

### DIFF
--- a/skills/.curated/twist-cli/LICENSE.txt
+++ b/skills/.curated/twist-cli/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Doist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.curated/twist-cli/SKILL.md
+++ b/skills/.curated/twist-cli/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: twist-cli
+description: Manage Twist workspaces, threads, messages, DMs, reactions, and search using the `tw` CLI; use for reading and responding to Twist conversations from the command line.
+---
+
+# Twist CLI (tw)
+
+Access Twist messaging via the `tw` CLI. Use when the user asks about their Twist workspaces, threads, messages, or wants to interact with Twist in any way.
+
+## Setup
+
+```bash
+tw auth token <your-api-token>   # Save API token
+tw auth status                   # Verify authentication
+tw auth logout                   # Remove saved token
+tw workspaces                    # List available workspaces
+tw workspace use <ref>           # Set current workspace
+```
+
+## Inbox
+
+```bash
+tw inbox                         # Show inbox threads
+tw inbox --unread                # Only unread threads
+tw inbox --channel <filter>      # Filter by channel name (fuzzy)
+tw inbox --since <date>          # Filter by date (ISO format)
+tw inbox --limit <n>             # Max items (default: 50)
+```
+
+## Threads
+
+```bash
+tw thread view <thread-ref>      # View thread with comments
+tw thread view <ref> --unread    # Show only unread comments
+tw thread view <ref> --context 3 # Include 3 read comments before unread
+tw thread reply <ref> "content"  # Post a comment
+tw thread done <ref>             # Archive thread (mark done)
+```
+
+## Conversations (DMs/Groups)
+
+```bash
+tw msg unread                    # List unread conversations
+tw msg view <conversation-ref>   # View conversation messages
+tw msg reply <ref> "content"     # Send a message
+tw msg done <ref>                # Archive conversation
+```
+
+## Search
+
+```bash
+tw search "query"                # Search content
+tw search "query" --type threads # Filter: threads, messages, or all
+tw search "query" --author <ref> # Filter by author
+tw search "query" --title-only   # Search thread titles only
+tw search "query" --mention-me   # Results mentioning current user
+tw search "query" --since <date> # Content from date
+tw search "query" --channel <id> # Filter by channel IDs (comma-separated)
+```
+
+## Users & Channels
+
+```bash
+tw user                          # Show current user info
+tw users                         # List workspace users
+tw users --search <text>         # Filter by name/email
+tw channels                      # List workspace channels
+```
+
+## Reactions
+
+```bash
+tw react thread <id> 👍          # Add reaction to thread
+tw react comment <id> +1         # Add reaction (shortcode)
+tw react message <id> heart      # Add reaction to DM message
+tw unreact thread <id> 👍        # Remove reaction
+```
+
+Supported shortcodes: +1, -1, heart, tada, smile, laughing, thinking, fire, check, x, eyes, pray, clap, rocket, wave
+
+## Output Formats
+
+All list/view commands support:
+
+```bash
+--json    # Output as JSON
+--ndjson  # Output as newline-delimited JSON (for streaming)
+--full    # Include all fields (default shows essential fields only)
+```
+
+## Reference System
+
+Commands accept flexible references:
+- **Numeric IDs**: `123` or `id:123`
+- **Twist URLs**: Full `https://twist.com/...` URLs (parsed automatically)
+- **Fuzzy names**: For workspaces/users - `"My Workspace"` or partial matches
+
+## Common Workflows
+
+**Check inbox and respond:**
+```bash
+tw inbox --unread --json
+tw thread view <id> --unread
+tw thread reply <id> "Thanks, I'll look into this."
+tw thread done <id>
+```
+
+**Search and review:**
+```bash
+tw search "deployment" --type threads --json
+tw thread view <thread-id>
+```
+
+**Check DMs:**
+```bash
+tw msg unread --json
+tw msg view <conversation-id>
+tw msg reply <id> "Got it, thanks!"
+```

--- a/skills/.curated/twist-cli/agents/openai.yaml
+++ b/skills/.curated/twist-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Twist CLI (tw)"
+  short_description: "Manage Twist conversations with the tw CLI"
+  default_prompt: "Help me manage Twist conversations using the tw CLI. Check my inbox, reply to threads or DMs, and search for relevant messages or threads."


### PR DESCRIPTION
## Summary
- Add a curated Twist CLI skill under `skills/.curated/twist-cli`
- Provide a structured guide to the `tw` CLI for day-to-day Twist communication tasks
- Include agent metadata and an MIT license

## Details
- Content is adapted from the Twist CLI’s built-in skill content to keep parity with the `tw` command surface
- Covers setup/auth commands and workspace selection to ensure users are ready to interact with Twist
- Documents inbox triage, thread viewing/replying, DM handling, search filters, user/channel listing, and reactions
- Includes output format options (`--json`, `--ndjson`, `--full`) and reference rules (numeric IDs, URLs, fuzzy names)
- Adds common workflows for inbox response, search review, and DM follow-ups
