### PR TITLE
fix(gh-address-comments): resolve script path and add CLI arguments

### DIFF
--- a/skills/.curated/gh-address-comments/SKILL.md
+++ b/skills/.curated/gh-address-comments/SKILL.md
@@ -11,15 +11,39 @@ Guide to find the open PR for the current branch and address its comments with g
 
 Prereq: ensure `gh` is authenticated (for example, run `gh auth login` once), then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
 
-## 1) Inspect comments needing attention
-- Run scripts/fetch_comments.py which will print out all the comments and review threads on the PR
+## Quick start
 
-## 2) Ask the user for clarification
+- `python "<path-to-skill>/scripts/fetch_comments.py" --repo "."`
+- Add `--pr <number-or-url>` to target a specific PR instead of the current branch.
+- Add `--json` for machine-friendly output.
+
+## Workflow
+
+### 1) Inspect comments needing attention
+- Preferred: run the bundled script:
+  - `python "<path-to-skill>/scripts/fetch_comments.py" --repo "."`
+  - If the user provides a PR number or URL, pass it: `--pr "<number-or-url>"`
+  - Add `--json` if you want machine-friendly output for summarization.
+- Manual fallback (if the script is unavailable):
+  - Use `gh api graphql` with the GraphQL query to fetch PR comments, reviews, and review threads.
+
+### 2) Ask the user for clarification
 - Number all the review threads and comments and provide a short summary of what would be required to apply a fix for it
 - Ask the user which numbered comments should be addressed
 
-## 3) If user chooses comments
+### 3) If user chooses comments
 - Apply fixes for the selected comments
+
+## Bundled Resources
+
+### scripts/fetch_comments.py
+
+Fetch all PR conversation comments, reviews, and inline review threads for a given PR. Outputs JSON to stdout.
+
+Usage examples:
+- `python "<path-to-skill>/scripts/fetch_comments.py" --repo "."`
+- `python "<path-to-skill>/scripts/fetch_comments.py" --repo "." --pr "123"`
+- `python "<path-to-skill>/scripts/fetch_comments.py" --repo "." --pr "https://github.com/org/repo/pull/456" --json`
 
 Notes:
 - If gh hits auth/rate issues mid-run, prompt the user to re-authenticate with `gh auth login`, then retry.

--- a/skills/.curated/gh-address-comments/agents/openai.yaml
+++ b/skills/.curated/gh-address-comments/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "GitHub Address Comments"
-  short_description: Address comments in a GitHub PR review"
+  short_description: "Address comments in a GitHub PR review"
   icon_small: "./assets/github-small.svg"
   icon_large: "./assets/github.png"
   default_prompt: "Address all actionable GitHub PR review comments in this branch and summarize the updates."

--- a/skills/.curated/gh-address-comments/scripts/fetch_comments.py
+++ b/skills/.curated/gh-address-comments/scripts/fetch_comments.py
@@ -7,17 +7,21 @@ for the PR associated with the current git branch, by shelling out to:
 
 Requires:
   - `gh auth login` already set up
-  - current branch has an associated (open) PR
+  - current branch has an associated (open) PR, or --pr is supplied
 
 Usage:
-  python fetch_comments.py > pr_comments.json
+  python fetch_comments.py --repo "."
+  python fetch_comments.py --repo "." --pr 123
+  python fetch_comments.py --repo "." --pr "https://github.com/org/repo/pull/456" --json
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 QUERY = """\
@@ -92,40 +96,85 @@ query(
 """
 
 
-def _run(cmd: list[str], stdin: str | None = None) -> str:
-    p = subprocess.run(cmd, input=stdin, capture_output=True, text=True)
+def _run(cmd: list[str], stdin: str | None = None, cwd: Path | None = None) -> str:
+    p = subprocess.run(cmd, input=stdin, capture_output=True, text=True, cwd=cwd)
     if p.returncode != 0:
         raise RuntimeError(f"Command failed: {' '.join(cmd)}\n{p.stderr}")
     return p.stdout
 
 
-def _run_json(cmd: list[str], stdin: str | None = None) -> dict[str, Any]:
-    out = _run(cmd, stdin=stdin)
+def _run_json(cmd: list[str], stdin: str | None = None, cwd: Path | None = None) -> dict[str, Any]:
+    out = _run(cmd, stdin=stdin, cwd=cwd)
     try:
         return json.loads(out)
     except json.JSONDecodeError as e:
         raise RuntimeError(f"Failed to parse JSON from command output: {e}\nRaw:\n{out}") from e
 
 
-def _ensure_gh_authenticated() -> None:
+def _ensure_gh_authenticated(cwd: Path | None = None) -> None:
     try:
-        _run(["gh", "auth", "status"])
+        _run(["gh", "auth", "status"], cwd=cwd)
     except RuntimeError:
         print("run `gh auth login` to authenticate the GitHub CLI", file=sys.stderr)
-        raise RuntimeError("gh auth status failed; run `gh auth login` to authenticate the GitHub CLI") from None
+        raise RuntimeError(
+            "gh auth status failed; run `gh auth login` to authenticate the GitHub CLI"
+        ) from None
 
 
-def gh_pr_view_json(fields: str) -> dict[str, Any]:
-    # fields is a comma-separated list like: "number,headRepositoryOwner,headRepository"
-    return _run_json(["gh", "pr", "view", "--json", fields])
+def _find_git_root(start: Path) -> Path | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=start,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
 
 
-def get_current_pr_ref() -> tuple[str, str, int]:
+def gh_pr_view_json(fields: str, cwd: Path | None = None) -> dict[str, Any]:
+    return _run_json(["gh", "pr", "view", "--json", fields], cwd=cwd)
+
+
+def get_current_pr_ref(cwd: Path | None = None) -> tuple[str, str, int]:
     """
     Resolve the PR for the current branch (whatever gh considers associated).
     Works for cross-repo PRs too, by reading head repository owner/name.
     """
-    pr = gh_pr_view_json("number,headRepositoryOwner,headRepository")
+    pr = gh_pr_view_json("number,headRepositoryOwner,headRepository", cwd=cwd)
+    owner = pr["headRepositoryOwner"]["login"]
+    repo = pr["headRepository"]["name"]
+    number = int(pr["number"])
+    return owner, repo, number
+
+
+def get_pr_ref_from_value(
+    pr_value: str, cwd: Path | None = None
+) -> tuple[str, str, int]:
+    """
+    Resolve owner, repo, and number from an explicit PR number or URL.
+
+    If ``pr_value`` is a URL we parse it directly.  If it is a bare number we
+    ask ``gh pr view`` to resolve it against the current repo.
+    """
+    if pr_value.startswith("http://") or pr_value.startswith("https://"):
+        parts = [p for p in pr_value.split("/") if p]
+        # https: / / github.com / owner / repo / pull / number
+        try:
+            idx = parts.index("pull")
+            owner = parts[idx - 2]
+            repo = parts[idx - 1]
+            number = int(parts[idx + 1])
+            return owner, repo, number
+        except (ValueError, IndexError):
+            pass
+
+    # Treat it as a number and let gh resolve the rest
+    pr = _run_json(
+        ["gh", "pr", "view", pr_value, "--json", "number,headRepositoryOwner,headRepository"],
+        cwd=cwd,
+    )
     owner = pr["headRepositoryOwner"]["login"]
     repo = pr["headRepository"]["name"]
     number = int(pr["number"])
@@ -139,6 +188,7 @@ def gh_api_graphql(
     comments_cursor: str | None = None,
     reviews_cursor: str | None = None,
     threads_cursor: str | None = None,
+    cwd: Path | None = None,
 ) -> dict[str, Any]:
     """
     Call `gh api graphql` using -F variables, avoiding JSON blobs with nulls.
@@ -164,10 +214,10 @@ def gh_api_graphql(
     if threads_cursor:
         cmd += ["-F", f"threadsCursor={threads_cursor}"]
 
-    return _run_json(cmd, stdin=QUERY)
+    return _run_json(cmd, stdin=QUERY, cwd=cwd)
 
 
-def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
+def fetch_all(owner: str, repo: str, number: int, cwd: Path | None = None) -> dict[str, Any]:
     conversation_comments: list[dict[str, Any]] = []
     reviews: list[dict[str, Any]] = []
     review_threads: list[dict[str, Any]] = []
@@ -186,6 +236,7 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
             comments_cursor=comments_cursor,
             reviews_cursor=reviews_cursor,
             threads_cursor=threads_cursor,
+            cwd=cwd,
         )
 
         if "errors" in payload and payload["errors"]:
@@ -226,12 +277,115 @@ def fetch_all(owner: str, repo: str, number: int) -> dict[str, Any]:
     }
 
 
-def main() -> None:
-    _ensure_gh_authenticated()
-    owner, repo, number = get_current_pr_ref()
-    result = fetch_all(owner, repo, number)
-    print(json.dumps(result, indent=2))
+def render_text(data: dict[str, Any]) -> None:
+    """Print a human-readable summary of the fetched PR data."""
+    pr = data["pull_request"]
+    print(f"PR #{pr['number']}: {pr['title']} ({pr['state']})")
+    print(f"URL: {pr['url']}")
+    print()
+
+    comments = data.get("conversation_comments") or []
+    if comments:
+        print(f"--- Conversation comments ({len(comments)}) ---")
+        for c in comments:
+            author = (c.get("author") or {}).get("login", "unknown")
+            print(f"\n[{author}] ({c.get('createdAt', '')}):")
+            print(c.get("body", ""))
+    else:
+        print("--- No conversation comments ---")
+    print()
+
+    review_list = data.get("reviews") or []
+    if review_list:
+        print(f"--- Reviews ({len(review_list)}) ---")
+        for r in review_list:
+            author = (r.get("author") or {}).get("login", "unknown")
+            state = r.get("state", "")
+            print(f"\n[{author}] {state} ({r.get('submittedAt', '')}):")
+            body = r.get("body", "")
+            if body:
+                print(body)
+    else:
+        print("--- No reviews ---")
+    print()
+
+    threads = data.get("review_threads") or []
+    if threads:
+        print(f"--- Review threads ({len(threads)}) ---")
+        for idx, t in enumerate(threads, start=1):
+            resolved = "RESOLVED" if t.get("isResolved") else "OPEN"
+            outdated = " (outdated)" if t.get("isOutdated") else ""
+            path = t.get("path", "")
+            line = t.get("line", "")
+            print(f"\nThread #{idx}: {path}:{line} [{resolved}{outdated}]")
+            for tc in (t.get("comments", {}).get("nodes") or []):
+                author = (tc.get("author") or {}).get("login", "unknown")
+                print(f"  [{author}] ({tc.get('createdAt', '')}):")
+                print(f"  {tc.get('body', '')}")
+    else:
+        print("--- No review threads ---")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch PR comments, reviews, and review threads via GitHub GraphQL.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Path inside the target Git repository.",
+    )
+    parser.add_argument(
+        "--pr",
+        default=None,
+        help="PR number or URL (defaults to current branch PR).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit JSON instead of human-readable text output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_path = Path(args.repo).resolve()
+    git_root = _find_git_root(repo_path)
+    if git_root is None:
+        print("Error: not inside a Git repository.", file=sys.stderr)
+        return 1
+
+    try:
+        _ensure_gh_authenticated(cwd=git_root)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        if args.pr:
+            owner, repo, number = get_pr_ref_from_value(args.pr, cwd=git_root)
+        else:
+            owner, repo, number = get_current_pr_ref(cwd=git_root)
+    except RuntimeError as exc:
+        print(f"Error resolving PR: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = fetch_all(owner, repo, number, cwd=git_root)
+    except RuntimeError as exc:
+        print(f"Error fetching comments: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json_output:
+        print(json.dumps(result, indent=2))
+    else:
+        render_text(result)
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes #96.

The `gh-address-comments` skill instructs agents to run `scripts/fetch_comments.py` using a bare relative path. Since agents execute from the **target repository** working directory (not the skill directory), the script is never found — forcing a fallback to raw GraphQL that loses the structured output the skill was designed around.

The sibling skill `gh-fix-ci` already solved this by using `<path-to-skill>/scripts/...` references. This PR aligns `gh-address-comments` to the same pattern and adds the missing CLI interface.

## Changes

**`SKILL.md`** — Rewrote the workflow section to reference the script with the `<path-to-skill>` prefix, added a Quick start block and Bundled Resources documentation matching the `gh-fix-ci` convention.

**`scripts/fetch_comments.py`** — Added `argparse` CLI with `--repo`, `--pr`, and `--json` flags. All `gh` and `git` subprocess calls now accept a `cwd` parameter resolved from `--repo`, so the script works when invoked from any directory. Added `get_pr_ref_from_value()` to resolve an explicit PR number or URL. Added `render_text()` for human-readable output (the default), with `--json` preserving the original raw JSON dump.

**`agents/openai.yaml`** — Fixed a missing opening quote on the `short_description` value (`Address comments in a GitHub PR review"` → `"Address comments in a GitHub PR review"`).

## Test plan

- [ ] Install the skill and invoke it from a repo with an open PR; verify the script is found and comments are printed
- [ ] Verify `--pr <number>` and `--pr <URL>` both resolve correctly
- [ ] Verify `--json` outputs valid JSON to stdout
- [ ] Verify the YAML parses without errors
