### PR TITLE
Add curated xcode-build skill

### DIFF
--- a/skills/.curated/xcode-build/LICENSE.txt
+++ b/skills/.curated/xcode-build/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/xcode-build/SKILL.md
+++ b/skills/.curated/xcode-build/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: "xcode-build"
+description: "Build and test iOS Xcode projects. Use when the user asks to build, compile, run tests, or verify an iOS project with xcodebuild. Supports xcworkspace/xcodeproj auto-detection, Rosetta mode (x86_64 simulator), Swift Testing and XCTest frameworks, unit and UI test filtering, and detailed failure reporting."
+---
+
+# iOS Build and Test
+
+## Prerequisites
+
+- Require macOS with Xcode installed. Check `xcode-select -p`. If missing, ask the user to install Xcode.
+- Require `xcrun simctl` for simulator detection. Verify with `xcrun simctl list devices available`.
+
+## Scripts
+
+- **build.sh**: `<path-to-skill>/scripts/build.sh` -- Build an iOS project for simulator.
+- **run_tests.sh**: `<path-to-skill>/scripts/run_tests.sh` -- Run unit, UI, or all tests.
+
+## Building
+
+```bash
+# Auto-detect project and build
+<path-to-skill>/scripts/build.sh
+
+# Build with Rosetta mode (x86_64 simulator)
+<path-to-skill>/scripts/build.sh --rosetta
+
+# Build with verbose output
+<path-to-skill>/scripts/build.sh --verbose
+
+# Build specific scheme
+<path-to-skill>/scripts/build.sh --scheme MyApp
+
+# Pass extra xcodebuild flags
+<path-to-skill>/scripts/build.sh -configuration Release CODE_SIGNING_ALLOWED=NO
+```
+
+## Testing
+
+```bash
+# Run all tests
+<path-to-skill>/scripts/run_tests.sh
+
+# Run only unit tests
+<path-to-skill>/scripts/run_tests.sh unit
+
+# Run only UI tests
+<path-to-skill>/scripts/run_tests.sh ui
+
+# Run specific test target
+<path-to-skill>/scripts/run_tests.sh single MyAppTests
+
+# Run with Rosetta mode
+<path-to-skill>/scripts/run_tests.sh --rosetta
+
+# Run with verbose output
+<path-to-skill>/scripts/run_tests.sh --verbose unit
+
+# Run specific scheme
+<path-to-skill>/scripts/run_tests.sh --scheme MyApp unit
+```
+
+## Flags Reference
+
+### Common Flags (both scripts)
+
+| Flag | Description |
+|---|---|
+| `--rosetta` | Run on x86_64 simulator (adds `arch -x86_64` prefix) |
+| `--verbose` or `-v` | Show full xcodebuild output (not just errors) |
+| `--scheme <name>` | Override auto-detected scheme |
+
+### Test Types (positional argument for run_tests.sh)
+
+| Type | Description |
+|---|---|
+| `all` (default) | Run all test targets |
+| `unit` | Targets ending in `Tests` (excluding `UITests`) |
+| `ui` | Targets ending in `UITests` |
+| `single <target>` | Run a specific test target by name |
+
+## Auto-Detection
+
+### Project Detection (priority order)
+
+1. `*.xcworkspace` (excluding Pods.xcworkspace)
+2. `*.xcodeproj` (excluding Pods.xcodeproj)
+
+### Scheme Detection (priority order)
+
+1. `--scheme` flag
+2. `SCHEME` from `.env` file in the current directory
+3. Scheme matching the project/workspace name
+4. First non-Pods scheme from `xcodebuild -list`
+
+### Simulator Detection (priority order)
+
+1. `DEVICE_ID` from `.env` file
+2. First available iPhone simulator from `xcrun simctl list devices available -j`
+
+## .env Configuration
+
+Both scripts source an optional `.env` file from the current directory:
+
+```bash
+DEVICE_ID=4019771F-38B3-4DA7-B4D7-B458E99A5394
+SCHEME=MyApp
+```
+
+Find available device IDs with `xcrun simctl list devices available`.
+
+## Log Files
+
+- **Build logs**: `.build_logs/build_YYYYMMDD_HHMMSS.log`
+- **Test logs**: `.test_logs/<target>_YYYYMMDD_HHMMSS.log`
+
+On failure, the scripts print extracted errors. Read the full log file for complete diagnostics.
+
+## Workflow
+
+1. Navigate to the project root (where `.xcodeproj` or `.xcworkspace` is located).
+2. Run the appropriate script with flags as needed.
+3. If the build or test fails, read the log file to diagnose errors.
+4. If the user needs Rosetta mode (for older dependencies or x86_64-only frameworks), add `--rosetta`.
+
+## Troubleshooting
+
+- **"No scheme found"**: Specify with `--scheme YourSchemeName` or add `SCHEME=...` to `.env`.
+- **"No simulator found"**: Add `DEVICE_ID=...` to `.env`. Find IDs with `xcrun simctl list devices available`.
+- **Build fails on Apple Silicon**: Use `--rosetta` for dependencies that require x86_64.
+- **Multiple projects found**: Specify the scheme explicitly with `--scheme`.

--- a/skills/.curated/xcode-build/agents/openai.yaml
+++ b/skills/.curated/xcode-build/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Xcode Build"
+  short_description: "Build and test iOS Xcode projects"
+  default_prompt: "Use $xcode-build to build this iOS project and run the tests."

--- a/skills/.curated/xcode-build/scripts/build.sh
+++ b/skills/.curated/xcode-build/scripts/build.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROSETTA=false
+VERBOSE=false
+SCHEME_FLAG=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --rosetta)
+            ROSETTA=true
+            shift
+            ;;
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --scheme)
+            SCHEME_FLAG="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+WORKSPACE=$(find . -maxdepth 1 -name "*.xcworkspace" ! -name "Pods.xcworkspace" | head -n 1)
+PROJECT=$(find . -maxdepth 1 -name "*.xcodeproj" ! -name "Pods.xcodeproj" | head -n 1)
+
+if [ -n "$WORKSPACE" ]; then
+    PROJECT_FILE="$WORKSPACE"
+    PROJECT_FLAG="-workspace"
+    PROJECT_NAME=$(basename "$WORKSPACE" .xcworkspace)
+elif [ -n "$PROJECT" ]; then
+    PROJECT_FILE="$PROJECT"
+    PROJECT_FLAG="-project"
+    PROJECT_NAME=$(basename "$PROJECT" .xcodeproj)
+else
+    echo "Error: No .xcworkspace or .xcodeproj found in current directory"
+    exit 1
+fi
+
+if [ -n "$SCHEME_FLAG" ]; then
+    SCHEME="$SCHEME_FLAG"
+elif [ -n "${SCHEME:-}" ]; then
+    : # Use SCHEME from .env
+else
+    ALL_SCHEMES=$(xcodebuild -list "$PROJECT_FLAG" "$PROJECT_FILE" 2>/dev/null | sed -n '/Schemes:/,/^$/p' | tail -n +2 | sed 's/^[[:space:]]*//' | grep -v '^$')
+
+    MATCHING_SCHEME=$(echo "$ALL_SCHEMES" | grep -i "^${PROJECT_NAME}$" || true)
+
+    if [ -n "$MATCHING_SCHEME" ]; then
+        SCHEME="$MATCHING_SCHEME"
+    else
+        FIRST_SCHEME=$(echo "$ALL_SCHEMES" | grep -v -i "pods" | head -n 1)
+        if [ -n "$FIRST_SCHEME" ]; then
+            SCHEME="$FIRST_SCHEME"
+        else
+            echo "Error: No scheme found. Please specify with --scheme or add SCHEME to .env"
+            exit 1
+        fi
+    fi
+fi
+
+if [ -n "${DEVICE_ID:-}" ]; then
+    DESTINATION="platform=iOS Simulator,id=$DEVICE_ID"
+else
+    SIMULATOR_JSON=$(xcrun simctl list devices available -j)
+    DEVICE_ID=$(echo "$SIMULATOR_JSON" | python3 -c "
+import sys, json
+devices = json.load(sys.stdin)['devices']
+for runtime, device_list in devices.items():
+    if 'iOS' in runtime:
+        for device in device_list:
+            if 'iPhone' in device['name'] and device.get('isAvailable', False):
+                print(device['udid'])
+                sys.exit(0)
+sys.exit(1)
+" || true)
+
+    if [ -z "$DEVICE_ID" ]; then
+        echo "Error: No simulator found. Please add DEVICE_ID to .env file"
+        echo "Run: xcrun simctl list devices available"
+        exit 1
+    fi
+
+    DESTINATION="platform=iOS Simulator,id=$DEVICE_ID"
+fi
+
+if [ "$ROSETTA" = true ]; then
+    DESTINATION="${DESTINATION},arch=x86_64"
+fi
+
+mkdir -p .build_logs
+LOG_FILE=".build_logs/build_$(date +%Y%m%d_%H%M%S).log"
+
+echo "Building $PROJECT_NAME (scheme: $SCHEME)..."
+if [ "$ROSETTA" = true ]; then
+    echo "Using Rosetta mode (x86_64)"
+fi
+
+if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
+    BUILD_CMD=(xcodebuild "$PROJECT_FLAG" "$PROJECT_FILE" -scheme "$SCHEME" -destination "$DESTINATION" build "${EXTRA_ARGS[@]}")
+else
+    BUILD_CMD=(xcodebuild "$PROJECT_FLAG" "$PROJECT_FILE" -scheme "$SCHEME" -destination "$DESTINATION" build)
+fi
+
+if [ "$ROSETTA" = true ]; then
+    BUILD_CMD=(arch -x86_64 "${BUILD_CMD[@]}")
+fi
+
+if [ "$VERBOSE" = true ]; then
+    "${BUILD_CMD[@]}" 2>&1 | tee "$LOG_FILE"
+    BUILD_STATUS=${PIPESTATUS[0]}
+else
+    "${BUILD_CMD[@]}" > "$LOG_FILE" 2>&1
+    BUILD_STATUS=$?
+fi
+
+if [ $BUILD_STATUS -eq 0 ]; then
+    echo "✓ Build succeeded"
+    echo "Log: $LOG_FILE"
+    exit 0
+else
+    echo "✗ Build failed"
+    echo "Log: $LOG_FILE"
+    echo ""
+    echo "Errors:"
+    grep -E "error:" "$LOG_FILE" || echo "No specific errors found in log"
+    exit 1
+fi

--- a/skills/.curated/xcode-build/scripts/run_tests.sh
+++ b/skills/.curated/xcode-build/scripts/run_tests.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROSETTA=false
+VERBOSE=false
+SCHEME_FLAG=""
+TEST_TYPE="all"
+TEST_IDENTIFIER=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --rosetta)
+            ROSETTA=true
+            shift
+            ;;
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --scheme)
+            SCHEME_FLAG="$2"
+            shift 2
+            ;;
+        unit|ui|all|single)
+            TEST_TYPE="$1"
+            shift
+            if [ "$TEST_TYPE" = "single" ] && [ $# -gt 0 ]; then
+                TEST_IDENTIFIER="$1"
+                shift
+            fi
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            echo "Usage: $0 [--rosetta] [--verbose] [--scheme <name>] [unit|ui|all|single <target>]"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+WORKSPACE=$(find . -maxdepth 1 -name "*.xcworkspace" ! -name "Pods.xcworkspace" | head -n 1)
+PROJECT=$(find . -maxdepth 1 -name "*.xcodeproj" ! -name "Pods.xcodeproj" | head -n 1)
+
+if [ -n "$WORKSPACE" ]; then
+    PROJECT_FILE="$WORKSPACE"
+    PROJECT_FLAG="-workspace"
+    PROJECT_NAME=$(basename "$WORKSPACE" .xcworkspace)
+elif [ -n "$PROJECT" ]; then
+    PROJECT_FILE="$PROJECT"
+    PROJECT_FLAG="-project"
+    PROJECT_NAME=$(basename "$PROJECT" .xcodeproj)
+else
+    echo "Error: No .xcworkspace or .xcodeproj found in current directory"
+    exit 1
+fi
+
+if [ -n "$SCHEME_FLAG" ]; then
+    SCHEME="$SCHEME_FLAG"
+elif [ -n "${SCHEME:-}" ]; then
+    : # Use SCHEME from .env
+else
+    ALL_SCHEMES=$(xcodebuild -list "$PROJECT_FLAG" "$PROJECT_FILE" 2>/dev/null | sed -n '/Schemes:/,/^$/p' | tail -n +2 | sed 's/^[[:space:]]*//' | grep -v '^$')
+
+    MATCHING_SCHEME=$(echo "$ALL_SCHEMES" | grep -i "^${PROJECT_NAME}$" || true)
+
+    if [ -n "$MATCHING_SCHEME" ]; then
+        SCHEME="$MATCHING_SCHEME"
+    else
+        FIRST_SCHEME=$(echo "$ALL_SCHEMES" | grep -v -i "pods" | head -n 1)
+        if [ -n "$FIRST_SCHEME" ]; then
+            SCHEME="$FIRST_SCHEME"
+        else
+            echo "Error: No scheme found. Please specify with --scheme or add SCHEME to .env"
+            exit 1
+        fi
+    fi
+fi
+
+if [ -n "${DEVICE_ID:-}" ]; then
+    DESTINATION="platform=iOS Simulator,id=$DEVICE_ID"
+else
+    SIMULATOR_JSON=$(xcrun simctl list devices available -j)
+    DEVICE_ID=$(echo "$SIMULATOR_JSON" | python3 -c "
+import sys, json
+devices = json.load(sys.stdin)['devices']
+for runtime, device_list in devices.items():
+    if 'iOS' in runtime:
+        for device in device_list:
+            if 'iPhone' in device['name'] and device.get('isAvailable', False):
+                print(device['udid'])
+                sys.exit(0)
+sys.exit(1)
+" || true)
+
+    if [ -z "$DEVICE_ID" ]; then
+        echo "Error: No simulator found. Please add DEVICE_ID to .env file"
+        echo "Run: xcrun simctl list devices available"
+        exit 1
+    fi
+
+    DESTINATION="platform=iOS Simulator,id=$DEVICE_ID"
+fi
+
+if [ "$ROSETTA" = true ]; then
+    DESTINATION="${DESTINATION},arch=x86_64"
+fi
+
+ALL_TARGETS=$(xcodebuild -list "$PROJECT_FLAG" "$PROJECT_FILE" 2>/dev/null | sed -n '/Targets:/,/^$/p' | tail -n +2 | sed 's/^[[:space:]]*//' | grep -v '^$')
+
+UNIT_TARGETS=$(echo "$ALL_TARGETS" | grep -E "Tests$" | grep -v "UITests" || true)
+UI_TARGETS=$(echo "$ALL_TARGETS" | grep -E "UITests$" || true)
+
+extract_test_failure_details() {
+    local test_name="$1"
+    local full_output="$2"
+    local xcresult_path="$3"
+    local method_name=$(echo "$test_name" | sed 's/.*\.//' | sed 's/()$//')
+
+    if [ "$VERBOSE" = true ]; then
+        echo "[DEBUG] Extracting failure details for: $test_name" >&2
+        echo "[DEBUG] Method name: $method_name" >&2
+        echo "[DEBUG] xcresult path: $xcresult_path" >&2
+    fi
+
+    if [ -n "$xcresult_path" ] && [ -d "$xcresult_path" ] && command -v xcrun >/dev/null 2>&1; then
+        if [ "$VERBOSE" = true ]; then
+            echo "[DEBUG] Attempting xcresulttool extraction..." >&2
+        fi
+
+        local failure_details=$(xcrun xcresulttool get --format json --path "$xcresult_path" 2>/dev/null |
+            jq -r --arg test_name "$test_name" '
+            .. | objects |
+            select(.testIdentifier? == $test_name or (.identifier? // .name? // .title?) | test($test_name)) |
+            (.failureSummary? // .message? // .issueDocument?.message? // empty)' 2>/dev/null |
+            grep -v "null" | head -5)
+
+        if [ -n "$failure_details" ] && [ "$failure_details" != "null" ] && [ "$failure_details" != "" ]; then
+            echo "$failure_details"
+            return
+        fi
+
+        local issue_details=$(xcrun xcresulttool get --format json --path "$xcresult_path" 2>/dev/null |
+            jq -r --arg test_name "$test_name" '
+            .. | objects | select(.issues?) | .issues[] |
+            select(.testCaseName? == $test_name or .message | contains($test_name)) |
+            .message' 2>/dev/null | head -3)
+
+        if [ -n "$issue_details" ] && [ "$issue_details" != "null" ] && [ "$issue_details" != "" ]; then
+            echo "$issue_details"
+            return
+        fi
+    fi
+
+    if [ "$VERBOSE" = true ]; then
+        echo "[DEBUG] Searching for error patterns in output..." >&2
+    fi
+
+    local swift_testing_errors=$(echo "$full_output" | grep -A 20 -B 5 "$method_name" |
+        grep -E "(failed|error|assertion|expectation|Issue recorded|XCTAssert)" | head -5)
+
+    if [ -n "$swift_testing_errors" ]; then
+        echo "$swift_testing_errors"
+        return
+    fi
+
+    local service_errors=$(echo "$full_output" |
+        grep -E "\[$method_name\].*❌|\[$method_name\].*failed|❌.*$method_name|error.*$method_name" | head -3)
+
+    if [ -n "$service_errors" ]; then
+        echo "$service_errors"
+        return
+    fi
+
+    local test_context=$(echo "$full_output" | grep -A 15 -B 5 "$test_name")
+    local failure_indicators=$(echo "$test_context" | grep -E "(failed|error|assertion|❌|✗|Issue recorded)" | head -3)
+
+    if [ -n "$failure_indicators" ]; then
+        echo "$failure_indicators"
+        return
+    fi
+
+    local nearby_errors=$(echo "$full_output" |
+        grep -A 50 -B 10 "Test \"$method_name\"" |
+        grep -E "(❌|failed|error|assertion)" | head -3)
+
+    if [ -n "$nearby_errors" ]; then
+        echo "$nearby_errors"
+        return
+    fi
+
+    if [ "$VERBOSE" = true ]; then
+        echo "Test failed - detailed context:"
+        echo "$test_context" | head -10
+        return
+    fi
+
+    echo "Test failed - run with --verbose for more details or individually: xcodebuild test -only-testing:\"$test_name\""
+}
+
+run_tests() {
+    local target="$1"
+    local name="$2"
+
+    echo ""
+    echo "🔍 Running $name ($target)..."
+
+    mkdir -p .test_logs
+    log_file=".test_logs/${target}_$(date +%Y%m%d_%H%M%S).log"
+
+    echo "Running tests..."
+
+    TEST_CMD=(xcodebuild test "$PROJECT_FLAG" "$PROJECT_FILE" -scheme "$SCHEME" -destination "$DESTINATION" -only-testing:"$target")
+
+    if [ "$ROSETTA" = true ]; then
+        TEST_CMD=(arch -x86_64 "${TEST_CMD[@]}")
+    fi
+
+    set +e
+    output=$("${TEST_CMD[@]}" 2>&1 | tee "$log_file")
+    local exit_code=$?
+    set -e
+
+    if [ "$VERBOSE" != true ]; then
+        output=$(cat "$log_file")
+    fi
+
+    echo "Log saved to: $log_file"
+
+    if echo "$output" | grep -q "BUILD FAILED\|fatal error:\|error:.*\.swift\|Build input file cannot be found\|Compilation failed"; then
+        echo "💥 $name: Build failed"
+        echo ""
+        echo "🔥 Build Errors:"
+        echo "$output" | grep -E "error:.*\.swift|fatal error:|Build input file cannot be found|.*\.swift:[0-9]+:[0-9]+: error:" | head -15 | sed 's/^/   /'
+        echo ""
+        echo "📋 Build Output (last 20 lines):"
+        echo "$output" | tail -20 | sed 's/^/   /'
+        return 1
+    fi
+
+    if echo "$output" | grep -q "Unable to find a destination\|does not contain a scheme"; then
+        echo "💥 $name: Configuration error"
+        echo ""
+        echo "🔧 Configuration Issues:"
+        echo "$output" | grep -E "Unable to find a destination|does not contain a scheme" | sed 's/^/   /'
+        return 1
+    fi
+
+    if echo "$output" | grep -q "Test run with.*tests\? "; then
+        swift_test_summary=$(echo "$output" | grep -E "Test run with [0-9]+ tests?" | tail -1)
+
+        if [ -n "$swift_test_summary" ]; then
+            if echo "$swift_test_summary" | grep -q "✔ Test run with.*passed"; then
+                total=$(echo "$swift_test_summary" | grep -o '[0-9]\+ tests\?' | head -1 | grep -o '[0-9]\+' || echo "")
+                if [ -n "$total" ]; then
+                    passed="$total"
+                    failed="0"
+                else
+                    passed="0"
+                    failed="0"
+                fi
+            elif echo "$swift_test_summary" | grep -q "✘ Test run with.*failed"; then
+                total=$(echo "$swift_test_summary" | grep -o '[0-9]\+ tests\?' | head -1 | grep -o '[0-9]\+' || echo "")
+                issues=$(echo "$swift_test_summary" | grep -o 'with [0-9]\+ issues\?' | grep -o '[0-9]\+' || echo "")
+
+                if [ -n "$total" ] && [ -n "$issues" ]; then
+                    failed="$issues"
+                    passed=$((total - issues))
+                else
+                    passed="0"
+                    failed="0"
+                fi
+            else
+                passed="0"
+                failed="0"
+            fi
+        else
+            passed="0"
+            failed="0"
+        fi
+
+        filtered_output=$(echo "$output" | grep -E "(✔ Test.*passed|✗ Test.*failed|✘ Test.*failed|◇ Test.*started)")
+    else
+        filtered_output=$(echo "$output" | grep -iE "(Test Case|Test Suite.*failed|Test Suite.*passed)")
+        passed=$(echo "$filtered_output" | grep -ic "Test Case.*passed" 2>/dev/null || echo "0")
+        failed=$(echo "$filtered_output" | grep -ic "Test Case.*failed" 2>/dev/null || echo "0")
+    fi
+
+    passed=$(echo "$passed" | tr -d ' \t\n\r')
+    failed=$(echo "$failed" | tr -d ' \t\n\r')
+
+    if [ -z "$passed" ] || [ -z "$failed" ] || ! [[ "$passed" =~ ^[0-9]+$ ]] || ! [[ "$failed" =~ ^[0-9]+$ ]]; then
+        echo "⚠️ $name: Failed to parse test results"
+        echo ""
+        echo "🔍 Debug Output (last 10 lines):"
+        echo "$output" | tail -10 | sed 's/^/   /'
+        return 1
+    fi
+
+    total=$((passed + failed))
+
+    if [ "$failed" -eq 0 ] && [ "$total" -gt 0 ]; then
+        echo "✅ $name: $total tests - $passed passed, $failed failed"
+        return 0
+    elif [ "$total" -eq 0 ]; then
+        if [ "$exit_code" -eq 0 ] && echo "$output" | grep -q "\*\* TEST SUCCEEDED \*\*"; then
+            echo "✅ $name: Tests passed (0 test cases counted — xcodebuild reported success)"
+            return 0
+        fi
+        echo "⚠️ $name: No tests found or build failed"
+        if [ "$exit_code" -ne 0 ]; then
+            echo ""
+            echo "🔍 Debug Information:"
+            echo "$output" | grep -E "Testing failed|BUILD FAILED|No tests|error:|fatal error:" | head -10 | sed 's/^/   /'
+            echo ""
+            echo "🔍 Full Build Output (last 30 lines):"
+            echo "$output" | tail -30 | sed 's/^/   /'
+        fi
+        return 1
+    else
+        echo "❌ $name: $total tests - $passed passed, $failed failed"
+        echo ""
+
+        if echo "$output" | grep -q "✗.*failed\|✘.*failed\|Failing tests:"; then
+            echo "   Failed tests:"
+            if echo "$filtered_output" | grep -q "✗.*failed\|✘.*failed"; then
+                echo "$filtered_output" | grep -E "✗.*failed|✘.*failed" | sed 's/^/   - /'
+            fi
+            if echo "$output" | grep -q "Failing tests:"; then
+                echo "$output" | sed -n '/Failing tests:/,/^$/p' | grep -E "^\s*[A-Za-z].*\(\)" | sed 's/^/   - /'
+            fi
+            echo ""
+            echo "   Detailed Failures:"
+
+            if echo "$output" | grep -q "Failing tests:"; then
+                failed_tests=$(echo "$output" | sed -n '/Failing tests:/,/^$/p' | grep -E "^\s*[A-Za-z].*\(\)" | sed 's/^\s*//' | sed 's/()$//')
+            else
+                failed_tests=$(echo "$filtered_output" | grep -E "✗.*failed|✘.*failed" | sed 's/.*Test "//' | sed 's/" failed.*//')
+            fi
+        else
+            echo "   Failed tests:"
+            echo "$filtered_output" | grep "Test Case.*failed" | sed 's/.*Test Case /   - /' | sed 's/ failed.*//' | sed "s/'//g"
+            echo ""
+            echo "   Detailed Failures:"
+
+            failed_tests=$(echo "$filtered_output" | grep "Test Case.*failed" | sed 's/.*Test Case //' | sed 's/ failed.*//' | sed "s/'//g")
+        fi
+
+        xcresult_path=$(echo "$output" | grep -o '/.*\.xcresult' | tail -1)
+
+        while IFS= read -r test_name; do
+            if [ -n "$test_name" ]; then
+                echo "   📍 $test_name:"
+
+                failure_details=$(extract_test_failure_details "$test_name" "$output" "$xcresult_path")
+
+                if [ -n "$failure_details" ]; then
+                    echo "$failure_details" | while IFS= read -r error_line; do
+                        if [ -n "$error_line" ]; then
+                            clean_line=$(echo "$error_line" | sed 's/^[0-9-]* [0-9:]* *[+-][0-9]* //' | sed 's/\[.*\] //' | sed 's/❌ //')
+
+                            file_info=$(echo "$error_line" | grep -o '[^/]*\.swift:[0-9]*')
+
+                            if [ -n "$file_info" ]; then
+                                echo "      ❌ $clean_line ($file_info)"
+                            else
+                                echo "      ❌ $clean_line"
+                            fi
+                        fi
+                    done
+                else
+                    echo "      ❌ Test failed - run with --verbose or check:"
+                    echo "         xcodebuild test -only-testing:\"$test_name\" -enableCodeCoverage NO"
+                fi
+                echo ""
+            fi
+        done <<< "$failed_tests"
+
+        return 1
+    fi
+}
+
+overall_failures=0
+
+if [ "$TEST_TYPE" = "single" ]; then
+    if [ -z "$TEST_IDENTIFIER" ]; then
+        echo "Error: single test type requires a test target name"
+        echo "Usage: $0 single <target>"
+        exit 1
+    fi
+
+    run_tests "$TEST_IDENTIFIER" "Single Test Target" || overall_failures=1
+elif [ "$TEST_TYPE" = "unit" ]; then
+    if [ -z "$UNIT_TARGETS" ]; then
+        echo "⚠️ No unit test targets found"
+        echo "   Available targets: $(echo "$ALL_TARGETS" | tr '\n' ' ')"
+        exit 1
+    fi
+
+    while IFS= read -r target; do
+        if [ -n "$target" ]; then
+            run_tests "$target" "Unit Tests" || overall_failures=1
+        fi
+    done <<< "$UNIT_TARGETS"
+elif [ "$TEST_TYPE" = "ui" ]; then
+    if [ -z "$UI_TARGETS" ]; then
+        echo "⚠️ No UI test targets found"
+        echo "   Available targets: $(echo "$ALL_TARGETS" | tr '\n' ' ')"
+        exit 1
+    fi
+
+    while IFS= read -r target; do
+        if [ -n "$target" ]; then
+            run_tests "$target" "UI Tests" || overall_failures=1
+        fi
+    done <<< "$UI_TARGETS"
+else
+    if [ -n "$UNIT_TARGETS" ]; then
+        while IFS= read -r target; do
+            if [ -n "$target" ]; then
+                run_tests "$target" "Unit Tests" || overall_failures=1
+            fi
+        done <<< "$UNIT_TARGETS"
+    fi
+
+    if [ -n "$UI_TARGETS" ]; then
+        while IFS= read -r target; do
+            if [ -n "$target" ]; then
+                run_tests "$target" "UI Tests" || overall_failures=1
+            fi
+        done <<< "$UI_TARGETS"
+    fi
+
+    if [ -z "$UNIT_TARGETS" ] && [ -z "$UI_TARGETS" ]; then
+        echo "⚠️ No test targets found"
+        echo "   Available targets: $(echo "$ALL_TARGETS" | tr '\n' ' ')"
+        exit 1
+    fi
+fi
+
+echo ""
+echo "=================="
+if [ $overall_failures -eq 0 ]; then
+    echo "🎉 All tests passed!"
+else
+    echo "💥 Some tests failed!"
+fi
+echo "=================="
+
+exit $overall_failures


### PR DESCRIPTION
## Summary

- Add a new curated skill `xcode-build` for building and testing iOS Xcode projects
- Includes `build.sh` and `run_tests.sh` scripts with auto-detection of xcworkspace/xcodeproj, scheme, and simulator
- Supports Rosetta mode (x86_64), Swift Testing and XCTest frameworks, unit/UI test filtering, verbose output, and detailed failure reporting
- **Token-friendly by design**: xcodebuild produces extremely verbose output (often 10,000+ lines for a single build). The scripts filter out all noise and surface only errors and test failure details, keeping context window consumption minimal while preserving actionable diagnostics
- Follows the `<path-to-skill>` convention and skill anatomy guidelines

## Skill Structure

```
xcode-build/
├── SKILL.md
├── agents/openai.yaml
├── scripts/
│   ├── build.sh
│   └── run_tests.sh
└── LICENSE.txt
```

## Test plan

- [ ] Verify `SKILL.md` frontmatter triggers correctly for build/test related queries
- [ ] Run `build.sh` against a sample iOS project with xcworkspace
- [ ] Run `build.sh` against a sample iOS project with xcodeproj only
- [ ] Run `run_tests.sh unit` to validate unit test filtering
- [ ] Run `run_tests.sh ui` to validate UI test filtering
- [ ] Run with `--rosetta` flag on Apple Silicon
- [ ] Validate `quick_validate.py` passes (confirmed locally)