### PR TITLE
Better deploy to Vercel skill, using first party vercel CLI first

### DIFF
--- a/skills/.curated/vercel-deploy/SKILL.md
+++ b/skills/.curated/vercel-deploy/SKILL.md
@@ -5,73 +5,226 @@ description: Deploy applications and websites to Vercel. Use when the user reque
 
 # Vercel Deploy
 
-Deploy any project to Vercel instantly. **Always deploy as preview** (not production) unless the user explicitly asks for production.
+Deploy any project to Vercel. **Always deploy as preview** (not production) unless the user explicitly asks for production.
 
-## Prerequisites
+The goal is to get the user into the best long-term setup: their project linked to Vercel with git-push deploys. Every method below tries to move the user closer to that state.
 
-- Check whether the Vercel CLI is installed **without** escalated permissions (for example, `command -v vercel`).
-- Only escalate the actual deploy command if sandboxing blocks the deployment network calls (`sandbox_permissions=require_escalated`).
-- The deployment might take a few minutes. Use appropriate timeout values.
+## Step 1: Gather Project State
 
-## Quick Start
-
-1. Check whether the Vercel CLI is installed (no escalation for this check):
+Run all four checks before deciding which method to use:
 
 ```bash
-command -v vercel
+# 1. Check for a git remote
+git remote get-url origin 2>/dev/null
+
+# 2. Check if locally linked to a Vercel project (either file means linked)
+cat .vercel/project.json 2>/dev/null || cat .vercel/repo.json 2>/dev/null
+
+# 3. Check if the Vercel CLI is installed and authenticated
+vercel whoami 2>/dev/null
+
+# 4. List available teams (if authenticated)
+vercel teams list --format json 2>/dev/null
 ```
 
-2. If `vercel` is installed, run this (with a 10 minute timeout):
+### Team selection
+
+If the user belongs to multiple teams, present all available team slugs as a bulleted list and ask which one to deploy to. Once the user picks a team, proceed immediately to the next step — do not ask for additional confirmation.
+
+Pass the team slug via `--scope` on all subsequent CLI commands (`vercel deploy`, `vercel link`, `vercel inspect`, etc.):
+
 ```bash
-vercel deploy [path] -y
+vercel deploy [path] -y --no-wait --scope <team-slug>
 ```
 
-**Important:** Use a 10 minute (600000ms) timeout for the deploy command since builds can take a while.
+If the project is already linked (`.vercel/project.json` or `.vercel/repo.json` exists), the `orgId` in those files determines the team — no need to ask again. If there is only one team (or just a personal account), skip the prompt and use it directly.
 
-3. If `vercel` is not installed, or if the CLI fails with "No existing credentials found", use the fallback method below.
+**About the `.vercel/` directory:** A linked project has either:
+- `.vercel/project.json` — created by `vercel link` (single project linking). Contains `projectId` and `orgId`.
+- `.vercel/repo.json` — created by `vercel link --repo` (repo-based linking). Contains `orgId`, `remoteName`, and a `projects` array mapping directories to Vercel project IDs.
 
-## Fallback (No Auth)
+Either file means the project is linked. Check for both.
 
-If CLI fails with auth error, use the deploy script:
+**Do NOT** use `vercel project inspect`, `vercel ls`, or `vercel link` to detect state in an unlinked directory — without a `.vercel/` config, they will interactively prompt (or with `--yes`, silently link as a side-effect). Only `vercel whoami` is safe to run anywhere.
+
+## Step 2: Choose a Deploy Method
+
+### Linked (`.vercel/` exists) + has git remote → Git Push
+
+This is the ideal state. The project is linked and has git integration.
+
+1. **Ask the user before pushing.** Never push without explicit approval:
+   ```
+   This project is connected to Vercel via git. I can commit and push to
+   trigger a deployment. Want me to proceed?
+   ```
+
+2. **Commit and push:**
+   ```bash
+   git add .
+   git commit -m "deploy: <description of changes>"
+   git push
+   ```
+   Vercel automatically builds from the push. Non-production branches get preview deployments; the production branch (usually `main`) gets a production deployment.
+
+3. **Retrieve the preview URL.** If the CLI is authenticated:
+   ```bash
+   sleep 5
+   vercel ls --format json
+   ```
+   The JSON output has a `deployments` array. Find the latest entry — its `url` field is the preview URL.
+
+   If the CLI is not authenticated, tell the user to check the Vercel dashboard or the commit status checks on their git provider for the preview URL.
+
+---
+
+### Linked (`.vercel/` exists) + no git remote → `vercel deploy`
+
+The project is linked but there's no git repo. Deploy directly with the CLI.
 
 ```bash
-skill_dir="<path-to-skill>"
-
-# Deploy current directory
-bash "$skill_dir/scripts/deploy.sh"
-
-# Deploy specific project
-bash "$skill_dir/scripts/deploy.sh" /path/to/project
-
-# Deploy existing tarball
-bash "$skill_dir/scripts/deploy.sh" /path/to/project.tgz
+vercel deploy [path] -y --no-wait
 ```
+
+Use `--no-wait` so the CLI returns immediately with the deployment URL instead of blocking until the build finishes (builds can take a while). Then check on the deployment status with:
+
+```bash
+vercel inspect <deployment-url>
+```
+
+For production deploys (only if user explicitly asks):
+```bash
+vercel deploy [path] --prod -y --no-wait
+```
+
+---
+
+### Not linked + CLI is authenticated → Link first, then deploy
+
+The CLI is working but the project isn't linked yet. This is the opportunity to get the user into the best state.
+
+1. **Ask the user which team to deploy to.** Present the team slugs from Step 1 as a bulleted list. If there's only one team (or just a personal account), skip this step.
+
+2. **Once a team is selected, proceed directly to linking.** Tell the user what will happen but do not ask for separate confirmation:
+   ```
+   Linking this project to <team name> on Vercel. This will create a Vercel
+   project to deploy to and enable automatic deployments on future git pushes.
+   ```
+
+3. **If a git remote exists**, use repo-based linking with the selected team scope:
+   ```bash
+   vercel link --repo --scope <team-slug>
+   ```
+   This reads the git remote URL and matches it to existing Vercel projects that deploy from that repo. It creates `.vercel/repo.json`. This is much more reliable than `vercel link` (without `--repo`), which tries to match by directory name and often fails when the local folder and Vercel project are named differently.
+
+   **If there is no git remote**, fall back to standard linking:
+   ```bash
+   vercel link --scope <team-slug>
+   ```
+   This prompts the user to select or create a project. It creates `.vercel/project.json`.
+
+4. **Then deploy using the best available method:**
+   - If a git remote exists → commit and push (see git push method above)
+   - If no git remote → `vercel deploy [path] -y --no-wait --scope <team-slug>`, then `vercel inspect <url>` to check status
+
+---
+
+### Not linked + CLI not authenticated → Install, auth, link, deploy
+
+The Vercel CLI isn't set up at all.
+
+1. **Install the CLI (if not already installed):**
+   ```bash
+   npm install -g vercel
+   ```
+
+2. **Authenticate:**
+   ```bash
+   vercel login
+   ```
+   The user completes auth in their browser. If running in a non-interactive environment where login is not possible, skip to the **no-auth fallback** below.
+
+3. **Ask which team to deploy to** — present team slugs from `vercel teams list --format json` as a bulleted list. If only one team / personal account, skip. Once selected, proceed immediately.
+
+4. **Link the project** with the selected team scope (use `--repo` if a git remote exists, plain `vercel link` otherwise):
+   ```bash
+   vercel link --repo --scope <team-slug>   # if git remote exists
+   vercel link --scope <team-slug>          # if no git remote
+   ```
+
+5. **Deploy** using the best available method (git push if remote exists, otherwise `vercel deploy -y --no-wait --scope <team-slug>`, then `vercel inspect <url>` to check status).
+
+---
+
+### No-Auth Fallback (Codex sandbox)
+
+**When to use:** In the Codex sandbox where the CLI may not be authenticated. Codex runs in a sandboxed environment by default — try the CLI first, and fall back to the deploy script if auth fails.
+
+1. **Check whether the Vercel CLI is installed** (no escalation needed for this check):
+   ```bash
+   command -v vercel
+   ```
+
+2. **If `vercel` is installed**, try deploying with the CLI:
+   ```bash
+   vercel deploy [path] -y --no-wait
+   ```
+
+3. **If `vercel` is not installed, or the CLI fails with "No existing credentials found"**, use the fallback script:
+   ```bash
+   skill_dir="<path-to-skill>"
+
+   # Deploy current directory
+   bash "$skill_dir/scripts/deploy.sh"
+
+   # Deploy specific project
+   bash "$skill_dir/scripts/deploy.sh" /path/to/project
+
+   # Deploy existing tarball
+   bash "$skill_dir/scripts/deploy.sh" /path/to/project.tgz
+   ```
 
 The script handles framework detection, packaging, and deployment. It waits for the build to complete and returns JSON with `previewUrl` and `claimUrl`.
 
 **Tell the user:** "Your deployment is ready at [previewUrl]. Claim it at [claimUrl] to manage your deployment."
 
-## Production Deploys
+**Escalated network access:** Only escalate the actual deploy command if sandboxing blocks the network call (`sandbox_permissions=require_escalated`). Do **not** escalate the `command -v vercel` check.
 
-Only if user explicitly asks:
-```bash
-vercel deploy [path] --prod -y
-```
+---
 
 ## Output
 
-Show the user the deployment URL. For fallback deployments, also show the claim URL.
+Always show the user the deployment URL.
+
+- **Git push:** Use `vercel ls --format json` to find the preview URL. If the CLI isn't authenticated, tell the user to check the Vercel dashboard or commit status checks.
+- **CLI deploy:** Show the URL returned by `vercel deploy --no-wait`. Use `vercel inspect <url>` to check build status and report it to the user.
+- **No-auth fallback:** Show both the preview URL and the claim URL:
+  ```
+  Deployment successful!
+
+  Preview URL: https://my-app-abc123.vercel.app
+  Claim URL:   https://vercel.com/claim-deployment?code=...
+
+  View your site at the Preview URL.
+  To transfer this deployment to your Vercel account, visit the Claim URL.
+  ```
 
 **Do not** curl or fetch the deployed URL to verify it works. Just return the link.
+
+---
 
 ## Troubleshooting
 
 ### Escalated Network Access
 
-If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the actual deploy command with escalated permissions (use `sandbox_permissions=require_escalated`). Do not escalate the `command -v vercel` installation check. The deploy requires escalated network access when sandbox networking blocks outbound requests.
+If deployment fails due to network issues (timeouts, DNS errors, connection resets), rerun the actual deploy command with escalated permissions (`sandbox_permissions=require_escalated`). Do not escalate the initial CLI availability check — only escalate the actual deploy command.
 
 Example guidance to the user:
+```
+The deploy needs escalated network access to deploy to Vercel. I can rerun
+the command with escalated permissions — want me to proceed?
+```
 
-```
-The deploy needs escalated network access to deploy to Vercel. I can rerun the command with escalated permissions—want me to proceed?
-```
+### CLI Auth Failure
+
+If `vercel login` or `vercel deploy` fails with authentication errors, fall back to the no-auth deploy script.


### PR DESCRIPTION
This pull request updates the documentation for the Vercel Deploy skill to provide a much more comprehensive and structured deployment guide. The new instructions clarify the recommended workflow, add detailed guidance for handling teams, linking projects, and deployment methods, and improve fallback handling for unauthenticated environments. The changes also enhance troubleshooting instructions and output formatting.

Deployment workflow improvements:

* Expanded the deployment instructions to prioritize linking projects to Vercel with git-push deploys, and provided step-by-step guidance for gathering project state, including checks for git remotes, Vercel linking, CLI authentication, and available teams.
* Added detailed instructions for handling team selection, including presenting available teams and passing the team slug to CLI commands, and clarified the use of `.vercel/project.json` and `.vercel/repo.json` for linked project detection.
* Provided explicit branching for deployment methods based on project state: linked projects with git remotes (git push), linked projects without git remotes (CLI deploy), not linked but authenticated (link then deploy), and not linked or authenticated (install, auth, link, deploy).

Fallback and troubleshooting enhancements:

* Improved no-auth fallback instructions for sandboxed environments, including when to escalate network permissions, and clarified the fallback deploy script usage. [[1]](diffhunk://#diff-eb1912d5ec11a8088fd78abc0ded440b3740c4575fd06927c923bab098e9e564L8-R173) [[2]](diffhunk://#diff-eb1912d5ec11a8088fd78abc0ded440b3740c4575fd06927c923bab098e9e564L54-R230)
* Enhanced troubleshooting guidance for network issues and CLI authentication failures, specifying when to escalate permissions and when to fall back to unauthenticated deployments.

Output and user communication improvements:

* Updated output instructions to always show the deployment URL, with clear guidance on preview and claim URLs in fallback scenarios, and specified not to verify the deployed URL by fetching it.
* Clarified how to retrieve and communicate the preview URL after deployment for both git push and CLI deploy methods. [[1]](diffhunk://#diff-eb1912d5ec11a8088fd78abc0ded440b3740c4575fd06927c923bab098e9e564L8-R173) [[2]](diffhunk://#diff-eb1912d5ec11a8088fd78abc0ded440b3740c4575fd06927c923bab098e9e564L54-R230)