### PR TITLE
Add token-usage-report skill to .experimental

### DIFF
--- a/skills/.experimental/token-usage-report/LICENSE.txt
+++ b/skills/.experimental/token-usage-report/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.experimental/token-usage-report/SKILL.md
+++ b/skills/.experimental/token-usage-report/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: token-usage-report
+description: >-
+  Summarize Codex token usage from local rollout logs across all projects and
+  sessions for a target date. Trigger when user asks for token totals/usages in
+  Chinese or English, e.g. "统计 token", "今天总共用了多少 token", "所有项目所有
+  session 的 token", "token usage today", "how many tokens did I use today",
+  "all projects all sessions token usage", or per-project token breakdown.
+---
+
+# Token Usage Report
+
+## Overview
+
+Use this skill to compute token usage totals from local Codex rollout logs:
+`~/.codex/sessions/**/rollout-*.jsonl`.
+
+This skill is designed for accurate day-level summaries across all projects and
+sessions, including sessions created on previous days but used on the target day.
+
+## Workflow
+
+1. Resolve date and timezone.
+- If user says "today", use current local date.
+- Prefer explicit `YYYY-MM-DD` when user gives relative dates.
+
+2. Run the bundled script.
+- Text summary:
+  - `bun ~/.codex/skills/token-usage-report/scripts/report-token-usage.mjs --date YYYY-MM-DD --timezone Asia/Shanghai`
+- JSON output:
+  - `bun ~/.codex/skills/token-usage-report/scripts/report-token-usage.mjs --date YYYY-MM-DD --timezone Asia/Shanghai --json`
+
+3. Return concise results.
+- Always include: total tokens, sessions count, per-project totals.
+- Include top sessions when helpful.
+
+## Script Options
+
+- `--date YYYY-MM-DD`: target date (default: today in selected timezone)
+- `--timezone IANA_TZ`: timezone, e.g. `Asia/Shanghai`
+- `--sessions-root PATH`: custom sessions root (default `~/.codex/sessions`)
+- `--limit N`: top session rows in text mode (default `20`)
+- `--json`: print machine-readable JSON
+
+## Notes
+
+- The script merges token events across rollout files by `sessionId` before counting.
+- Day usage is computed from cumulative totals using monotonic increments to avoid
+  double counting in resumed sessions.

--- a/skills/.experimental/token-usage-report/agents/openai.yaml
+++ b/skills/.experimental/token-usage-report/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Token Usage Report"
+  short_description: "Summarize Codex token usage by date and project"
+  default_prompt: "统计今天在所有项目和所有 session 的 token 使用总量，并给我项目拆分。"

--- a/skills/.experimental/token-usage-report/scripts/report-token-usage.mjs
+++ b/skills/.experimental/token-usage-report/scripts/report-token-usage.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import readline from "node:readline";
+
+function printHelp() {
+	console.log(`Usage:
+  bun report-token-usage.mjs [options]
+
+Options:
+  --date YYYY-MM-DD        Target date in the selected timezone (default: today)
+  --timezone IANA_TZ       IANA timezone name (default: local timezone)
+  --sessions-root PATH     Sessions root path (default: ~/.codex/sessions)
+  --limit N                Max session rows shown in text output (default: 20)
+  --json                   Print JSON only
+  --help                   Show this help
+
+Examples:
+  bun report-token-usage.mjs --date 2026-03-05 --timezone Asia/Shanghai
+  bun report-token-usage.mjs --date 2026-03-05 --json
+`);
+}
+
+function parseArgs(argv) {
+	const args = {
+		date: null,
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+		sessionsRoot: path.join(os.homedir(), ".codex", "sessions"),
+		limit: 20,
+		json: false,
+		help: false,
+	};
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--help" || arg === "-h") {
+			args.help = true;
+			continue;
+		}
+		if (arg === "--json") {
+			args.json = true;
+			continue;
+		}
+
+		const [k, vInline] = arg.split("=", 2);
+		const nextValue = vInline ?? argv[i + 1];
+
+		if (k === "--date") {
+			if (!nextValue) throw new Error("--date requires a value");
+			args.date = nextValue;
+			if (vInline === undefined) i++;
+			continue;
+		}
+		if (k === "--timezone") {
+			if (!nextValue) throw new Error("--timezone requires a value");
+			args.timezone = nextValue;
+			if (vInline === undefined) i++;
+			continue;
+		}
+		if (k === "--sessions-root") {
+			if (!nextValue) throw new Error("--sessions-root requires a value");
+			args.sessionsRoot = nextValue;
+			if (vInline === undefined) i++;
+			continue;
+		}
+		if (k === "--limit") {
+			if (!nextValue) throw new Error("--limit requires a value");
+			const n = Number(nextValue);
+			if (!Number.isFinite(n) || n <= 0) {
+				throw new Error("--limit must be a positive number");
+			}
+			args.limit = Math.floor(n);
+			if (vInline === undefined) i++;
+			continue;
+		}
+
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	return args;
+}
+
+function isValidDate(date) {
+	return /^\d{4}-\d{2}-\d{2}$/.test(date);
+}
+
+function getDateInTimezone(timezone, date = new Date()) {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: timezone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+function getDateFormatter(timezone) {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: timezone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+}
+
+function formatNumber(num) {
+	return new Intl.NumberFormat("en-US").format(num);
+}
+
+async function collectRolloutFiles(rootDir) {
+	const out = [];
+	const stack = [rootDir];
+
+	while (stack.length > 0) {
+		const dir = stack.pop();
+		let entries = [];
+		try {
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(fullPath);
+				continue;
+			}
+			if (
+				entry.isFile() &&
+				entry.name.startsWith("rollout-") &&
+				entry.name.endsWith(".jsonl")
+			) {
+				out.push(fullPath);
+			}
+		}
+	}
+
+	return out;
+}
+
+async function parseRolloutFile(filePath) {
+	let sessionId = null;
+	let cwd = "(unknown)";
+	const events = [];
+
+	const rl = readline.createInterface({
+		input: fs.createReadStream(filePath, { encoding: "utf8" }),
+		crlfDelay: Infinity,
+	});
+
+	for await (const line of rl) {
+		if (!line) continue;
+		let obj;
+		try {
+			obj = JSON.parse(line);
+		} catch {
+			continue;
+		}
+
+		if (obj.type === "session_meta" && obj.payload) {
+			sessionId = obj.payload.id || sessionId;
+			cwd = obj.payload.cwd || cwd;
+			continue;
+		}
+
+		if (
+			obj.type === "event_msg" &&
+			obj.payload?.type === "token_count" &&
+			obj.payload?.info
+		) {
+			const total = Number(obj.payload.info?.total_token_usage?.total_tokens);
+			const ts = obj.timestamp;
+			const timeMs = ts ? Date.parse(ts) : Number.NaN;
+			if (!Number.isFinite(total) || !Number.isFinite(timeMs)) continue;
+			events.push({ ts, timeMs, total });
+		}
+	}
+
+	if (events.length === 0) return null;
+
+	return {
+		sessionId,
+		cwd,
+		filePath,
+		events,
+	};
+}
+
+function chooseBestCwd(cwdCounts) {
+	let best = "(unknown)";
+	let bestCount = -1;
+	for (const [cwd, count] of cwdCounts.entries()) {
+		if (count > bestCount) {
+			best = cwd;
+			bestCount = count;
+		}
+	}
+	return best;
+}
+
+function buildSessionAggregates(fileResults) {
+	const bySession = new Map();
+
+	for (const result of fileResults) {
+		if (!result) continue;
+		const key = result.sessionId ? `sid:${result.sessionId}` : `file:${result.filePath}`;
+		let agg = bySession.get(key);
+		if (!agg) {
+			agg = {
+				sessionKey: key,
+				sessionId: result.sessionId,
+				cwdCounts: new Map(),
+				events: [],
+				sourceFiles: new Set(),
+			};
+			bySession.set(key, agg);
+		}
+
+		if (result.cwd && result.cwd !== "(unknown)") {
+			agg.cwdCounts.set(result.cwd, (agg.cwdCounts.get(result.cwd) || 0) + 1);
+		}
+		agg.events.push(...result.events);
+		agg.sourceFiles.add(result.filePath);
+	}
+
+	return [...bySession.values()].map((agg) => ({
+		sessionKey: agg.sessionKey,
+		sessionId: agg.sessionId,
+		cwd: chooseBestCwd(agg.cwdCounts),
+		events: agg.events,
+		sourceFiles: [...agg.sourceFiles],
+	}));
+}
+
+function computeTokensForDay(events, targetDate, dateFormatter) {
+	const deduped = [];
+	const seen = new Set();
+	for (const event of events) {
+		const k = `${event.timeMs}|${event.total}`;
+		if (seen.has(k)) continue;
+		seen.add(k);
+		deduped.push(event);
+	}
+
+	deduped.sort((a, b) => (a.timeMs - b.timeMs) || (a.total - b.total));
+
+	let maxSeenTotal = null;
+	let tokensForDay = 0;
+
+	for (const event of deduped) {
+		const delta =
+			maxSeenTotal === null ? event.total : Math.max(0, event.total - maxSeenTotal);
+		maxSeenTotal = maxSeenTotal === null ? event.total : Math.max(maxSeenTotal, event.total);
+
+		if (dateFormatter.format(new Date(event.timeMs)) === targetDate) {
+			tokensForDay += delta;
+		}
+	}
+
+	return tokensForDay;
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.help) {
+		printHelp();
+		return;
+	}
+
+	if (!args.date) {
+		args.date = getDateInTimezone(args.timezone);
+	}
+
+	if (!isValidDate(args.date)) {
+		throw new Error(`Invalid --date: ${args.date} (expected YYYY-MM-DD)`);
+	}
+
+	if (!fs.existsSync(args.sessionsRoot)) {
+		throw new Error(`Sessions root not found: ${args.sessionsRoot}`);
+	}
+
+	const dateFormatter = getDateFormatter(args.timezone);
+	const files = await collectRolloutFiles(args.sessionsRoot);
+
+	const parsedFiles = [];
+	for (const filePath of files) {
+		parsedFiles.push(await parseRolloutFile(filePath));
+	}
+
+	const sessionAggregates = buildSessionAggregates(parsedFiles);
+
+	const sessions = [];
+	const projects = new Map();
+	let totalTokens = 0;
+
+	for (const agg of sessionAggregates) {
+		const tokens = computeTokensForDay(agg.events, args.date, dateFormatter);
+		if (tokens <= 0) continue;
+
+		const sessionRow = {
+			sessionId: agg.sessionId,
+			sessionKey: agg.sessionKey,
+			cwd: agg.cwd,
+			tokens,
+			sourceFiles: agg.sourceFiles.length,
+		};
+		sessions.push(sessionRow);
+		totalTokens += tokens;
+		projects.set(sessionRow.cwd, (projects.get(sessionRow.cwd) || 0) + tokens);
+	}
+
+	sessions.sort((a, b) => b.tokens - a.tokens);
+	const projectRows = [...projects.entries()]
+		.map(([cwd, tokens]) => ({ cwd, tokens }))
+		.sort((a, b) => b.tokens - a.tokens);
+
+	const summary = {
+		date: args.date,
+		timezone: args.timezone,
+		sessionsRoot: args.sessionsRoot,
+		totalTokens,
+		sessionsCount: sessions.length,
+		projects: projectRows,
+		sessions,
+	};
+
+	if (args.json) {
+		console.log(JSON.stringify(summary, null, 2));
+		return;
+	}
+
+	console.log(`Token Usage Summary`);
+	console.log(`Date: ${summary.date}`);
+	console.log(`Timezone: ${summary.timezone}`);
+	console.log(`Sessions with usage: ${summary.sessionsCount}`);
+	console.log(`Total tokens: ${formatNumber(summary.totalTokens)}`);
+
+	if (projectRows.length > 0) {
+		console.log(`\nBy project:`);
+		for (const row of projectRows) {
+			console.log(`- ${row.cwd}: ${formatNumber(row.tokens)}`);
+		}
+	}
+
+	if (sessions.length > 0) {
+		console.log(`\nTop sessions:`);
+		for (const [idx, session] of sessions.slice(0, args.limit).entries()) {
+			console.log(
+				`${idx + 1}. ${session.sessionId ?? "(unknown session)"} | ${formatNumber(session.tokens)} | ${session.cwd}`,
+			);
+		}
+	}
+}
+
+main().catch((error) => {
+	console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Add a new experimental skill: `token-usage-report`.

Path:
- `skills/.experimental/token-usage-report`

This skill summarizes Codex token usage for a target day from local rollout logs across all projects and sessions.

## What is included

- `SKILL.md` with Chinese + English trigger phrases and workflow
- `agents/openai.yaml` UI metadata
- `scripts/report-token-usage.mjs` for deterministic reporting
- `LICENSE.txt` (Apache-2.0)

## Notable behavior

The script merges token events across rollout files by `sessionId` and computes day usage from monotonic cumulative increments. This avoids double counting when sessions are resumed across multiple rollout files.

## Validation

- `python3 skills/.system/skill-creator/scripts/quick_validate.py skills/.experimental/token-usage-report`
- `bun skills/.experimental/token-usage-report/scripts/report-token-usage.mjs --date 2026-03-06 --timezone Asia/Shanghai --limit 3`
