### PR TITLE
fix(gh-fix-ci): Prefer job-specific logs over run-level logs to prevent cross-job contamination

### DIFF
--- a/skills/.curated/gh-fix-ci/scripts/inspect_pr_checks.py
+++ b/skills/.curated/gh-fix-ci/scripts/inspect_pr_checks.py
@@ -335,19 +335,19 @@ def fetch_check_log(
     job_id: str | None,
     repo_root: Path,
 ) -> tuple[str, str, str]:
-    log_text, log_error = fetch_run_log(run_id, repo_root)
-    if not log_error:
-        return log_text, "", "ok"
-
-    if is_log_pending_message(log_error) and job_id:
+    # Prefer job-specific logs when job_id is available to avoid mixing
+    # logs from multiple jobs in the same workflow run.
+    if job_id:
         job_log, job_error = fetch_job_log(job_id, repo_root)
         if job_log:
             return job_log, "", "ok"
         if job_error and is_log_pending_message(job_error):
             return "", job_error, "pending"
-        if job_error:
-            return "", job_error, "error"
-        return "", log_error, "pending"
+        # Fall through to run-level log as fallback.
+
+    log_text, log_error = fetch_run_log(run_id, repo_root)
+    if not log_error:
+        return log_text, "", "ok"
 
     if is_log_pending_message(log_error):
         return "", log_error, "pending"


### PR DESCRIPTION
## Problem

When a workflow run contains multiple jobs, `fetch_check_log` fetches the entire run log (`gh run view --log`) which combines output from ALL jobs. It only falls back to job-specific logs when the run log is unavailable (pending).

This causes **cross-job log contamination**: the failure snippet for one job can contain errors from a completely different job, leading to incorrect CI failure diagnosis.

### Example

In a workflow with 22 jobs (e.g., [Velox Fuzzer Jobs](https://github.com/facebookincubator/velox/actions/workflows/scheduled.yml)), all failing checks get the same mixed log blob. `extract_failure_snippet` then picks up errors from the wrong job:

- "Spark Aggregate Fuzzer" snippet showed Memory Arbitration errors instead of its own aggregation mismatch
- "Ubuntu debug" snippet showed "Linux release with adapters" errors

## Fix

Prioritize `fetch_job_log(job_id)` via the GitHub API (`/repos/.../actions/jobs/{job_id}/logs`) when a `job_id` is available. Fall back to run-level logs (`gh run view --log`) only when:
- No `job_id` is available, OR
- The job-specific log fetch fails (non-pending error)

### Before
```python
def fetch_check_log(run_id, job_id, repo_root):
    log_text, log_error = fetch_run_log(run_id, repo_root)  # ALL jobs
    if not log_error:
        return log_text, "", "ok"  # ignores job_id
    # only tries job log when run log is PENDING
```

### After
```python
def fetch_check_log(run_id, job_id, repo_root):
    if job_id:
        job_log, job_error = fetch_job_log(job_id, repo_root)  # specific job
        if job_log:
            return job_log, "", "ok"
    # falls back to run-level log
    log_text, log_error = fetch_run_log(run_id, repo_root)
```

## Testing

Tested against [facebookincubator/velox#16308](https://github.com/facebookincubator/velox/pull/16308) which has a Fuzzer Jobs workflow with 22 jobs (1 failing). After the fix, each failing check correctly shows its own job-specific errors.