### PR TITLE
Fix playwright CLI package reference

### DIFF
--- a/skills/.curated/playwright/SKILL.md
+++ b/skills/.curated/playwright/SKILL.md
@@ -25,7 +25,7 @@ node --version
 npm --version
 
 # If missing, install Node.js/npm, then:
-npm install -g @playwright/mcp@latest
+npm install -g @playwright/cli@latest
 playwright-cli --help
 ```
 
@@ -56,7 +56,7 @@ Use the wrapper script:
 If the user prefers a global install, this is also valid:
 
 ```bash
-npm install -g @playwright/mcp@latest
+npm install -g @playwright/cli@latest
 playwright-cli --help
 ```
 
@@ -121,7 +121,7 @@ Refs can go stale. When a command fails due to a missing ref, snapshot again.
 
 ## Wrapper script
 
-The wrapper script uses `npx --package @playwright/mcp playwright-cli` so the CLI can run without a global install:
+The wrapper script uses `npx --package @playwright/cli playwright-cli` so the CLI can run without a global install:
 
 ```bash
 "$PWCLI" --help

--- a/skills/.curated/playwright/scripts/playwright_cli.sh
+++ b/skills/.curated/playwright/scripts/playwright_cli.sh
@@ -16,7 +16,7 @@ for arg in "$@"; do
   esac
 done
 
-cmd=(npx --yes --package @playwright/mcp playwright-cli)
+cmd=(npx --yes --package @playwright/cli playwright-cli)
 if [[ "${has_session_flag}" != "true" && -n "${PLAYWRIGHT_CLI_SESSION:-}" ]]; then
   cmd+=(--session "${PLAYWRIGHT_CLI_SESSION}")
 fi


### PR DESCRIPTION
## Summary
Fix Playwright CLI skill to reference the correct npm package.

## Changes
- Use `@playwright/cli` in the wrapper script instead of `@playwright/mcp`.
- Update skill install guidance to match the correct package.

## Why
The Playwright CLI binary is provided by `@playwright/cli`. The skill currently points at `@playwright/mcp`, which does not install `playwright-cli`, causing installs to succeed but the CLI to be missing.

## Testing
- Installed the updated skill locally.
- Opened Google and performed a search via `playwright-cli` in headed mode.
