### PR TITLE
Add curated latex-paper skill

### DIFF
--- a/skills/.curated/latex-paper/LICENSE.txt
+++ b/skills/.curated/latex-paper/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kudaliar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.curated/latex-paper/SKILL.md
+++ b/skills/.curated/latex-paper/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: "latex-paper"
+description: "End-to-end LaTeX paper authoring and editing for research-grade manuscripts. Use when tasks require creating, restructuring, or updating formatted .tex projects, managing citations/figures/tables, enforcing section conventions, and running deterministic compile/lint/troubleshooting workflows."
+---
+
+# LaTeX Paper Skill
+
+## Overview
+
+Use this skill to create and maintain publication-ready LaTeX projects with predictable structure, formatting consistency, and reproducible compile diagnostics.
+
+## Workflow Decision Tree
+
+1. Identify intent:
+- If the user asks to start a paper, scaffold with `scripts/new_paper.sh`.
+- If the user asks to edit an existing paper, preserve class/template choices and patch minimally.
+- If the user asks to convert a `.tex` file directly into PDF, run `scripts/tex_to_pdf.sh`.
+- If the user reports build failures, run `scripts/compile.sh` first to capture deterministic diagnostics.
+- If the user reports citation/reference issues, run `scripts/fixrefs.sh` and then patch affected `.tex`/`.bib` entries.
+
+2. Choose template only when creating a new project:
+- Use `article` for general manuscripts, drafts, and arXiv-style preprints.
+- Use `ieeetran` for IEEE conference/journal flows.
+- Use `acmart` for ACM conference/journal flows.
+- Load [template_matrix.md](references/template_matrix.md) for selection details.
+
+3. Apply editing conventions:
+- Keep one idea per paragraph in methods/results-heavy sections.
+- Keep labels stable; never rename labels/cite keys unless all references are updated atomically.
+- Prefer explicit section names over vague titles.
+- Ensure every figure/table has caption + label + in-text reference.
+
+4. Verify before completion:
+- Run `scripts/compile.sh <project-dir>`.
+- Run `scripts/lint.sh <project-dir>`.
+- Run `scripts/fixrefs.sh <project-dir>`.
+- Return the concrete file changes and remaining warnings.
+
+## Commands
+
+### New paper scaffold
+
+```bash
+scripts/new_paper.sh /path/to/paper --template article --title "Paper Title" --author "Author Name"
+```
+
+### Compile with deterministic logs
+
+```bash
+scripts/compile.sh /path/to/paper --main main.tex --engine pdflatex
+```
+
+### Convert a single TeX file to PDF
+
+```bash
+scripts/tex_to_pdf.sh /path/to/main.tex --engine pdflatex
+```
+
+### Lint and style checks
+
+```bash
+scripts/lint.sh /path/to/paper --main main.tex
+```
+
+### Missing refs/citations diagnostics
+
+```bash
+scripts/fixrefs.sh /path/to/paper
+```
+
+## Project Editing Rules
+
+- Preserve existing class and package choices unless the user asks to migrate templates.
+- Avoid broad rewrites; patch the smallest viable region.
+- Keep bibliography keys stable and human-readable (`lastnameYYYYtopic`).
+- Add comments only where logic is non-obvious (for example, custom macros or float constraints).
+
+## Reference Loading (Progressive)
+
+Load only what is needed:
+
+- Structure and section logic: [structure.md](references/structure.md)
+- Citations and bibliography workflows: [citations.md](references/citations.md)
+- Figure/table conventions: [figures_tables.md](references/figures_tables.md)
+- Template choice and tradeoffs: [template_matrix.md](references/template_matrix.md)
+
+## Done Criteria
+
+Complete the task only after these checks:
+
+- Project compiles or has explicit blocking diagnostics with file/line pointers.
+- No unresolved `\\ref`/`\\cite` issues from `scripts/fixrefs.sh`.
+- Requested formatting changes are reflected in source, not only in generated output.

--- a/skills/.curated/latex-paper/agents/openai.yaml
+++ b/skills/.curated/latex-paper/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "LaTeX Paper"
+  short_description: "Research-grade LaTeX paper authoring"
+  icon_small: "./assets/latex-paper-small.svg"
+  icon_large: "./assets/latex-paper.svg"
+  brand_color: "#178F98"
+  default_prompt: "Use $latex-paper to create or edit a structured LaTeX research paper and keep references, citations, and formatting consistent."

--- a/skills/.curated/latex-paper/assets/latex-paper-small.svg
+++ b/skills/.curated/latex-paper/assets/latex-paper-small.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400" role="img" aria-labelledby="title desc">
+  <title id="title">Codex LaTeX Icon</title>
+  <desc id="desc">Small icon for Codex LaTeX skill.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1f3a"/>
+      <stop offset="100%" stop-color="#178f98"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" rx="44" fill="url(#bg)"/>
+  <text x="52" y="218" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="118" font-weight="700" fill="#ffffff">L</text>
+  <text x="128" y="232" font-family="'JetBrains Mono', Consolas, monospace" font-size="68" fill="#ffd166">TX</text>
+</svg>

--- a/skills/.curated/latex-paper/assets/latex-paper.svg
+++ b/skills/.curated/latex-paper/assets/latex-paper.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="480" viewBox="0 0 1600 480" role="img" aria-labelledby="title desc">
+  <title id="title">Codex LaTeX Banner</title>
+  <desc id="desc">Banner image for the Codex LaTeX skill.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1f3a"/>
+      <stop offset="55%" stop-color="#124d77"/>
+      <stop offset="100%" stop-color="#178f98"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f7c948"/>
+      <stop offset="100%" stop-color="#ffd166"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="480" fill="url(#bg)"/>
+  <circle cx="1300" cy="120" r="180" fill="#ffffff" fill-opacity="0.07"/>
+  <circle cx="1425" cy="370" r="150" fill="#ffffff" fill-opacity="0.06"/>
+
+  <rect x="96" y="120" width="10" height="240" fill="url(#accent)" rx="5"/>
+  <text x="140" y="215" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="86" font-weight="700" fill="#ffffff">Codex LaTeX</text>
+  <text x="140" y="285" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="34" fill="#dbe7f3">Research-grade paper writing skill for structured LaTeX workflows</text>
+
+  <text x="140" y="360" font-family="'JetBrains Mono', 'Fira Code', Consolas, monospace" font-size="30" fill="#ffd166">\\documentclass{article}  \\begin{abstract} ... \\end{abstract}</text>
+</svg>

--- a/skills/.curated/latex-paper/assets/snippets/abstract.tex
+++ b/skills/.curated/latex-paper/assets/snippets/abstract.tex
@@ -1,0 +1,5 @@
+\begin{abstract}
+This paper addresses [problem] by proposing [method].
+Across [setting/dataset], the approach improves [metric] by [value] over [baseline].
+These results indicate [main implication] for [domain/application].
+\end{abstract}

--- a/skills/.curated/latex-paper/assets/snippets/algorithm.tex
+++ b/skills/.curated/latex-paper/assets/snippets/algorithm.tex
@@ -1,0 +1,12 @@
+% Requires: \usepackage{algorithm,algpseudocode}
+\begin{algorithm}
+\caption{Algorithm Name}
+\label{alg:main}
+\begin{algorithmic}[1]
+\State Initialize state
+\For{each iteration}
+  \State Update parameters
+\EndFor
+\State \Return output
+\end{algorithmic}
+\end{algorithm}

--- a/skills/.curated/latex-paper/assets/snippets/appendix.tex
+++ b/skills/.curated/latex-paper/assets/snippets/appendix.tex
@@ -1,0 +1,3 @@
+\appendix
+\section{Additional Experimental Details}
+Add ablations, implementation details, and supplemental plots here.

--- a/skills/.curated/latex-paper/assets/snippets/figure.tex
+++ b/skills/.curated/latex-paper/assets/snippets/figure.tex
@@ -1,0 +1,6 @@
+\begin{figure}[t]
+  \centering
+  \includegraphics[width=0.95\linewidth]{figures/example}
+  \caption{Caption that explains what is plotted and why it matters.}
+  \label{fig:example}
+\end{figure}

--- a/skills/.curated/latex-paper/assets/snippets/table.tex
+++ b/skills/.curated/latex-paper/assets/snippets/table.tex
@@ -1,0 +1,13 @@
+\begin{table}[t]
+  \centering
+  \caption{Main quantitative results. Higher is better unless noted.}
+  \label{tab:results}
+  \begin{tabular}{lcc}
+    \toprule
+    Method & Metric A & Metric B \\
+    \midrule
+    Baseline & 0.00 & 0.00 \\
+    Ours & 0.00 & 0.00 \\
+    \bottomrule
+  \end{tabular}
+\end{table}

--- a/skills/.curated/latex-paper/assets/snippets/theorem.tex
+++ b/skills/.curated/latex-paper/assets/snippets/theorem.tex
@@ -1,0 +1,6 @@
+\begin{theorem}[Main Result]
+Let $f$ satisfy [assumptions]. Then $f$ guarantees [property].
+\end{theorem}
+\begin{proof}
+Provide a concise proof sketch or full proof.
+\end{proof}

--- a/skills/.curated/latex-paper/assets/templates/acmart/main.tex
+++ b/skills/.curated/latex-paper/assets/templates/acmart/main.tex
@@ -1,0 +1,51 @@
+\documentclass[sigconf]{acmart}
+
+\setcopyright{none}
+\copyrightyear{2026}
+\acmYear{2026}
+\acmDOI{TBD}
+\acmConference[Conference Acronym '26]{Conference Name}{Month Day--Day, 2026}{City, Country}
+\acmBooktitle{Conference Name (Conference Acronym '26), Month Day--Day, 2026, City, Country}
+\acmPrice{15.00}
+\acmISBN{978-x-xxxx-xxxx-x/YY/MM}
+
+\usepackage{booktabs}
+\usepackage{amsmath}
+\usepackage{graphicx}
+
+\title{__TITLE__}
+\author{__AUTHOR__}
+\affiliation{
+  \institution{Institution Name}
+  \city{City}
+  \country{Country}
+}
+\email{name@example.com}
+
+\begin{document}
+
+\begin{abstract}
+Write a concise abstract that states motivation, method, and measurable impact.
+\end{abstract}
+
+\maketitle
+
+\section{Introduction}
+Explain the research question and core contribution.
+
+\section{Method}
+Describe design, implementation choices, and constraints.
+
+\section{Evaluation}
+Provide experiment design and metrics with quantitative outcomes.
+
+\section{Discussion and Limitations}
+Discuss trade-offs, failure modes, and deployment considerations.
+
+\section{Conclusion}
+Summarize findings and practical next steps.
+
+\bibliographystyle{ACM-Reference-Format}
+\bibliography{references}
+
+\end{document}

--- a/skills/.curated/latex-paper/assets/templates/acmart/references.bib
+++ b/skills/.curated/latex-paper/assets/templates/acmart/references.bib
@@ -1,0 +1,6 @@
+@book{lamport1994,
+  title     = {LaTeX: A Document Preparation System},
+  author    = {Lamport, Leslie},
+  year      = {1994},
+  publisher = {Addison-Wesley}
+}

--- a/skills/.curated/latex-paper/assets/templates/article/main.tex
+++ b/skills/.curated/latex-paper/assets/templates/article/main.tex
@@ -1,0 +1,44 @@
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{amsmath,amssymb,amsthm}
+\usepackage[numbers,sort&compress]{natbib}
+\usepackage[colorlinks=true,allcolors=blue]{hyperref}
+
+\title{__TITLE__}
+\author{__AUTHOR__}
+\date{__DATE__}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+Write a concise abstract (4--7 sentences): problem, method, key result, and impact.
+\end{abstract}
+
+\section{Introduction}
+State the problem, motivation, and contributions. Cite prior work where needed \citep{lamport1994}.
+
+\section{Method}
+Describe assumptions, model, and algorithmic details.
+
+\section{Results}
+Summarize experimental setup, metrics, and quantitative findings.
+
+\section{Discussion}
+Interpret findings, limitations, and practical implications.
+
+\section{Conclusion}
+Provide a short summary and concrete future work directions.
+
+\bibliographystyle{plainnat}
+\bibliography{references}
+
+\end{document}

--- a/skills/.curated/latex-paper/assets/templates/article/references.bib
+++ b/skills/.curated/latex-paper/assets/templates/article/references.bib
@@ -1,0 +1,6 @@
+@book{lamport1994,
+  title     = {LaTeX: A Document Preparation System},
+  author    = {Lamport, Leslie},
+  year      = {1994},
+  publisher = {Addison-Wesley}
+}

--- a/skills/.curated/latex-paper/assets/templates/ieeetran/main.tex
+++ b/skills/.curated/latex-paper/assets/templates/ieeetran/main.tex
@@ -1,0 +1,39 @@
+\documentclass[conference]{IEEEtran}
+
+\usepackage{cite}
+\usepackage{amsmath,amssymb}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage[colorlinks=true,allcolors=blue]{hyperref}
+
+\title{__TITLE__}
+
+\author{\IEEEauthorblockN{__AUTHOR__}}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+Write a concise abstract summarizing the problem, approach, and main quantitative result.
+\end{abstract}
+
+\section{Introduction}
+State problem context, gap, and contributions.
+
+\section{Related Work}
+Position this work relative to prior methods \cite{lamport1994}.
+
+\section{Method}
+Describe architecture, assumptions, and implementation details.
+
+\section{Experiments}
+Describe setup, datasets, metrics, and comparisons.
+
+\section{Conclusion}
+Summarize outcomes and future work.
+
+\bibliographystyle{IEEEtran}
+\bibliography{references}
+
+\end{document}

--- a/skills/.curated/latex-paper/assets/templates/ieeetran/references.bib
+++ b/skills/.curated/latex-paper/assets/templates/ieeetran/references.bib
@@ -1,0 +1,6 @@
+@book{lamport1994,
+  title     = {LaTeX: A Document Preparation System},
+  author    = {Lamport, Leslie},
+  year      = {1994},
+  publisher = {Addison-Wesley}
+}

--- a/skills/.curated/latex-paper/references/citations.md
+++ b/skills/.curated/latex-paper/references/citations.md
@@ -1,0 +1,32 @@
+# Citation Workflow
+
+## Default bibliography flow in this skill
+
+Templates in this skill use BibTeX-style workflows:
+
+- `article`: `plainnat` + `natbib`
+- `ieeetran`: `IEEEtran`
+- `acmart`: `ACM-Reference-Format`
+
+## Citation key conventions
+
+Use stable, readable keys:
+
+- Preferred: `lastnameYYYYshorttopic`
+- Example: `smith2024contrastive`
+
+Avoid random key changes once citations are used in manuscript text.
+
+## In-text citation patterns
+
+- Narrative form: `\\citet{key}`
+- Parenthetical form: `\\citep{key}`
+- Generic class-safe fallback: `\\cite{key}`
+
+## Common failure modes
+
+- Missing `.bib` entries for cited keys
+- Typo mismatch between `\\cite{...}` and `@...{key,...}`
+- Running LaTeX only once (cross-refs and bibliography need multiple passes)
+
+Use `scripts/fixrefs.sh` to detect missing keys before finalizing.

--- a/skills/.curated/latex-paper/references/figures_tables.md
+++ b/skills/.curated/latex-paper/references/figures_tables.md
@@ -1,0 +1,26 @@
+# Figures and Tables Guide
+
+## Figure rules
+
+- Place `\\caption` before `\\label`.
+- Use semantic labels such as `fig:ablation` or `fig:architecture`.
+- Reference every figure in text before or near its first appearance.
+- Keep axis labels and legends self-contained.
+
+## Table rules
+
+- Use `booktabs` (`\\toprule`, `\\midrule`, `\\bottomrule`) over vertical borders.
+- Keep units in headers, not data cells.
+- Include short metric direction notes when needed (`higher is better`).
+
+## Placement strategy
+
+- Use `[t]` for most floats, `[tb]` when layout is tight.
+- Avoid excessive `[h]`; it often causes unstable layout in long papers.
+- Group closely related figures/tables near the first textual reference.
+
+## Caption style
+
+- Start with what is shown.
+- End with why it matters.
+- Keep captions declarative and concise.

--- a/skills/.curated/latex-paper/references/structure.md
+++ b/skills/.curated/latex-paper/references/structure.md
@@ -1,0 +1,32 @@
+# Paper Structure Guide
+
+## Core ordering
+
+Use this baseline order unless the target venue defines a different one:
+
+1. Title
+2. Abstract
+3. Introduction
+4. Related Work (if venue expects an explicit section)
+5. Method
+6. Experiments / Evaluation
+7. Discussion and Limitations
+8. Conclusion
+9. References
+10. Appendix (optional)
+
+## Section expectations
+
+- Abstract: 4--7 sentences covering problem, approach, key result, and implication.
+- Introduction: Motivation, problem statement, gap, and contribution list.
+- Method: Assumptions, design decisions, and reproducibility-critical details.
+- Experiments: Dataset/task setup, baselines, metrics, and confidence intervals when available.
+- Discussion: Interpret results and state practical limitations clearly.
+- Conclusion: Crisp summary plus bounded future work.
+
+## Writing constraints
+
+- Prefer short paragraphs with one idea each.
+- Avoid claims without quantitative evidence in Results.
+- Keep notation consistent across sections.
+- Ensure every figure/table is referenced in the main text.

--- a/skills/.curated/latex-paper/references/template_matrix.md
+++ b/skills/.curated/latex-paper/references/template_matrix.md
@@ -1,0 +1,31 @@
+# Template Selection Matrix
+
+## Quick recommendation
+
+- Choose `article` for generic research writing, drafts, and preprints.
+- Choose `ieeetran` for IEEE-targeted conference/journal submissions.
+- Choose `acmart` for ACM-targeted submissions.
+
+## Comparison
+
+| Template | Best for | Strengths | Trade-offs |
+| --- | --- | --- | --- |
+| `article` | Early drafts, arXiv-like manuscripts | Minimal dependencies, easy customization | Not venue-branded |
+| `ieeetran` | IEEE venues | Venue-aligned styling and bibliography | Tighter formatting constraints |
+| `acmart` | ACM venues | Official ACM metadata and bibliography defaults | More metadata fields required |
+
+## Scaffold commands
+
+```bash
+scripts/new_paper.sh /path/to/paper --template article
+scripts/new_paper.sh /path/to/paper --template ieeetran
+scripts/new_paper.sh /path/to/paper --template acmart
+```
+
+## Migration guidance
+
+Switch templates only when venue requirements are finalized. Template migration often requires:
+
+- package compatibility checks
+- title/author block rewrites
+- bibliography style updates

--- a/skills/.curated/latex-paper/scripts/compile.sh
+++ b/skills/.curated/latex-paper/scripts/compile.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") <project-dir> [--main main.tex] [--engine pdflatex|xelatex|lualatex]
+
+Examples:
+  $(basename "$0") ./paper
+  $(basename "$0") ./paper --main manuscript.tex --engine xelatex
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+project_dir="$1"
+shift
+
+main_tex="main.tex"
+engine="pdflatex"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --main)
+      main_tex="${2:-}"
+      shift 2
+      ;;
+    --engine)
+      engine="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$project_dir" ]]; then
+  echo "Project directory not found: $project_dir" >&2
+  exit 1
+fi
+
+if [[ ! -f "$project_dir/$main_tex" ]]; then
+  echo "Main TeX file not found: $project_dir/$main_tex" >&2
+  exit 1
+fi
+
+if ! command -v latexmk >/dev/null 2>&1; then
+  echo "latexmk is required but not installed." >&2
+  echo "Install TeX Live or MacTeX and ensure latexmk is in PATH." >&2
+  exit 1
+fi
+
+engine_flag="-pdf"
+case "$engine" in
+  pdflatex)
+    engine_flag="-pdf"
+    ;;
+  xelatex)
+    engine_flag="-xelatex"
+    ;;
+  lualatex)
+    engine_flag="-lualatex"
+    ;;
+  *)
+    echo "Unsupported engine: $engine" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$project_dir/build"
+log_file="$project_dir/build/compile.log"
+
+set +e
+(
+  cd "$project_dir"
+  latexmk "$engine_flag" -interaction=nonstopmode -file-line-error -halt-on-error -outdir=build "$main_tex"
+) 2>&1 | tee "$log_file"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ $status -ne 0 ]]; then
+  echo
+  echo "Compile failed. Key diagnostics:"
+  grep -E '^!|^[^:]+:[0-9]+:|LaTeX Warning:|Package .* Warning:' "$log_file" | head -n 40 || true
+  echo
+  echo "Full log: $log_file"
+  exit "$status"
+fi
+
+pdf_name="${main_tex%.tex}.pdf"
+echo "Compile succeeded: $project_dir/build/$pdf_name"
+echo "Log file: $log_file"

--- a/skills/.curated/latex-paper/scripts/fixrefs.sh
+++ b/skills/.curated/latex-paper/scripts/fixrefs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") <project-dir>
+
+Checks:
+  - unresolved label references (\\ref, \\eqref, \\autoref, \\cref, \\Cref, \\pageref)
+  - missing bibliography keys for \\cite* commands
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+project_dir="$1"
+if [[ ! -d "$project_dir" ]]; then
+  echo "Project directory not found: $project_dir" >&2
+  exit 1
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required." >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+labels_file="$tmp_dir/labels.txt"
+ref_targets_file="$tmp_dir/ref_targets.txt"
+missing_labels_file="$tmp_dir/missing_labels.txt"
+
+cite_targets_file="$tmp_dir/cite_targets.txt"
+bib_keys_file="$tmp_dir/bib_keys.txt"
+missing_cites_file="$tmp_dir/missing_cites.txt"
+
+rg -No --glob '*.tex' '\\label\{[^}]+\}' "$project_dir" \
+  | sed -E 's/.*\\label\{([^}]+)\}.*/\1/' \
+  | sort -u > "$labels_file" || true
+
+rg -No --glob '*.tex' '\\(ref|eqref|autoref|cref|Cref|pageref)\{[^}]+\}' "$project_dir" \
+  | sed -E 's/.*\{([^}]+)\}.*/\1/' \
+  | sort -u > "$ref_targets_file" || true
+
+comm -23 "$ref_targets_file" "$labels_file" > "$missing_labels_file" || true
+
+rg -No --glob '*.tex' '\\cite[a-zA-Z*]*\{[^}]+\}' "$project_dir" \
+  | sed -E 's/.*\{([^}]+)\}.*/\1/' \
+  | tr ',' '\n' \
+  | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+  | rg -v '^$' \
+  | sort -u > "$cite_targets_file" || true
+
+: > "$bib_keys_file"
+while IFS= read -r bib_file; do
+  rg -No '^@[a-zA-Z]+\{[^,]+' "$bib_file" \
+    | sed -E 's/^@[a-zA-Z]+\{([^,]+).*/\1/' \
+    | sort -u >> "$bib_keys_file" || true
+done < <(rg --files "$project_dir" -g '*.bib' || true)
+sort -u -o "$bib_keys_file" "$bib_keys_file"
+
+comm -23 "$cite_targets_file" "$bib_keys_file" > "$missing_cites_file" || true
+
+status=0
+
+if [[ -s "$missing_labels_file" ]]; then
+  echo "Missing label definitions for these references:"
+  cat "$missing_labels_file"
+  status=1
+fi
+
+if [[ -s "$missing_cites_file" ]]; then
+  echo "Missing bibliography entries for these citation keys:"
+  cat "$missing_cites_file"
+  status=1
+fi
+
+if [[ $status -eq 0 ]]; then
+  echo "No missing label/citation keys found."
+fi
+
+exit "$status"

--- a/skills/.curated/latex-paper/scripts/lint.sh
+++ b/skills/.curated/latex-paper/scripts/lint.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") <project-dir> [--main main.tex]
+
+Examples:
+  $(basename "$0") ./paper
+  $(basename "$0") ./paper --main manuscript.tex
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+project_dir="$1"
+shift
+main_tex="main.tex"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --main)
+      main_tex="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$project_dir" ]]; then
+  echo "Project directory not found: $project_dir" >&2
+  exit 1
+fi
+
+if [[ ! -f "$project_dir/$main_tex" ]]; then
+  echo "Main TeX file not found: $project_dir/$main_tex" >&2
+  exit 1
+fi
+
+status=0
+mkdir -p "$project_dir/build"
+
+if command -v chktex >/dev/null 2>&1; then
+  echo "Running chktex..."
+  set +e
+  chktex -q -f'%f:%l:%c:%k:%n:%m\n' "$project_dir/$main_tex" | tee "$project_dir/build/chktex.log"
+  chktex_status=${PIPESTATUS[0]}
+  set -e
+  if [[ $chktex_status -ne 0 ]]; then
+    status=1
+  fi
+else
+  echo "chktex not found. Skipping chktex pass."
+fi
+
+echo "Checking duplicate labels..."
+dup_labels="$(
+  rg -No -h --glob '*.tex' '\\label\\{[^}]+\\}' "$project_dir" 2>/dev/null \
+    | sed -E 's/^\\\\label[{]([^}]+)[}]$/\\1/' \
+    | sort \
+    | uniq -d \
+    || true
+)"
+if [[ -n "$dup_labels" ]]; then
+  echo "Duplicate labels detected:"
+  echo "$dup_labels"
+  status=1
+fi
+
+echo "Checking TODO/FIXME markers..."
+if rg -n --glob '*.tex' 'TODO|FIXME' "$project_dir" >/dev/null 2>&1; then
+  rg -n --glob '*.tex' 'TODO|FIXME' "$project_dir"
+fi
+
+if [[ $status -eq 0 ]]; then
+  echo "Lint checks passed."
+else
+  echo "Lint checks found issues."
+fi
+
+exit "$status"

--- a/skills/.curated/latex-paper/scripts/new_paper.sh
+++ b/skills/.curated/latex-paper/scripts/new_paper.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") <output-dir> [--template article|ieeetran|acmart] [--title TITLE] [--author AUTHOR] [--date DATE]
+
+Examples:
+  $(basename "$0") /tmp/my-paper
+  $(basename "$0") /tmp/my-paper --template ieeetran --title "My Paper" --author "A. Researcher"
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+output_dir="$1"
+shift
+
+template="article"
+title="Untitled Paper"
+author="Anonymous"
+date_value="\\today"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --template)
+      template="${2:-}"
+      shift 2
+      ;;
+    --title)
+      title="${2:-}"
+      shift 2
+      ;;
+    --author)
+      author="${2:-}"
+      shift 2
+      ;;
+    --date)
+      date_value="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+case "$template" in
+  article|ieeetran|acmart)
+    ;;
+  *)
+    echo "Unsupported template: $template" >&2
+    exit 1
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_dir="$(cd "${script_dir}/.." && pwd)"
+template_dir="${skill_dir}/assets/templates/${template}"
+
+if [[ ! -d "$template_dir" ]]; then
+  echo "Template directory not found: $template_dir" >&2
+  exit 1
+fi
+
+if [[ -e "$output_dir" && -n "$(ls -A "$output_dir" 2>/dev/null || true)" ]]; then
+  echo "Output directory exists and is not empty: $output_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$output_dir"
+cp -R "$template_dir/." "$output_dir/"
+
+main_tex="${output_dir}/main.tex"
+if [[ -f "$main_tex" ]]; then
+  escape_sed() {
+    printf '%s' "$1" | sed -e 's/[\\/&]/\\&/g'
+  }
+
+  title_escaped="$(escape_sed "$title")"
+  author_escaped="$(escape_sed "$author")"
+  date_escaped="$(escape_sed "$date_value")"
+
+  sed -i \
+    -e "s/__TITLE__/${title_escaped}/g" \
+    -e "s/__AUTHOR__/${author_escaped}/g" \
+    -e "s/__DATE__/${date_escaped}/g" \
+    "$main_tex"
+fi
+
+echo "Created LaTeX project: $output_dir"
+echo "Template: $template"

--- a/skills/.curated/latex-paper/scripts/tex_to_pdf.sh
+++ b/skills/.curated/latex-paper/scripts/tex_to_pdf.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $(basename "$0") <file.tex> [--engine pdflatex|xelatex|lualatex] [--output-dir DIR] [--clean]
+
+Examples:
+  $(basename "$0") ./paper/main.tex
+  $(basename "$0") ./paper/main.tex --engine xelatex --output-dir ./paper/dist
+USAGE
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+input_tex="$1"
+shift
+
+engine="pdflatex"
+output_dir=""
+clean_aux="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --engine)
+      engine="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --clean)
+      clean_aux="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "$input_tex" ]]; then
+  echo "TeX file not found: $input_tex" >&2
+  exit 1
+fi
+
+if [[ "${input_tex##*.}" != "tex" ]]; then
+  echo "Input must be a .tex file: $input_tex" >&2
+  exit 1
+fi
+
+if ! command -v latexmk >/dev/null 2>&1; then
+  echo "latexmk is required but not installed." >&2
+  echo "Install TeX Live or MacTeX and ensure latexmk is in PATH." >&2
+  exit 1
+fi
+
+engine_flag="-pdf"
+case "$engine" in
+  pdflatex)
+    engine_flag="-pdf"
+    ;;
+  xelatex)
+    engine_flag="-xelatex"
+    ;;
+  lualatex)
+    engine_flag="-lualatex"
+    ;;
+  *)
+    echo "Unsupported engine: $engine" >&2
+    exit 1
+    ;;
+esac
+
+input_abs="$(cd "$(dirname "$input_tex")" && pwd)/$(basename "$input_tex")"
+project_dir="$(dirname "$input_abs")"
+main_tex="$(basename "$input_abs")"
+
+if [[ -z "$output_dir" ]]; then
+  output_dir="$project_dir/build"
+fi
+mkdir -p "$output_dir"
+output_abs="$(cd "$output_dir" && pwd)"
+
+log_file="$output_abs/tex_to_pdf.log"
+
+set +e
+(
+  cd "$project_dir"
+  latexmk "$engine_flag" -interaction=nonstopmode -file-line-error -halt-on-error -outdir="$output_abs" "$main_tex"
+) 2>&1 | tee "$log_file"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ $status -ne 0 ]]; then
+  echo
+  echo "Conversion failed. Key diagnostics:"
+  grep -E '^!|^[^:]+:[0-9]+:|LaTeX Warning:|Package .* Warning:' "$log_file" | head -n 40 || true
+  echo
+  echo "Full log: $log_file"
+  exit "$status"
+fi
+
+if [[ "$clean_aux" == "true" ]]; then
+  (
+    cd "$project_dir"
+    latexmk -c -outdir="$output_abs" "$main_tex" >/dev/null 2>&1 || true
+  )
+fi
+
+pdf_name="${main_tex%.tex}.pdf"
+pdf_path="$output_abs/$pdf_name"
+
+if [[ ! -f "$pdf_path" ]]; then
+  echo "Conversion reported success, but PDF not found: $pdf_path" >&2
+  exit 1
+fi
+
+echo "PDF generated: $pdf_path"
+echo "Log file: $log_file"


### PR DESCRIPTION
## Summary
- add a new curated skill: `skills/.curated/latex-paper`
- include LaTeX paper scaffolding templates (`article`, `ieeetran`, `acmart`)
- include reusable scripts for scaffold, compile, lint, ref/citation checks, and tex-to-pdf conversion
- include references and snippet assets for research writing workflows

## Notes
- skill frontmatter and metadata validated with quick_validate
- scripts pass shell syntax checks
- no external runtime deps beyond common LaTeX tooling (`latexmk`, optional `chktex`)