### PR TITLE
Use absolute path for `gh-address-comment` script path

### DIFF
--- a/skills/.curated/gh-address-comments/SKILL.md
+++ b/skills/.curated/gh-address-comments/SKILL.md
@@ -12,7 +12,7 @@ Guide to find the open PR for the current branch and address its comments with g
 Prereq: ensure `gh` is authenticated (for example, run `gh auth login` once), then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
 
 ## 1) Inspect comments needing attention
-- Run scripts/fetch_comments.py which will print out all the comments and review threads on the PR
+- Run `python "<path-to-skill>/scripts/fetch_comments.py"` which will print out all the comments and review threads on the PR
 
 ## 2) Ask the user for clarification
 - Number all the review threads and comments and provide a short summary of what would be required to apply a fix for it


### PR DESCRIPTION
When `gh-address-comment` is installed globally and invoked from a project directory, the agent treats `scripts/fetch_comments.py` as a relative path (understandably). As a result, it can’t reliably locate or use the script.

Observed behavior varies:
- Fails to find the script (requires manual steering)
- Eventually finds the script in the codex/skills directory (slow or wasted tokens)
- Falls back to using the `gh` GraphQL API to fetch comments instead







The change uses absolute path, similar to [how `gh-fix-ci` is done](https://github.com/openai/skills/blob/4ab6e0fd99c6667163bc34173e3ed3a3fed75ebc/skills/.curated/gh-fix-ci/SKILL.md?plain=1#L24)

Screenshot (from Codex App)
<img width="661" height="395" alt="Screenshot 2026-03-09 at 18 09 44" src="https://github.com/user-attachments/assets/e727aff4-5995-47bc-9ee0-eca0fe4d3238" />