### PR TITLE
docs: update Linear skill MCP tool names

### DIFF
--- a/skills/.curated/linear/SKILL.md
+++ b/skills/.curated/linear/SKILL.md
@@ -54,9 +54,11 @@ Summarize results, call out remaining gaps or blockers, and propose next actions
 
 ## Available Tools
 
-Issue Management: `list_issues`, `get_issue`, `create_issue`, `update_issue`, `list_my_issues`, `list_issue_statuses`, `list_issue_labels`, `create_issue_label`
+Issue Management: `list_issues`, `get_issue`, `save_issue` (create/update), `list_issue_statuses`, `list_issue_labels`, `create_issue_label`
 
-Project & Team: `list_projects`, `get_project`, `create_project`, `update_project`, `list_teams`, `get_team`, `list_users`
+Project & Team: `list_projects`, `get_project`, `save_project` (create/update), `list_teams`, `get_team`, `list_users`
+
+To review "my issues," use `list_issues` with `assignee="me"`.
 
 Documentation & Collaboration: `list_documents`, `get_document`, `search_documentation`, `list_comments`, `create_comment`, `list_cycles`
 


### PR DESCRIPTION
## Summary
- replace deprecated Linear MCP tool names in the curated Linear skill
- note that `save_issue` and `save_project` handle both create and update flows
- document using `list_issues` with `assignee="me"` for "my issues"

Closes #203.

## Validation
- searched the updated skill to confirm the deprecated tool names were removed
- ran `git diff --check`