### PR TITLE
Add rlhf-feedback-loop curated skill

### DIFF
--- a/skills/.curated/rlhf-feedback-loop/LICENSE.txt
+++ b/skills/.curated/rlhf-feedback-loop/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Igor Ganapolsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.curated/rlhf-feedback-loop/SKILL.md
+++ b/skills/.curated/rlhf-feedback-loop/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: rlhf-feedback-loop
+description: Capture thumbs up/down feedback, block repeated mistakes, recall past learnings, and export DPO training pairs. Activate when the user says thumbs up, thumbs down, that worked, that failed, or asks to recall past feedback.
+---
+
+# RLHF Feedback Loop
+
+Persistent feedback capture and recall for AI coding agents. This skill gives Codex memory of what worked and what failed across sessions.
+
+## How to Use
+
+### Capture Feedback
+
+When the user gives explicit positive or negative feedback:
+
+```bash
+npx -y rlhf-feedback-loop capture --feedback=up --context="description of what worked" --tags="relevant,tags"
+npx -y rlhf-feedback-loop capture --feedback=down --context="description of failure" --what-went-wrong="root cause" --what-to-change="fix" --tags="relevant,tags"
+```
+
+### Recall Past Feedback
+
+Before starting any non-trivial task, check for relevant past feedback:
+
+```bash
+npx -y rlhf-feedback-loop stats
+```
+
+### Generate Prevention Rules
+
+After accumulating negative feedback, generate guardrails:
+
+```bash
+npx -y rlhf-feedback-loop rules
+```
+
+### Export DPO Training Pairs
+
+Export preference pairs for model fine-tuning:
+
+```bash
+npx -y rlhf-feedback-loop export-dpo
+```
+
+## MCP Server (Recommended)
+
+For real-time in-session recall, use the MCP server:
+
+```bash
+codex mcp add rlhf -- npx -y rlhf-feedback-loop serve
+```
+
+This exposes 11 tools including `recall`, `capture_feedback`, `prevention_rules`, and `export_dpo_pairs`.
+
+## Rules
+
+1. ALWAYS capture feedback when the user says "thumbs up", "thumbs down", "that worked", "that failed", or similar.
+2. ALWAYS include context describing what happened and relevant tags.
+3. For negative feedback, ALWAYS include `--what-went-wrong` and `--what-to-change`.
+4. Before starting complex tasks, check `stats` for patterns of past failures.
+5. All data stays local in JSONL files. Nothing is sent to external services.
+
+## References
+
+- `references/architecture.md` — system architecture and data flow

--- a/skills/.curated/rlhf-feedback-loop/references/architecture.md
+++ b/skills/.curated/rlhf-feedback-loop/references/architecture.md
@@ -1,0 +1,45 @@
+# RLHF Feedback Loop Architecture
+
+## Data Flow
+
+```
+Thumbs up/down → Capture (JSONL log) → Rubric engine → Memory promotion
+                                                          |
+                                                    +-----+-----+
+                                                    |           |
+                                                  Learn      Prevent
+                                                    |           |
+                                                LanceDB    Prevention
+                                                vectors      rules
+                                                    |
+                                                DPO export → fine-tune
+```
+
+## Storage
+
+- **Feedback log**: `.rlhf/feedback-log.jsonl` — raw signals
+- **Memory log**: `.rlhf/memory-log.jsonl` — promoted memories
+- **Prevention rules**: `.rlhf/prevention-rules.md` — auto-generated guardrails
+- **LanceDB**: `.claude/memory/feedback/lancedb/` — vector embeddings
+
+## MCP Tools (11 total)
+
+| Tool | Purpose |
+|------|---------|
+| `recall` | Search past feedback for current task context |
+| `capture_feedback` | Record thumbs up/down with structured metadata |
+| `feedback_stats` | Analytics: counts, ratios, domain breakdown |
+| `feedback_summary` | Human-readable summary of recent feedback |
+| `prevention_rules` | Generate/retrieve prevention guardrails |
+| `export_dpo_pairs` | Export DPO training pairs (prompt/chosen/rejected) |
+| `construct_context_pack` | Build bounded context from memories |
+| `evaluate_context_pack` | Record pack outcome for improvement |
+| `context_provenance` | Audit trail of context decisions |
+| `list_intents` | Available action plans |
+| `plan_intent` | Generate execution plan with checkpoints |
+
+## Links
+
+- GitHub: https://github.com/IgorGanapolsky/rlhf-feedback-loop
+- npm: https://www.npmjs.com/package/rlhf-feedback-loop
+- MCP Registry: io.github.IgorGanapolsky/rlhf-feedback-loop


### PR DESCRIPTION
## New Curated Skill: rlhf-feedback-loop

**What it does:** Captures thumbs up/down feedback, blocks repeated mistakes with auto-generated prevention rules, recalls past learnings in-session, and exports DPO training pairs for model fine-tuning.

**How Codex users install it:**
```
codex mcp add rlhf -- npx -y rlhf-feedback-loop serve
```

**MCP tools exposed (11):** recall, capture_feedback, feedback_stats, prevention_rules, export_dpo_pairs, and more.

**Links:**
- npm: https://www.npmjs.com/package/rlhf-feedback-loop (v0.6.6, MIT license)
- GitHub: https://github.com/IgorGanapolsky/rlhf-feedback-loop
- MCP Registry: io.github.IgorGanapolsky/rlhf-feedback-loop
- 573 tests, CI passing

**Files added:**
- `skills/.curated/rlhf-feedback-loop/SKILL.md` — skill definition with triggers and commands
- `skills/.curated/rlhf-feedback-loop/references/architecture.md` — data flow and MCP tool reference
- `skills/.curated/rlhf-feedback-loop/LICENSE.txt` — MIT