### PR TITLE
Add arduino-cli-suite curated skill

### DIFF
--- a/skills/.curated/arduino-cli-suite/LICENSE.txt
+++ b/skills/.curated/arduino-cli-suite/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Trent Wyatt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.curated/arduino-cli-suite/SKILL.md
+++ b/skills/.curated/arduino-cli-suite/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: arduino-cli-suite
+description: Unified orchestration for Arduino CLI tasks across discovery, setup, build, deployment, and diagnostics. Use when requests span multiple Arduino CLI domains or need an end-to-end workflow that coordinates board selection, core and library state, sketch operations, compile or upload, debug or monitor, configuration, maintenance, profiles, or daemon and gRPC integration.
+---
+
+# Workflow
+1. Classify the request into one or more Arduino CLI domains.
+2. Establish shared context first: board target, FQBN, port, sketch path, and output mode (`--json` vs text).
+3. Route to the minimum set of domain modules needed for execution.
+4. Execute in dependency order, then return verification commands and next checks.
+
+# Domain Modules
+- Foundation and global flags: `references/foundation.md`
+- Board and port discovery: `references/board-ops.md`
+- Core platform lifecycle: `references/core-ops.md`
+- Library lifecycle: `references/lib-ops.md`
+- Sketch creation and packaging: `references/sketch-ops.md`
+- Build, upload, and bootloader: `references/build-upload.md`
+- Debug and monitor sessions: `references/debug-monitor.md`
+- Config initialization and edits: `references/config.md`
+- Profile operations: `references/profile-ops.md`
+- Environment maintenance and upgrades: `references/maintenance.md`
+- Daemon and gRPC operation: `references/daemon-grpc.md`
+- Ecosystem specifications and compliance: `references/ecosystem-specs.md`
+
+# Routing Rules
+- Prefer explicit `--fqbn` and `-p` when compiling, uploading, debugging, or monitoring.
+- Run index refresh steps before install, search, upgrade, or outdated checks.
+- Use profile-driven flows when a sketch project contains multiple targets.
+- Use `--json` for automation output and text output for interactive diagnosis.
+- Load only the domain modules needed for the current request.
+
+# Common End-to-End Sequences
+- Board bring-up: foundation -> board -> core -> lib -> compile -> upload -> monitor.
+- Existing project recovery: config -> maintenance -> board -> compile -> upload -> debug.
+- Multi-target project setup: sketch -> profile -> core -> lib -> compile (per profile).
+
+# ICL Examples (Captured 2026-02-14)
+1. End-to-end Nano workflow with explicit discovery, profile, build, and upload.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board attach -p /dev/cu.usbserial-3120 -b arduino:avr:nano:cpu=atmega328old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data profile create --profile nano-old --fqbn arduino:avr:nano:cpu=atmega328old --set-default /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data compile -b arduino:avr:nano:cpu=atmega328old --output-dir /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/build_nano_old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data upload -p /dev/cu.usbserial-3120 -b arduino:avr:nano:cpu=atmega328old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed outcomes: successful attach, profile creation, compile memory report, and upload to `/dev/cu.usbserial-3120`.
+2. Post-upload runtime observation.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data monitor -p /dev/cu.usbserial-3120 --config baudrate=9600
+```
+Observed live serial payload: `{"profile":"uno-dev","note":"icl example"}`.

--- a/skills/.curated/arduino-cli-suite/agents/openai.yaml
+++ b/skills/.curated/arduino-cli-suite/agents/openai.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: "Arduino CLI Suite"
+  short_description: "Unified end-to-end Arduino CLI workflows."
+  icon_small: "./assets/icon-small.svg"
+  icon_large: "./assets/icon-large.svg"
+  brand_color: "#1E88A8"
+  default_prompt: "Use $arduino-cli-suite to run this Arduino workflow end to end, including setup, build, upload, and diagnostics."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/.curated/arduino-cli-suite/assets/icon-large.svg
+++ b/skills/.curated/arduino-cli-suite/assets/icon-large.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="Arduino CLI Suite logo Uno style with CLI overlay">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0F2D3D"/>
+      <stop offset="100%" stop-color="#134E5E"/>
+    </linearGradient>
+    <linearGradient id="board" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E88A8"/>
+      <stop offset="100%" stop-color="#0E6E8A"/>
+    </linearGradient>
+    <linearGradient id="cli" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFD166"/>
+      <stop offset="100%" stop-color="#F77F00"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="14" stdDeviation="14" flood-color="#001018" flood-opacity="0.45"/>
+    </filter>
+    <radialGradient id="sparkFill" cx="0.38" cy="0.3" r="0.9">
+      <stop offset="0%" stop-color="#FFF7B2"/>
+      <stop offset="62%" stop-color="#FFD35A"/>
+      <stop offset="100%" stop-color="#F4A528"/>
+    </radialGradient>
+    <filter id="sparkGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#FFE38A" flood-opacity="0.7"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" rx="210" fill="url(#bg)"/>
+
+  <g transform="translate(512 532) rotate(-7) translate(-512 -532)" filter="url(#shadow)">
+    <path d="M220 286H744C786 286 820 320 820 362V694C820 736 786 770 744 770H220C178 770 144 736 144 694V362C144 320 178 286 220 286Z" fill="url(#board)" stroke="#9AE0E8" stroke-width="12"/>
+
+    <path d="M144 410H92C78 410 66 422 66 436V620C66 634 78 646 92 646H144" fill="#D5DDE3" stroke="#6A7880" stroke-width="8"/>
+
+    <rect x="176" y="338" width="590" height="72" rx="16" fill="#0B4E62" opacity="0.55"/>
+
+    <g fill="#132530" stroke="#A5E5EC" stroke-width="4">
+      <rect x="188" y="300" width="20" height="62" rx="4"/>
+      <rect x="214" y="300" width="20" height="62" rx="4"/>
+      <rect x="240" y="300" width="20" height="62" rx="4"/>
+      <rect x="266" y="300" width="20" height="62" rx="4"/>
+      <rect x="292" y="300" width="20" height="62" rx="4"/>
+      <rect x="318" y="300" width="20" height="62" rx="4"/>
+      <rect x="344" y="300" width="20" height="62" rx="4"/>
+      <rect x="370" y="300" width="20" height="62" rx="4"/>
+      <rect x="396" y="300" width="20" height="62" rx="4"/>
+      <rect x="422" y="300" width="20" height="62" rx="4"/>
+      <rect x="448" y="300" width="20" height="62" rx="4"/>
+      <rect x="474" y="300" width="20" height="62" rx="4"/>
+      <rect x="500" y="300" width="20" height="62" rx="4"/>
+      <rect x="526" y="300" width="20" height="62" rx="4"/>
+      <rect x="552" y="300" width="20" height="62" rx="4"/>
+      <rect x="578" y="300" width="20" height="62" rx="4"/>
+      <rect x="604" y="300" width="20" height="62" rx="4"/>
+      <rect x="630" y="300" width="20" height="62" rx="4"/>
+      <rect x="656" y="300" width="20" height="62" rx="4"/>
+      <rect x="682" y="300" width="20" height="62" rx="4"/>
+      <rect x="708" y="300" width="20" height="62" rx="4"/>
+      <rect x="734" y="300" width="20" height="62" rx="4"/>
+    </g>
+
+    <g fill="#132530" stroke="#A5E5EC" stroke-width="4">
+      <rect x="188" y="694" width="20" height="62" rx="4"/>
+      <rect x="214" y="694" width="20" height="62" rx="4"/>
+      <rect x="240" y="694" width="20" height="62" rx="4"/>
+      <rect x="266" y="694" width="20" height="62" rx="4"/>
+      <rect x="292" y="694" width="20" height="62" rx="4"/>
+      <rect x="318" y="694" width="20" height="62" rx="4"/>
+      <rect x="344" y="694" width="20" height="62" rx="4"/>
+      <rect x="370" y="694" width="20" height="62" rx="4"/>
+      <rect x="396" y="694" width="20" height="62" rx="4"/>
+      <rect x="422" y="694" width="20" height="62" rx="4"/>
+      <rect x="448" y="694" width="20" height="62" rx="4"/>
+      <rect x="474" y="694" width="20" height="62" rx="4"/>
+      <rect x="500" y="694" width="20" height="62" rx="4"/>
+      <rect x="526" y="694" width="20" height="62" rx="4"/>
+      <rect x="552" y="694" width="20" height="62" rx="4"/>
+      <rect x="578" y="694" width="20" height="62" rx="4"/>
+      <rect x="604" y="694" width="20" height="62" rx="4"/>
+      <rect x="630" y="694" width="20" height="62" rx="4"/>
+      <rect x="656" y="694" width="20" height="62" rx="4"/>
+      <rect x="682" y="694" width="20" height="62" rx="4"/>
+      <rect x="708" y="694" width="20" height="62" rx="4"/>
+      <rect x="734" y="694" width="20" height="62" rx="4"/>
+    </g>
+
+    <g filter="url(#sparkGlow)" stroke="#FFF6D6" stroke-width="8" stroke-linejoin="round">
+      <path d="M510 414L534 500L620 524L534 548L510 634L486 548L400 524L486 500Z" fill="url(#sparkFill)"/>
+      <path d="M372 500L384 542L426 554L384 566L372 608L360 566L318 554L360 542Z" fill="url(#sparkFill)"/>
+      <path d="M648 458L658 492L692 502L658 512L648 546L638 512L604 502L638 492Z" fill="url(#sparkFill)"/>
+    </g>
+
+  </g>
+</svg>

--- a/skills/.curated/arduino-cli-suite/assets/icon-small.svg
+++ b/skills/.curated/arduino-cli-suite/assets/icon-small.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="Arduino CLI Suite logo Uno style with CLI overlay">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0F2D3D"/>
+      <stop offset="100%" stop-color="#134E5E"/>
+    </linearGradient>
+    <linearGradient id="board" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E88A8"/>
+      <stop offset="100%" stop-color="#0E6E8A"/>
+    </linearGradient>
+    <linearGradient id="cli" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFD166"/>
+      <stop offset="100%" stop-color="#F77F00"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="14" stdDeviation="14" flood-color="#001018" flood-opacity="0.45"/>
+    </filter>
+    <radialGradient id="sparkFill" cx="0.38" cy="0.3" r="0.9">
+      <stop offset="0%" stop-color="#FFF7B2"/>
+      <stop offset="62%" stop-color="#FFD35A"/>
+      <stop offset="100%" stop-color="#F4A528"/>
+    </radialGradient>
+    <filter id="sparkGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#FFE38A" flood-opacity="0.7"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" rx="210" fill="url(#bg)"/>
+
+  <g transform="translate(512 532) rotate(-7) translate(-512 -532)" filter="url(#shadow)">
+    <path d="M220 286H744C786 286 820 320 820 362V694C820 736 786 770 744 770H220C178 770 144 736 144 694V362C144 320 178 286 220 286Z" fill="url(#board)" stroke="#9AE0E8" stroke-width="12"/>
+
+    <path d="M144 410H92C78 410 66 422 66 436V620C66 634 78 646 92 646H144" fill="#D5DDE3" stroke="#6A7880" stroke-width="8"/>
+
+    <rect x="176" y="338" width="590" height="72" rx="16" fill="#0B4E62" opacity="0.55"/>
+
+    <g fill="#132530" stroke="#A5E5EC" stroke-width="4">
+      <rect x="188" y="300" width="20" height="62" rx="4"/>
+      <rect x="214" y="300" width="20" height="62" rx="4"/>
+      <rect x="240" y="300" width="20" height="62" rx="4"/>
+      <rect x="266" y="300" width="20" height="62" rx="4"/>
+      <rect x="292" y="300" width="20" height="62" rx="4"/>
+      <rect x="318" y="300" width="20" height="62" rx="4"/>
+      <rect x="344" y="300" width="20" height="62" rx="4"/>
+      <rect x="370" y="300" width="20" height="62" rx="4"/>
+      <rect x="396" y="300" width="20" height="62" rx="4"/>
+      <rect x="422" y="300" width="20" height="62" rx="4"/>
+      <rect x="448" y="300" width="20" height="62" rx="4"/>
+      <rect x="474" y="300" width="20" height="62" rx="4"/>
+      <rect x="500" y="300" width="20" height="62" rx="4"/>
+      <rect x="526" y="300" width="20" height="62" rx="4"/>
+      <rect x="552" y="300" width="20" height="62" rx="4"/>
+      <rect x="578" y="300" width="20" height="62" rx="4"/>
+      <rect x="604" y="300" width="20" height="62" rx="4"/>
+      <rect x="630" y="300" width="20" height="62" rx="4"/>
+      <rect x="656" y="300" width="20" height="62" rx="4"/>
+      <rect x="682" y="300" width="20" height="62" rx="4"/>
+      <rect x="708" y="300" width="20" height="62" rx="4"/>
+      <rect x="734" y="300" width="20" height="62" rx="4"/>
+    </g>
+
+    <g fill="#132530" stroke="#A5E5EC" stroke-width="4">
+      <rect x="188" y="694" width="20" height="62" rx="4"/>
+      <rect x="214" y="694" width="20" height="62" rx="4"/>
+      <rect x="240" y="694" width="20" height="62" rx="4"/>
+      <rect x="266" y="694" width="20" height="62" rx="4"/>
+      <rect x="292" y="694" width="20" height="62" rx="4"/>
+      <rect x="318" y="694" width="20" height="62" rx="4"/>
+      <rect x="344" y="694" width="20" height="62" rx="4"/>
+      <rect x="370" y="694" width="20" height="62" rx="4"/>
+      <rect x="396" y="694" width="20" height="62" rx="4"/>
+      <rect x="422" y="694" width="20" height="62" rx="4"/>
+      <rect x="448" y="694" width="20" height="62" rx="4"/>
+      <rect x="474" y="694" width="20" height="62" rx="4"/>
+      <rect x="500" y="694" width="20" height="62" rx="4"/>
+      <rect x="526" y="694" width="20" height="62" rx="4"/>
+      <rect x="552" y="694" width="20" height="62" rx="4"/>
+      <rect x="578" y="694" width="20" height="62" rx="4"/>
+      <rect x="604" y="694" width="20" height="62" rx="4"/>
+      <rect x="630" y="694" width="20" height="62" rx="4"/>
+      <rect x="656" y="694" width="20" height="62" rx="4"/>
+      <rect x="682" y="694" width="20" height="62" rx="4"/>
+      <rect x="708" y="694" width="20" height="62" rx="4"/>
+      <rect x="734" y="694" width="20" height="62" rx="4"/>
+    </g>
+
+    <g filter="url(#sparkGlow)" stroke="#FFF6D6" stroke-width="8" stroke-linejoin="round">
+      <path d="M510 414L534 500L620 524L534 548L510 634L486 548L400 524L486 500Z" fill="url(#sparkFill)"/>
+      <path d="M372 500L384 542L426 554L384 566L372 608L360 566L318 554L360 542Z" fill="url(#sparkFill)"/>
+      <path d="M648 458L658 492L692 502L658 512L648 546L638 512L604 502L638 492Z" fill="url(#sparkFill)"/>
+    </g>
+
+  </g>
+</svg>

--- a/skills/.curated/arduino-cli-suite/references/board-ops.md
+++ b/skills/.curated/arduino-cli-suite/references/board-ops.md
@@ -1,0 +1,36 @@
+---
+name: arduino-cli-board-ops
+description: Board and port discovery workflows for selecting the right FQBN and attachment metadata. Use when requests involve `arduino-cli board` commands (`list`, `attach`, `details`, `listall`, `search`) or board identification and port mapping.
+---
+
+# Workflow
+1. Start with hardware discovery (`board list`) and catalog ports.
+2. Resolve or confirm FQBN using `board listall` or `board search`.
+3. Use `board details` to inspect capabilities and options.
+4. Use `board attach` to persist sketch-to-board association when needed.
+
+# Command Coverage
+- `arduino-cli board list`
+- `arduino-cli board listall`
+- `arduino-cli board search <query>`
+- `arduino-cli board details -b <fqbn>`
+- `arduino-cli board attach -p <port> -b <fqbn> <sketch>`
+
+# Defaults
+- Prefer explicit `-p` and `-b` flags in examples.
+- Include protocol only when auto-detection fails.
+
+# ICL Examples (Captured 2026-02-14)
+1. Discover connected ports and candidate Nano board mappings.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board list
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board search nano
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board listall nano
+```
+Observed output included USB serial port `/dev/cu.usbserial-3120` and `Arduino Nano arduino:avr:nano`.
+2. Inspect board options and attach sketch defaults for old bootloader.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board details -b arduino:avr:nano
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board attach -p /dev/cu.usbserial-3120 -b arduino:avr:nano:cpu=atmega328old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed output showed `Processor` option `cpu=atmega328old` and set default port/FQBN for the sketch.

--- a/skills/.curated/arduino-cli-suite/references/build-upload.md
+++ b/skills/.curated/arduino-cli-suite/references/build-upload.md
@@ -1,0 +1,36 @@
+---
+name: arduino-cli-build-upload
+description: End-to-end build and deployment flows for firmware binaries and programmers. Use when requests involve `arduino-cli compile`, `upload`, or `burn-bootloader`, including build properties, artifacts, verification, and port/programmer selection.
+---
+
+# Workflow
+1. Compile with explicit `--fqbn` and deterministic build flags.
+2. Store or export binaries to predictable output locations.
+3. Upload with explicit port or programmer settings.
+4. Use verify and verbose flags only when needed for diagnosis.
+
+# Command Coverage
+- `arduino-cli compile`
+- `arduino-cli upload`
+- `arduino-cli burn-bootloader`
+
+# Defaults
+- Pass `--profile` for profile-managed projects.
+- Prefer `--output-dir` or `--build-path` in automated pipelines.
+- Use `--upload` on compile only when a combined flow is intended.
+
+# ICL Examples (Captured 2026-02-14)
+1. Compile for Nano old bootloader with explicit FQBN and output directory.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data compile -b arduino:avr:nano:cpu=atmega328old --output-dir /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/build_nano_old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed output:
+```text
+Sketch uses 5332 bytes (17%) of program storage space.
+Global variables use 402 bytes (19%) of dynamic memory.
+```
+2. Upload compiled firmware to an explicitly selected port.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data upload -p /dev/cu.usbserial-3120 -b arduino:avr:nano:cpu=atmega328old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed output confirmed target port: `New upload port: /dev/cu.usbserial-3120 (serial)`.

--- a/skills/.curated/arduino-cli-suite/references/config.md
+++ b/skills/.curated/arduino-cli-suite/references/config.md
@@ -1,0 +1,43 @@
+---
+name: arduino-cli-config
+description: Arduino CLI configuration initialization and mutation, including key inspection and precedence-safe edits. Use when requests involve `arduino-cli config` commands (`init`, `dump`, `get`, `set`, `add`, `remove`, `delete`) or debugging config-driven behavior.
+---
+
+# Workflow
+1. Dump current configuration before mutating values.
+2. Edit the narrowest possible key path.
+3. Re-dump the affected key to confirm the write.
+4. Explain precedence impacts from flags and environment variables.
+
+# Command Coverage
+- `arduino-cli config init`
+- `arduino-cli config dump`
+- `arduino-cli config get <key>`
+- `arduino-cli config set <key> <value>`
+- `arduino-cli config add <key> <value>`
+- `arduino-cli config remove <key> <value>`
+- `arduino-cli config delete <key>`
+
+# Safety Rules
+- Back up config files before broad deletes.
+- Use `config get` after each targeted update.
+
+# ICL Examples (Captured 2026-02-14)
+1. Initialize and inspect config in an isolated workspace.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data config init --overwrite
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data config dump
+```
+Observed output included:
+```text
+Config file written to: /tmp/arduino_cli_suite_icl_data/arduino-cli.yaml
+board_manager:
+    additional_urls: []
+```
+2. Add and remove an additional board-manager URL safely.
+```bash
+arduino-cli --config-dir /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/arduino_data config add board_manager.additional_urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+arduino-cli --config-dir /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/arduino_data config get board_manager.additional_urls
+arduino-cli --config-dir /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/arduino_data config remove board_manager.additional_urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+```
+Observed `config get` first returned the URL, then returned `[]` after removal.

--- a/skills/.curated/arduino-cli-suite/references/core-ops.md
+++ b/skills/.curated/arduino-cli-suite/references/core-ops.md
@@ -1,0 +1,42 @@
+---
+name: arduino-cli-core-ops
+description: Platform core lifecycle management for install, search, update, and upgrade flows. Use when requests involve `arduino-cli core` commands (`download`, `install`, `list`, `search`, `uninstall`, `update-index`, `upgrade`) or platform/toolchain provisioning.
+---
+
+# Workflow
+1. Refresh indexes before install and upgrade operations.
+2. Search and pin target platform references explicitly.
+3. Confirm installed versions after each mutation.
+4. Remove unused cores only after dependency checks.
+
+# Command Coverage
+- `arduino-cli core update-index`
+- `arduino-cli core search <query>`
+- `arduino-cli core list`
+- `arduino-cli core download <core[@version]>`
+- `arduino-cli core install <core[@version]>`
+- `arduino-cli core uninstall <core[@version]>`
+- `arduino-cli core upgrade [<core>]`
+
+# Defaults
+- Add `--additional-urls` when third-party package indexes are required.
+- Prefer explicit version pinning for reproducible builds.
+
+# ICL Examples (Captured 2026-02-14)
+1. Refresh indexes, search, install, and verify an AVR core.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data core update-index
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data core search arduino:avr
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data core install arduino:avr
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data core list
+```
+Observed output included:
+```text
+arduino:avr 1.8.7 Arduino AVR Boards
+Platform arduino:avr@1.8.7 installed
+```
+2. Download core artifacts without changing active installation state.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data core download arduino:avr@1.8.7
+```
+Observed output downloaded `arduino:avr@1.8.7` and required tools (`avr-gcc`, `avrdude`, `arduinoOTA`).

--- a/skills/.curated/arduino-cli-suite/references/daemon-grpc.md
+++ b/skills/.curated/arduino-cli-suite/references/daemon-grpc.md
@@ -1,0 +1,35 @@
+---
+name: arduino-cli-daemon-grpc
+description: Arduino CLI daemon and gRPC integration workflows for external tools and automation services. Use when requests involve `arduino-cli daemon`, gRPC transport behavior, debug tracing of RPC calls, or mapping CLI operations to RPC usage.
+---
+
+# Workflow
+1. Start daemon with explicit port and message size constraints.
+2. Enable debug tracing selectively to diagnose RPC behavior.
+3. Restrict debug filters to relevant RPC method names.
+4. Validate client connectivity before running long workflows.
+
+# Command Coverage
+- `arduino-cli daemon`
+
+# Defaults
+- Keep daemon on default port unless orchestration requires a custom port.
+- Use `--debug-file` for persistent RPC tracing during integration tests.
+- Keep daemon execution separate from direct CLI invocation in scripts.
+
+# ICL Examples (Captured 2026-02-14)
+1. Start daemon mode on an explicit port with logs enabled.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data daemon --port 50052 --log-level debug --log
+```
+Observed startup logs included:
+```text
+time="2026-02-14T18:47:46-06:00" level=info msg="arduino-cli version 1.4.1"
+time="2026-02-14T18:47:46-06:00" level=info msg="Using config file: /tmp/arduino_cli_suite_icl_data/arduino-cli.yaml"
+time="2026-02-14T18:47:46-06:00" level=info msg="Executing `arduino-cli daemon`"
+```
+2. Capture non-interactive daemon startup for transcript logging.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data daemon --port 50052
+```
+Observed as a valid launch path for daemon/gRPC workflows in capture logs.

--- a/skills/.curated/arduino-cli-suite/references/debug-monitor.md
+++ b/skills/.curated/arduino-cli-suite/references/debug-monitor.md
@@ -1,0 +1,40 @@
+---
+name: arduino-cli-debug-monitor
+description: Debug session setup and serial communication workflows for supported boards. Use when requests involve `arduino-cli debug`, `debug check`, or `monitor`, including interpreter modes, debug metadata, and monitor port configuration.
+---
+
+# Workflow
+1. Check board and programmer debug support before session start.
+2. Resolve and pass explicit debug artifacts or input directories.
+3. Start debugger with the required interpreter mode.
+4. Configure serial monitor settings before runtime observation.
+
+# Command Coverage
+- `arduino-cli debug`
+- `arduino-cli debug check`
+- `arduino-cli monitor`
+
+# Defaults
+- Use `debug --info` when metadata inspection is requested.
+- Use `monitor --describe` before setting custom monitor configs.
+- Add `--timestamp` in monitor mode for time-series debugging.
+
+# ICL Examples (Captured 2026-02-14)
+1. Inspect monitor capabilities on the connected Nano serial port.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data monitor --describe -p /dev/cu.usbserial-3120
+```
+Observed output listed settings for `baudrate`, `bits`, `parity`, `rts`, and `stop_bits`.
+2. Stream live serial output from the sketch at 9600 baud.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data monitor -p /dev/cu.usbserial-3120 --config baudrate=9600
+```
+Observed sample line from live output:
+```text
+{"profile":"uno-dev","note":"icl example"}
+```
+3. Validate debugger support on AVR Nano target.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data debug check -b arduino:avr:nano:cpu=atmega328old /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed output: `The given board/programmer configuration does NOT support debugging.`

--- a/skills/.curated/arduino-cli-suite/references/ecosystem-specs.md
+++ b/skills/.curated/arduino-cli-suite/references/ecosystem-specs.md
@@ -1,0 +1,33 @@
+---
+name: arduino-cli-ecosystem-specs
+description: Authoring and compliance guidance for the Arduino CLI ecosystem specifications. Use when requests involve package index, platform, library format, pluggable discovery, or pluggable monitor specifications, including ecosystem-compatible hardware package design.
+---
+
+# Workflow
+1. Identify which specification controls the requested artifact.
+2. Validate field names and constraints against the relevant spec.
+3. Keep examples minimal and aligned with current CLI behavior.
+4. Call out compatibility implications across cores, tools, and monitors.
+
+# Specification Coverage
+- Package index JSON specification
+- Platform specification
+- Library specification
+- Pluggable discovery specification
+- Pluggable monitor specification
+
+# Defaults
+- Prefer spec-compliant examples over ad-hoc conventions.
+- Keep references to required fields explicit and testable.
+
+# ICL Examples (Captured 2026-02-14)
+1. Validate FQBN and platform-id naming patterns across board catalog output.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board search nano
+```
+Observed mapping included `Arduino Nano -> arduino:avr:nano` with platform ID `arduino:avr`.
+2. Inspect board option schema for processor variants.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data board details -b arduino:avr:nano
+```
+Observed spec-like option key/value pairs including `Processor (cpu)` and `cpu=atmega328old`.

--- a/skills/.curated/arduino-cli-suite/references/foundation.md
+++ b/skills/.curated/arduino-cli-suite/references/foundation.md
@@ -1,0 +1,33 @@
+---
+name: arduino-cli-foundation
+description: Baseline Arduino CLI command usage, output shaping, and shell integration. Use when requests involve general `arduino-cli` guidance, command discovery, shared global flags (`--json`, logging, config paths, additional URLs), or the commands `help`, `version`, and `completion`.
+---
+
+# Workflow
+1. Detect whether the request needs human output or automation-safe output.
+2. Apply global flags consistently: `--json`, `--config-file`, `--config-dir`, `--additional-urls`, and log flags.
+3. Prefer short, copyable command examples with explicit flags.
+4. Return verification commands after any change-oriented action.
+
+# Command Coverage
+- `arduino-cli help`
+- `arduino-cli version`
+- `arduino-cli completion bash|zsh|fish|powershell`
+
+# Output Rules
+- Use `--json` for pipelines and scripts.
+- Use text output for interactive diagnosis.
+- Increase to `--log-level debug` only when troubleshooting.
+
+# ICL Examples (Captured 2026-02-14)
+1. Command discovery and version check.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data version
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data help
+```
+Observed output included `Version: 1.4.1` and the top-level command set (`board`, `compile`, `upload`, `monitor`, `profile`, `sketch`).
+2. Shell completion generation for automation shells.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data completion bash | sed -n '1,8p'
+```
+Observed output began with `# bash completion V2 for arduino-cli`.

--- a/skills/.curated/arduino-cli-suite/references/lib-ops.md
+++ b/skills/.curated/arduino-cli-suite/references/lib-ops.md
@@ -1,0 +1,41 @@
+---
+name: arduino-cli-lib-ops
+description: Library lifecycle and dependency workflows for Arduino projects. Use when requests involve `arduino-cli lib` commands (`search`, `install`, `list`, `deps`, `examples`, `download`, `uninstall`, `update-index`, `upgrade`) or library compatibility management.
+---
+
+# Workflow
+1. Update indexes before new searches in stale environments.
+2. Select library version constraints explicitly when reproducibility matters.
+3. Inspect dependency status before removals.
+4. Verify installed set after each operation.
+
+# Command Coverage
+- `arduino-cli lib update-index`
+- `arduino-cli lib search <query>`
+- `arduino-cli lib install <name[@version]>`
+- `arduino-cli lib list`
+- `arduino-cli lib deps <name>`
+- `arduino-cli lib examples <name>`
+- `arduino-cli lib download <name[@version]>`
+- `arduino-cli lib uninstall <name>`
+- `arduino-cli lib upgrade [<name>]`
+
+# Defaults
+- Prefer `--json` when dependency output is consumed by tooling.
+- Use exact versions for CI and reproducible firmware pipelines.
+
+# ICL Examples (Captured 2026-02-14)
+1. Search, install, and verify a pinned library version.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data lib search ArduinoJson
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data lib install ArduinoJson@6.21.4
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data lib list
+```
+Observed output listed `ArduinoJson` with `Installed 6.21.4` and `Available 7.4.2`.
+2. Inspect dependency and examples, then download the library archive.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data lib deps ArduinoJson
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data lib examples ArduinoJson
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data lib download ArduinoJson@6.21.4
+```
+Observed output included dependency mismatch signal (`7.4.2 required but 6.21.4 installed`) and example sketch paths.

--- a/skills/.curated/arduino-cli-suite/references/maintenance.md
+++ b/skills/.curated/arduino-cli-suite/references/maintenance.md
@@ -1,0 +1,36 @@
+---
+name: arduino-cli-maintenance
+description: Environment maintenance and upgrade hygiene for Arduino CLI installations. Use when requests involve `arduino-cli cache clean`, `update`, `upgrade`, or `outdated`, including index refresh and upgrade drift checks.
+---
+
+# Workflow
+1. Refresh indexes before evaluating outdated components.
+2. Review outdated status before broad upgrades.
+3. Perform upgrades with explicit pre/post script behavior when needed.
+4. Clean manager caches when recovering from corrupted or stale downloads.
+
+# Command Coverage
+- `arduino-cli cache clean`
+- `arduino-cli update`
+- `arduino-cli upgrade`
+- `arduino-cli outdated`
+
+# Defaults
+- Use `update --show-outdated` for quick health checks.
+- Prefer targeted remediation before full-environment resets.
+
+# ICL Examples (Captured 2026-02-14)
+1. Detect outdated components and verify after refresh.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data outdated
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data update --show-outdated
+```
+Observed output consistently reported:
+```text
+ArduinoJson 6.21.4 installed, 7.4.2 latest
+```
+2. Clean cache before a fresh download cycle.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data cache clean
+```
+Observed successful completion (`EXIT: 0`) in the supplemental run.

--- a/skills/.curated/arduino-cli-suite/references/profile-ops.md
+++ b/skills/.curated/arduino-cli-suite/references/profile-ops.md
@@ -1,0 +1,36 @@
+---
+name: arduino-cli-profile-ops
+description: Build profile management in sketch project files, including profile-scoped library sets. Use when requests involve `arduino-cli profile` commands (`create`, `set-default`, `lib add`, `lib remove`) or multi-target build profile workflows.
+---
+
+# Workflow
+1. Define or update named profiles with explicit board and options.
+2. Set a default profile only after validating primary workflows.
+3. Manage per-profile libraries with add and remove operations.
+4. Re-run compile using the target profile to confirm correctness.
+
+# Command Coverage
+- `arduino-cli profile create`
+- `arduino-cli profile set-default <name>`
+- `arduino-cli profile lib add <library> --profile <name>`
+- `arduino-cli profile lib remove <library> --profile <name>`
+
+# Defaults
+- Keep profile names stable and environment-agnostic.
+- Prefer profile-driven commands for multi-board projects.
+
+# ICL Examples (Captured 2026-02-14)
+1. Create a Nano old-bootloader profile and make it default.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data profile create --profile nano-old --fqbn arduino:avr:nano:cpu=atmega328old --set-default /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed output:
+```text
+Project file created in: .../icl_suite_demo_v2/sketch.yaml
+```
+2. Add and remove profile-scoped libraries.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data profile lib add ArduinoJson@6.21.4 --profile uno-dev --sketch-path /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data profile lib remove ArduinoJson@6.21.4 --profile uno-dev --sketch-path /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed outputs confirmed add/remove actions against the selected profile.

--- a/skills/.curated/arduino-cli-suite/references/sketch-ops.md
+++ b/skills/.curated/arduino-cli-suite/references/sketch-ops.md
@@ -1,0 +1,32 @@
+---
+name: arduino-cli-sketch-ops
+description: Sketch project creation and packaging workflows with Arduino sketch structure expectations. Use when requests involve `arduino-cli sketch` commands (`new`, `archive`) or standardizing sketch folder layout and deliverable archives.
+---
+
+# Workflow
+1. Create sketches with canonical naming and folder structure.
+2. Keep source and metadata files in spec-compliant locations.
+3. Package sketch deliverables with archive output when sharing.
+
+# Command Coverage
+- `arduino-cli sketch new <name>`
+- `arduino-cli sketch archive <path>`
+
+# Defaults
+- Use `sketch new` over manual folder creation.
+- Validate output archive contents before distribution.
+
+# ICL Examples (Captured 2026-02-14)
+1. Create a new sketch directory for integration testing.
+```bash
+arduino-cli --config-dir /tmp/arduino_cli_suite_icl_data sketch new /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+Observed output:
+```text
+Sketch created in: /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo_v2
+```
+2. Archive an existing sketch for distribution.
+```bash
+arduino-cli --config-dir /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/arduino_data sketch archive /Volumes/trent/Documents/Arduino/Arduino_CLI_Codex_Skills/tmp/icl_capture/project/icl_suite_demo
+```
+Observed exit status was successful (`EXIT: 0`) in the captured run.


### PR DESCRIPTION
## Summary
- Add a new curated skill at `skills/.curated/arduino-cli-suite`
- Provide a single self-contained Arduino CLI suite skill covering board discovery, core/library setup, sketch operations, compile/upload, monitor/debug, profiles, config, maintenance, daemon/grpc, and ecosystem specs
- Include per-skill MIT license, OpenAI metadata, icons, and bundled module references for progressive disclosure

## What is included
- `SKILL.md` with orchestration workflow and captured ICL command examples
- `agents/openai.yaml` with display metadata and default prompt
- `assets/icon-small.svg` and `assets/icon-large.svg`
- `references/*.md` module guides used by the suite skill
- `LICENSE.txt` (MIT)

## Validation
- Ran: `python3 skills/.system/skill-creator/scripts/quick_validate.py skills/.curated/arduino-cli-suite`
- Result: `Skill is valid!`

## Notes
- The suite skill is self-contained (no cross-folder dependencies outside its own directory).
- The workflow/examples are based on real Arduino CLI usage, including Nano old bootloader build/upload flows.
