### PR TITLE
fix(skill-installer): add --force flag to allow reinstall/update

### DIFF
--- a/skills/.system/skill-installer/SKILL.md
+++ b/skills/.system/skill-installer/SKILL.md
@@ -35,19 +35,22 @@ All of these scripts use network, so when running in the sandbox, request escala
 
 - `scripts/list-skills.py` (prints skills list with installed annotations)
 - `scripts/list-skills.py --format json`
+- `scripts/list-skills.py --show-path` (show install path and health status for installed skills)
 - Example (experimental list): `scripts/list-skills.py --path skills/.experimental`
 - `scripts/install-skill-from-github.py --repo <owner>/<repo> --path <path/to/skill> [<path/to/skill> ...]`
 - `scripts/install-skill-from-github.py --url https://github.com/<owner>/<repo>/tree/<ref>/<path>`
+- Reinstall an existing skill: `scripts/install-skill-from-github.py --repo <owner>/<repo> --path <path/to/skill> --force`
 - Example (experimental skill): `scripts/install-skill-from-github.py --repo openai/skills --path skills/.experimental/<skill-name>`
 
 ## Behavior and Options
 
 - Defaults to direct download for public GitHub repos.
 - If download fails with auth/permission errors, falls back to git sparse checkout.
-- Aborts if the destination skill directory already exists.
+- Aborts if the destination skill directory already exists, unless `--force` is supplied.
+- With `--force`, the existing skill directory is removed and replaced with the freshly downloaded version. This is useful for updating a skill or recovering from a broken install.
 - Installs into `$CODEX_HOME/skills/<skill-name>` (defaults to `~/.codex/skills`).
 - Multiple `--path` values install multiple skills in one run, each named from the path basename unless `--name` is supplied.
-- Options: `--ref <ref>` (default `main`), `--dest <path>`, `--method auto|download|git`.
+- Options: `--ref <ref>` (default `main`), `--dest <path>`, `--method auto|download|git`, `--force`.
 
 ## Notes
 

--- a/skills/.system/skill-installer/scripts/install-skill-from-github.py
+++ b/skills/.system/skill-installer/scripts/install-skill-from-github.py
@@ -27,6 +27,7 @@ class Args:
     dest: str | None = None
     name: str | None = None
     method: str = "auto"
+    force: bool = False
 
 
 @dataclass
@@ -169,10 +170,15 @@ def _validate_skill(path: str) -> None:
         raise InstallError("SKILL.md not found in selected skill directory.")
 
 
-def _copy_skill(src: str, dest_dir: str) -> None:
+def _copy_skill(src: str, dest_dir: str, force: bool = False) -> None:
     os.makedirs(os.path.dirname(dest_dir), exist_ok=True)
     if os.path.exists(dest_dir):
-        raise InstallError(f"Destination already exists: {dest_dir}")
+        if not force:
+            raise InstallError(
+                f"Destination already exists: {dest_dir}\n"
+                "Use --force to remove the existing skill and reinstall."
+            )
+        shutil.rmtree(dest_dir)
     shutil.copytree(src, dest_dir)
 
 
@@ -263,6 +269,12 @@ def _parse_args(argv: list[str]) -> Args:
         choices=["auto", "download", "git"],
         default="auto",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Remove and reinstall if the skill already exists.",
+    )
     return parser.parse_args(argv, namespace=Args())
 
 
@@ -287,17 +299,21 @@ def main(argv: list[str]) -> int:
                 if not skill_name:
                     raise InstallError("Unable to derive skill name.")
                 dest_dir = os.path.join(dest_root, skill_name)
-                if os.path.exists(dest_dir):
-                    raise InstallError(f"Destination already exists: {dest_dir}")
+                if os.path.exists(dest_dir) and not args.force:
+                    raise InstallError(
+                        f"Destination already exists: {dest_dir}\n"
+                        "Use --force to remove the existing skill and reinstall."
+                    )
                 skill_src = os.path.join(repo_root, path)
                 _validate_skill(skill_src)
-                _copy_skill(skill_src, dest_dir)
+                _copy_skill(skill_src, dest_dir, force=args.force)
                 installed.append((skill_name, dest_dir))
         finally:
             if os.path.isdir(tmp_dir):
                 shutil.rmtree(tmp_dir, ignore_errors=True)
         for skill_name, dest_dir in installed:
-            print(f"Installed {skill_name} to {dest_dir}")
+            verb = "Reinstalled" if args.force else "Installed"
+            print(f"{verb} {skill_name} to {dest_dir}")
         return 0
     except InstallError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/skills/.system/skill-installer/scripts/list-skills.py
+++ b/skills/.system/skill-installer/scripts/list-skills.py
@@ -25,6 +25,7 @@ class Args(argparse.Namespace):
     path: str
     ref: str
     format: str
+    show_path: bool
 
 
 def _request(url: str) -> bytes:
@@ -45,6 +46,22 @@ def _installed_skills() -> set[str]:
         if os.path.isdir(path):
             entries.add(name)
     return entries
+
+
+def _installed_skills_detail() -> dict[str, dict[str, str]]:
+    """Return installed skills with path and health status."""
+    root = os.path.join(_codex_home(), "skills")
+    if not os.path.isdir(root):
+        return {}
+    detail: dict[str, dict[str, str]] = {}
+    for name in sorted(os.listdir(root)):
+        path = os.path.join(root, name)
+        if not os.path.isdir(path):
+            continue
+        skill_md = os.path.join(path, "SKILL.md")
+        status = "ok" if os.path.isfile(skill_md) else "broken (missing SKILL.md)"
+        detail[name] = {"path": path, "status": status}
+    return detail
 
 
 def _list_skills(repo: str, path: str, ref: str) -> list[str]:
@@ -80,6 +97,12 @@ def _parse_args(argv: list[str]) -> Args:
         default="text",
         help="Output format",
     )
+    parser.add_argument(
+        "--show-path",
+        action="store_true",
+        default=False,
+        help="Show install path and health status for installed skills.",
+    )
     return parser.parse_args(argv, namespace=Args())
 
 
@@ -88,14 +111,32 @@ def main(argv: list[str]) -> int:
     try:
         skills = _list_skills(args.repo, args.path, args.ref)
         installed = _installed_skills()
+        detail = _installed_skills_detail() if args.show_path else {}
         if args.format == "json":
-            payload = [
-                {"name": name, "installed": name in installed} for name in skills
-            ]
+            payload = []
+            for name in skills:
+                entry: dict[str, object] = {
+                    "name": name,
+                    "installed": name in installed,
+                }
+                if args.show_path and name in detail:
+                    entry["path"] = detail[name]["path"]
+                    entry["status"] = detail[name]["status"]
+                payload.append(entry)
             print(json.dumps(payload))
         else:
             for idx, name in enumerate(skills, start=1):
-                suffix = " (already installed)" if name in installed else ""
+                if name in installed:
+                    info = detail.get(name, {})
+                    if args.show_path and info:
+                        status = info.get("status", "")
+                        path_str = info.get("path", "")
+                        status_hint = f" [{status}]" if status != "ok" else ""
+                        suffix = f" (installed: {path_str}{status_hint})"
+                    else:
+                        suffix = " (already installed)"
+                else:
+                    suffix = ""
                 print(f"{idx}. {name}{suffix}")
         return 0
     except ListError as exc:


### PR DESCRIPTION
## Summary

Fixes #127.

The skill installer currently aborts with a hard error when the destination directory already exists. There is no built-in way to update a skill to a newer version, reinstall after local corruption, or recover from a partially-failed installation. This PR adds a `--force` flag that removes the existing directory before copying the new version in.

## Changes

**`scripts/install-skill-from-github.py`**
- Added `--force` CLI flag (defaults to `False`, preserving the current safe default).
- Updated `_copy_skill()` to accept a `force` parameter; when `True` the existing directory is removed via `shutil.rmtree` before `copytree`.
- Updated the early exists-check in `main()` to respect `--force` and surface an actionable hint ("Use --force to remove the existing skill and reinstall") when the flag is absent.
- Success message now says "Reinstalled" vs "Installed" when `--force` is active.

**`scripts/list-skills.py`**
- Added `_installed_skills_detail()` to return installed skill paths and health status (detects missing `SKILL.md` as "broken").
- Added `--show-path` CLI flag that displays the install directory and health status for each installed skill in both text and JSON output modes.

**`SKILL.md`**
- Documented `--force` in the Scripts and Behavior and Options sections.
- Documented `--show-path` in the Scripts section.
- Updated the Options line to include `--force`.

## Test plan

- [ ] Install a fresh skill, verify normal behavior unchanged
- [ ] Install the same skill again without `--force`, verify error message includes the `--force` hint
- [ ] Install the same skill again with `--force`, verify it reinstalls and prints "Reinstalled"
- [ ] Run `list-skills.py --show-path` and verify paths and status are shown
- [ ] Create a broken skill dir (no SKILL.md), verify `--show-path` reports "broken"
- [ ] Verify `--show-path --format json` includes `path` and `status` fields
