### PR TITLE
Update vercel skill instructions for CLI check and fallback

### DIFF
--- a/skills/.curated/vercel-deploy/SKILL.md
+++ b/skills/.curated/vercel-deploy/SKILL.md
@@ -9,33 +9,42 @@ Deploy any project to Vercel instantly. **Always deploy as preview** (not produc
 
 ## Prerequisites
 
-- When sandboxing blocks the deployment network calls, rerun with `sandbox_permissions=require_escalated`.
+- Check whether the Vercel CLI is installed **without** escalated permissions (for example, `command -v vercel`).
+- Only escalate the actual deploy command if sandboxing blocks the deployment network calls (`sandbox_permissions=require_escalated`).
 - The deployment might take a few minutes. Use appropriate timeout values.
 
 ## Quick Start
 
-**Just run this (with a 10 minute timeout):**
+1. Check whether the Vercel CLI is installed (no escalation for this check):
+
+```bash
+command -v vercel
+```
+
+2. If `vercel` is installed, run this (with a 10 minute timeout):
 ```bash
 vercel deploy [path] -y
 ```
 
 **Important:** Use a 10 minute (600000ms) timeout for the deploy command since builds can take a while.
 
-If that fails with "No existing credentials found", use the fallback method below.
+3. If `vercel` is not installed, or if the CLI fails with "No existing credentials found", use the fallback method below.
 
 ## Fallback (No Auth)
 
 If CLI fails with auth error, use the deploy script:
 
 ```bash
+skill_dir="<path-to-skill>"
+
 # Deploy current directory
-bash scripts/deploy.sh
+bash "$skill_dir/scripts/deploy.sh"
 
 # Deploy specific project
-bash scripts/deploy.sh /path/to/project
+bash "$skill_dir/scripts/deploy.sh" /path/to/project
 
 # Deploy existing tarball
-bash scripts/deploy.sh /path/to/project.tgz
+bash "$skill_dir/scripts/deploy.sh" /path/to/project.tgz
 ```
 
 The script handles framework detection, packaging, and deployment. It waits for the build to complete and returns JSON with `previewUrl` and `claimUrl`.
@@ -59,7 +68,7 @@ Show the user the deployment URL. For fallback deployments, also show the claim 
 
 ### Escalated Network Access
 
-If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the deploy with escalated permissions (use `sandbox_permissions=require_escalated`). The deploy requires escalated network access when sandbox networking blocks outbound requests.
+If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the actual deploy command with escalated permissions (use `sandbox_permissions=require_escalated`). Do not escalate the `command -v vercel` installation check. The deploy requires escalated network access when sandbox networking blocks outbound requests.
 
 Example guidance to the user:
 


### PR DESCRIPTION
Summary
- document a preliminary `vercel` CLI check and clarify when to escalate permissions
- align deploy script references with other skills using the `skill_dir` placeholder for script paths
- spell out fallback behavior when the CLI is missing or lacks credentials
Testing
- Not run (not requested)