### PR TITLE
feat: add --force flag to skill installer for reinstall/update

### DIFF
--- a/skills/.system/skill-installer/scripts/install-skill-from-github.py
+++ b/skills/.system/skill-installer/scripts/install-skill-from-github.py
@@ -27,6 +27,7 @@ class Args:
     dest: str | None = None
     name: str | None = None
     method: str = "auto"
+    force: bool = False
 
 
 @dataclass
@@ -169,10 +170,14 @@ def _validate_skill(path: str) -> None:
         raise InstallError("SKILL.md not found in selected skill directory.")
 
 
-def _copy_skill(src: str, dest_dir: str) -> None:
+def _copy_skill(src: str, dest_dir: str, *, force: bool = False) -> None:
     os.makedirs(os.path.dirname(dest_dir), exist_ok=True)
     if os.path.exists(dest_dir):
-        raise InstallError(f"Destination already exists: {dest_dir}")
+        if not force:
+            raise InstallError(
+                f"Destination already exists: {dest_dir}  (use --force to overwrite)"
+            )
+        shutil.rmtree(dest_dir)
     shutil.copytree(src, dest_dir)
 
 
@@ -263,6 +268,11 @@ def _parse_args(argv: list[str]) -> Args:
         choices=["auto", "download", "git"],
         default="auto",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing skill directory",
+    )
     return parser.parse_args(argv, namespace=Args())
 
 
@@ -287,11 +297,13 @@ def main(argv: list[str]) -> int:
                 if not skill_name:
                     raise InstallError("Unable to derive skill name.")
                 dest_dir = os.path.join(dest_root, skill_name)
-                if os.path.exists(dest_dir):
-                    raise InstallError(f"Destination already exists: {dest_dir}")
+                if os.path.exists(dest_dir) and not args.force:
+                    raise InstallError(
+                        f"Destination already exists: {dest_dir}  (use --force to overwrite)"
+                    )
                 skill_src = os.path.join(repo_root, path)
                 _validate_skill(skill_src)
-                _copy_skill(skill_src, dest_dir)
+                _copy_skill(skill_src, dest_dir, force=args.force)
                 installed.append((skill_name, dest_dir))
         finally:
             if os.path.isdir(tmp_dir):


### PR DESCRIPTION
## Problem

The skill installer aborts when the destination directory already exists, with no way to update or reinstall a skill without manually deleting the directory first. This makes scripted workflows fragile and prevents easy skill updates.

Fixes #127

## Changes

Added a `--force` flag to `install-skill-from-github.py`:

| Scenario | Without `--force` | With `--force` |
|---|---|---|
| Skill doesn't exist | Install normally | Install normally |
| Skill already exists | Abort with error | Remove and reinstall |

### Implementation

- Added `force: bool = False` to `Args` dataclass
- Added `--force` to argparse
- Updated `_copy_skill()` to accept `force` kwarg — removes existing dir before copy
- Updated `main()` to pass `force` through both check points
- Error messages now suggest `--force` when destination exists

### Safety

- Default behavior is **unchanged** (abort on existing directory)
- `--force` must be explicitly provided
- Skill validation (`_validate_skill`) still runs before copy