### PR TITLE
docs: tighten skill installer wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Learn more:
 
 Skills in [`.system`](skills/.system/) are automatically installed in the latest version of Codex.
 
-To install [curated](skills/.curated/) or [experimental](skills/.experimental/) skills, you can use the `$skill-installer` inside Codex.
+To install [curated](skills/.curated/) or [experimental](skills/.experimental/) skills, use `$skill-installer` in Codex.
 
 Curated skills can be installed by name (defaults to `skills/.curated`):
 


### PR DESCRIPTION
Simplify one README sentence about using skill-installer in Codex. Meaning and examples stay unchanged. Docs-only change.