### PR TITLE
Re-add .experimental folder with README

### DIFF
--- a/skills/.experimental/README.md
+++ b/skills/.experimental/README.md
@@ -1,0 +1,19 @@
+# Experimental
+
+This directory contains experimental skills, prototypes, and early-stage ideas.
+
+Content here is intentionally unstable and may change, move, or be removed without notice.
+
+## Purpose
+
+- Rapid prototyping  
+- Testing new patterns or capabilities  
+- Exploring ideas before formal adoption  
+
+## Expectations
+
+- Not production-ready  
+- No stability guarantees  
+- May not follow final project conventions  
+
+Promising experiments may be promoted to stable modules once validated.


### PR DESCRIPTION
## Description

Closes #153

Adding this folder with a README so it's a bit more of a permanent fixture.  In a recent PR, the single skill was deleted, and since there wasn't any permanent content, the whole `.experimental` folder was deleted

## How it's referenced in docs

The `skills/.experimental` folder is referenced in this repo's README:
https://github.com/openai/skills/blob/4ab6e0fd99c6667163bc34173e3ed3a3fed75ebc/README.md?plain=1#L16

As well as the docs:
https://developers.openai.com/codex/skills/#install-skills
<img width="894" height="156" alt="image" src="https://github.com/user-attachments/assets/697a68ef-4f06-4eeb-a642-95e51eccf72c" />
