### PR TITLE
feat: add gh-manage-issues skill for GitHub issue management

### DIFF
--- a/skills/.curated/gh-manage-issues/LICENSE.txt
+++ b/skills/.curated/gh-manage-issues/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/gh-manage-issues/SKILL.md
+++ b/skills/.curated/gh-manage-issues/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: "gh-manage-issues"
+description: "Use when a user asks to create, list, update, close, or manage GitHub issues; use `gh` to interact with issues, add labels, assign users, and manage issue workflows."
+---
+
+# GitHub Issues Management
+
+## Overview
+
+Use GitHub CLI (`gh`) to manage issues - create, list, update, close, add labels, assign users, and more. This skill provides a comprehensive workflow for GitHub issue management.
+
+Prereq: authenticate with the standard GitHub CLI once (run `gh auth login`), then confirm with `gh auth status` (repo scope required).
+
+## Inputs
+
+- `repo`: path to the repository (default `.`)
+- `action`: create, list, view, update, close, add-label, remove-label, assign, unassign
+- `issue_number`: issue number (for view, update, close, label operations)
+- `title`: issue title (for create)
+- `body`: issue body/description (for create)
+- `labels`: comma-separated labels (for create or add-label)
+- `assignee`: username to assign (for assign)
+
+## Quick Start
+
+### List issues
+```bash
+gh issue list --repo "owner/repo"
+gh issue list --repo "owner/repo" --state all --limit 20
+```
+
+### Create issue
+```bash
+gh issue create --repo "owner/repo" --title "Bug: Login fails" --body "Description here"
+gh issue create --repo "owner/repo" --title "Feature Request" --label "enhancement"
+```
+
+### View issue
+```bash
+gh issue view 123 --repo "owner/repo"
+gh issue view 123 --repo "owner/repo" --comments
+```
+
+### Update issue
+```bash
+gh issue edit 123 --repo "owner/repo" --title "New Title"
+gh issue edit 123 --repo "owner/repo" --add-label "bug"
+gh issue edit 123 --repo "owner/repo" --add-assignee "username"
+```
+
+### Close issue
+```bash
+gh issue close 123 --repo "owner/repo"
+```
+
+## Workflow
+
+1. Verify gh authentication
+   - Run `gh auth status` in the repo
+   - If unauthenticated, ask user to run `gh auth login`
+
+2. Determine the action
+   - Create: Create a new issue
+   - List: List issues with optional filters
+   - View: View issue details and comments
+   - Update: Edit issue title, body, labels
+   - Add-label/remove-label: Manage labels
+   - Assign/unassign: Manage assignees
+   - Close: Close an issue
+
+3. Execute the action
+   - Use appropriate `gh issue` command
+   - Use `--json` flag for machine-friendly output when needed
+
+4. Report results
+   - Show issue URL for created/updated issues
+   - List relevant issues with their numbers and titles
+
+## Examples
+
+### Create a bug report with labels
+```bash
+gh issue create --title "Bug: Cannot upload files" --body "Steps to reproduce..." --label "bug,high-priority"
+```
+
+### List all open issues assigned to you
+```bash
+gh issue list --assignee "@me" --state open
+```
+
+### Add a label to multiple issues
+```bash
+# First list issues, then add label
+gh issue list --label "needs-triage" --json number | jq -r '.[].number' | xargs -I {} gh issue edit {} --add-label "in-progress"
+```
+
+### Create issue from template
+```bash
+gh issue create --title "Issue Title" --body-file /path/to/template.md
+```
+
+## Tips
+
+- Use `--jq` flag to filter JSON output: `gh issue list --json title,state,labels`
+- Use `--search` flag for complex queries: `gh issue list --search "is:issue is:open label:bug"`
+- Use `gh issue develop` to create a branch from an issue
+- Use `gh issue comment` to add comments to issues

--- a/skills/.curated/gh-manage-issues/scripts/issue_manager.py
+++ b/skills/.curated/gh-manage-issues/scripts/issue_manager.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""GitHub Issues Manager - Bulk operations helper."""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess:
+    """Run gh command and return result."""
+    result = subprocess.run(["gh"] + args, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}", file=sys.stderr)
+        sys.exit(result.returncode)
+    return result
+
+
+def list_issues(repo: str, state: str = "open", labels: str = None, assignee: str = None):
+    """List issues with optional filters."""
+    args = ["issue", "list", "--repo", repo, "--state", state, "--json", "number,title,labels,assignees,state"]
+    if labels:
+        args.extend(["--label", labels])
+    if assignee:
+        args.extend(["--assignee", assignee])
+    
+    result = run_gh(args)
+    issues = json.loads(result.stdout)
+    
+    if not issues:
+        print("No issues found")
+        return
+    
+    for issue in issues:
+        labels_str = ", ".join([l["name"] for l in issue.get("labels", [])]) or "no labels"
+        assignees_str = ", ".join(issue.get("assignees", [])) or "unassigned"
+        print(f"#{issue['number']}: {issue['title']}")
+        print(f"   Labels: {labels_str} | Assignees: {assignees_str} | State: {issue['state']}")
+        print()
+
+
+def create_issue(repo: str, title: str, body: str = None, labels: str = None, assignee: str = None):
+    """Create a new issue."""
+    args = ["issue", "create", "--repo", repo, "--title", title]
+    
+    if body:
+        args.extend(["--body", body])
+    if labels:
+        for label in labels.split(","):
+            args.extend(["--label", label.strip()])
+    if assignee:
+        args.extend(["--assignee", assignee])
+    
+    result = run_gh(args)
+    print(f"Issue created: {result.stdout.strip()}")
+
+
+def add_labels(repo: str, issue_num: int, labels: str):
+    """Add labels to an issue."""
+    args = ["issue", "edit", f"{repo}", "--issue-number", str(issue_num), "--add-label"]
+    
+    for label in labels.split(","):
+        args.append(label.strip())
+    
+    run_gh(args)
+    print(f"Labels added to issue #{issue_num}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GitHub Issues Manager")
+    parser.add_argument("--repo", required=True, help="Repository (owner/repo)")
+    parser.add_argument("--action", choices=["list", "create", "add-labels"], required=True)
+    parser.add_argument("--state", default="open", help="Issue state (open/closed/all)")
+    parser.add_argument("--labels", help="Filter by labels (comma-separated)")
+    parser.add_argument("--assignee", help="Filter by assignee")
+    parser.add_argument("--title", help="Issue title (for create)")
+    parser.add_argument("--body", help="Issue body (for create)")
+    parser.add_argument("--issue", type=int, help="Issue number (for add-labels)")
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    
+    args = parser.parse_args()
+    
+    if args.action == "list":
+        list_issues(args.repo, args.state, args.labels, args.assignee)
+    elif args.action == "create":
+        if not args.title:
+            print("Error: --title required for create action", file=sys.stderr)
+            sys.exit(1)
+        create_issue(args.repo, args.title, args.body, args.labels, args.assignee)
+    elif args.action == "add-labels":
+        if not args.issue or not args.labels:
+            print("Error: --issue and --labels required for add-labels action", file=sys.stderr)
+            sys.exit(1)
+        add_labels(args.repo, args.issue, args.labels)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add a new skill for GitHub issue management

## Changes
- Added new skill: `gh-manage-issues`
- Includes SKILL.md with comprehensive documentation  
- Includes Python helper script for bulk operations

## Features
- Create, list, view, update, close issues
- Add/remove labels
- Assign/unassign users
- Bulk operations support