### PR TITLE
Add apex-spec to .experimental catalog

### DIFF
--- a/skills/.experimental/apex-spec/LICENSE.txt
+++ b/skills/.experimental/apex-spec/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Apex Spec System Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.experimental/apex-spec/README.md
+++ b/skills/.experimental/apex-spec/README.md
@@ -1,0 +1,67 @@
+# Apex Spec System
+
+A specification-driven workflow system for AI-assisted development.
+
+Break large projects into manageable, well-scoped implementation sessions
+that fit within AI context windows and human attention spans.
+
+**Philosophy**: 1 session = 1 spec = 2-4 hours (12-25 tasks)
+
+## What It Does
+
+Provides a 22-command workflow that guides you from project initialization
+through phased implementation:
+
+1. **Initialize** - Set up spec system, create PRD, build phase structure
+2. **Implement** - Plan sessions, implement tasks, validate completeness
+3. **Transition** - Audit quality, set up CI/CD, carry forward lessons
+
+## Requirements
+
+- bash, git, jq (standard CLI tools)
+
+## Installation
+
+Install from the catalog:
+
+```
+$skill-installer install the apex-spec skill from the .experimental folder
+```
+
+Or install directly:
+
+```bash
+git clone https://github.com/aiwithapex/apex-spec-system-open.git \
+  ~/.agents/skills/apex-spec
+```
+
+## Usage
+
+```bash
+# Initialize spec system in your project
+$apex-spec initspec
+
+# Create PRD from requirements
+$apex-spec createprd
+
+# Build phase structure
+$apex-spec phasebuild
+
+# Plan and implement sessions
+$apex-spec plansession
+$apex-spec implement
+$apex-spec validate
+$apex-spec updateprd
+```
+
+The skill also activates implicitly when working in a project with a
+`.spec_system/` directory.
+
+## Source Repository
+
+Full documentation, contributing guidelines, and development resources:
+https://github.com/aiwithapex/apex-spec-system-open
+
+## License
+
+[MIT](LICENSE.txt)

--- a/skills/.experimental/apex-spec/SKILL.md
+++ b/skills/.experimental/apex-spec/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: apex-spec
+description: >
+  Specification-driven workflow system for AI-assisted development.
+  Use when the user mentions "spec system", "session workflow", "create PRD",
+  "UX PRD", "plan session", "implement session", "validate session",
+  "phase build", "session scope", "task checklist", "initspec", "plansession",
+  "audit", "pipeline", "infra", "carryforward", "documents", "copush",
+  "sculpt-ui", "docker build", "upstream changes", "quick implement",
+  "quick frontend", "quick backend", "pull upstream",
+  or when working in a project containing a .spec_system/ directory.
+  Philosophy: 1 session = 1 spec = 2-4 hours (12-25 tasks).
+version: 2.0.9-codex
+---
+
+# Apex Spec Workflow
+
+A specification-driven workflow system for AI-assisted development that breaks
+large projects into manageable 2-4 hour sessions with 12-25 tasks each.
+
+## Core Philosophy
+
+**1 session = 1 spec = 2-4 hours (12-25 tasks)**
+
+Break large projects into manageable, well-scoped implementation sessions that
+fit within AI context windows and human attention spans.
+
+A collection of sessions is a phase. A collection of phases is a mature/late
+technical PRD.
+
+## Session Scope Rules
+
+### Hard Limits (Reject if Exceeded)
+
+| Limit | Value |
+|-------|-------|
+| Maximum tasks | 25 |
+| Maximum duration | 4 hours |
+| Objectives | Single clear objective |
+
+### Ideal Targets
+
+| Target | Value |
+|--------|-------|
+| Task count | 12-25 (sweet spot: 20) |
+| Duration | 2-3 hours |
+| Focus | Stable/late MVP |
+
+## The 13-Command Workflow
+
+The workflow has **3 distinct stages**:
+
+### Stage 1: INITIALIZATION (One-Time Setup)
+
+```
+initspec           ->  Set up spec system in project
+      |
+      v
+createprd          ->  Generate PRD from requirements doc (optional)
+  OR                   OR
+[User Action]      ->  Manually populate PRD with requirements
+      |
+      v
+createuxprd        ->  Generate UX PRD from design docs (optional)
+  OR                   OR
+[User Action]      ->  Manually populate UX PRD with requirements
+      |
+      v
+phasebuild         ->  Create first phase structure (session stubs)
+```
+
+### Stage 2: SESSIONS WORKFLOW (Repeat Until Phase Complete)
+
+```
+plansession    ->  Analyze project, create spec + task checklist
+      |
+      v
+implement      ->  AI-led task-by-task implementation
+      |
+      v
+validate       ->  Verify session completeness
+      |
+      v
+updateprd      ->  Sync PRD, mark session complete
+      |
+      +-------------> Loop back to plansession
+                      until ALL phase sessions complete
+```
+
+### Stage 3: PHASE TRANSITION (After All Previous Phase Sessions Are Complete)
+
+```
+audit              ->  Local dev tooling (formatter, linter, types, tests)
+      |
+      v
+pipeline           ->  CI/CD workflows (quality, build, security)
+      |
+      v
+infra              ->  Production infrastructure (health, security, deploy)
+      |
+      v
+carryforward       ->  Capture lessons learned (optional but recommended)
+      |
+      v
+documents          ->  Audit and update documentation
+      |
+      v
+[User Action]      ->  Manual testing and LLM audit (HIGHLY recommended)
+      |
+      v
+phasebuild         ->  Create next phase structure
+      |
+      v
+                   ->  Return to Stage 2 for new phase
+```
+
+### Utility Commands (Safe at Any Time)
+
+These 9 commands run outside the session workflow:
+
+| Command | Purpose |
+|---------|---------|
+| copush | Pull, version-bump, commit all changes, push to origin |
+| sculpt-ui | Guide AI-led creation of distinctive frontend interfaces |
+| dockbuild | Quick Docker Compose build and start |
+| dockcleanbuild | Clean Docker environment and rebuild from scratch |
+| up2imp | Audit upstream changes and curate implementation list |
+| qimpl | Context-aware autonomous implementation session |
+| qfrontdev | Autonomous frontend implementation session |
+| qbackenddev | Autonomous backend/infrastructure development session |
+| pullndoc | Git pull upstream repo and document imported changes |
+
+---
+
+## Command Dispatch
+
+When the user requests a specific workflow step, read the corresponding
+reference document from this skill's references/ directory and follow
+its instructions exactly. Match the user's intent to the closest entry
+in the table below.
+
+### Stage 1: Initialization Commands
+
+| User Keywords | Reference File | Description |
+|---------------|----------------|-------------|
+| "init", "initialize", "setup spec" | references/initspec.md | Set up spec system in project |
+| "create PRD", "PRD", "requirements" | references/createprd.md | Generate master PRD from requirements |
+| "UX PRD", "design PRD" | references/createuxprd.md | Generate UX PRD from design docs |
+| "phase", "new phase", "phase build" | references/phasebuild.md | Create phase structure with session stubs |
+
+### Stage 2: Session Workflow Commands
+
+| User Keywords | Reference File | Description |
+|---------------|----------------|-------------|
+| "plan session", "next session" | references/plansession.md | Analyze project, create spec and task checklist |
+| "implement", "execute tasks" | references/implement.md | AI-led task-by-task implementation |
+| "validate", "verify session" | references/validate.md | Verify session completeness |
+| "update PRD", "mark complete" | references/updateprd.md | Sync PRD, mark session complete |
+
+### Stage 3: Phase Transition Commands
+
+| User Keywords | Reference File | Description |
+|---------------|----------------|-------------|
+| "audit", "dev tools", "linting" | references/audit.md | Local dev tooling setup |
+| "pipeline", "CI/CD", "workflows" | references/pipeline.md | CI/CD workflow configuration |
+| "infra", "infrastructure" | references/infra.md | Production infrastructure setup |
+| "carry forward", "lessons learned" | references/carryforward.md | Capture lessons and security posture |
+| "documents", "documentation" | references/documents.md | Audit and update documentation |
+
+### Utility Commands
+
+| User Keywords | Reference File | Description |
+|---------------|----------------|-------------|
+| "copush", "push", "bump version" | references/copush.md | Pull, bump, commit, push |
+| "sculpt", "UI design", "frontend design" | references/sculpt-ui.md | Distinctive frontend interface design |
+| "docker build" | references/dockbuild.md | Docker Compose build and start |
+| "docker clean", "docker rebuild" | references/dockcleanbuild.md | Clean Docker rebuild |
+| "upstream", "upstream changes" | references/up2imp.md | Audit upstream changes |
+| "quick implement" | references/qimpl.md | Context-aware autonomous implementation |
+| "quick frontend" | references/qfrontdev.md | Autonomous frontend development |
+| "quick backend" | references/qbackenddev.md | Autonomous backend development |
+| "pull upstream", "pull and document" | references/pullndoc.md | Pull and document upstream changes |
+
+**Total**: 22 commands mapped to 22 reference files.
+
+---
+
+## Directory Structure
+
+Projects using this system follow this layout:
+
+```
+project/
+|-- .spec_system/               # All spec system files
+|   |-- state.json              # Project state tracking
+|   |-- CONSIDERATIONS.md       # Institutional memory (lessons learned)
+|   |-- SECURITY-COMPLIANCE.md  # Security posture and compliance
+|   |-- CONVENTIONS.md          # Project coding standards
+|   |-- PRD/                    # Product requirements
+|   |   |-- PRD.md              # Master PRD
+|   |   \-- phase_NN/           # Phase definitions
+|   |-- specs/                  # Implementation specs
+|   |   \-- phaseNN-sessionNN-name/
+|   |       |-- spec.md
+|   |       |-- tasks.md
+|   |       |-- implementation-notes.md
+|   |       |-- security-compliance.md
+|   |       \-- validation.md
+|   |-- scripts/                # Bash automation (copied during init)
+|   \-- archive/                # Completed work
+\-- (project source files)
+```
+
+### Monorepo Support
+
+The system auto-detects monorepo structures. Single `.spec_system/` at the
+repo root. Sessions reference their target package in metadata (spec.md
+header and state.json), not in directory names. Sessions interleave across
+packages within a phase.
+
+---
+
+## Scripts
+
+Project analysis scripts provide deterministic state facts and environment
+verification. Scripts are copied to `.spec_system/scripts/` during
+initialization (via the initspec workflow step).
+
+### Script Locations
+
+Scripts can be found in two places. **Local scripts take precedence**:
+
+1. **Local** (per-project): `.spec_system/scripts/` -- copied during init
+2. **Skill directory**: `scripts/` -- bundled with this skill
+
+### Available Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `analyze-project.sh` | Deterministic project state | `bash .spec_system/scripts/analyze-project.sh --json` |
+| `check-prereqs.sh` | Environment and tool verification | `bash .spec_system/scripts/check-prereqs.sh --json --env` |
+| `common.sh` | Shared functions (sourced by other scripts) | Sourced automatically |
+
+### Local-First Resolution Pattern
+
+Commands that need scripts should check for local copies first:
+
+```bash
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+---
+
+## Task Design
+
+### Task Format
+
+```
+- [ ] TNNN [SNNMM] [P] Action verb + what + where (`path/to/file`)
+```
+
+Components:
+- `TNNN`: Sequential task ID (T001, T002, ...)
+- `[SNNMM]`: Session reference (S0103 = Phase 01, Session 03)
+- `[P]`: Optional parallelization marker
+- Description: Action verb + clear description
+- Path: File being created or modified
+
+### ASCII Encoding (Non-Negotiable)
+
+All files must use ASCII-only characters (code points 0-127):
+- NO Unicode characters, emoji, smart quotes, or em-dashes
+- Use straight quotes (" ') and hyphens (-) only
+- Unix LF line endings (no CRLF)
+
+---
+
+## Quick Reference
+
+| Command | Purpose | Input | Output |
+|---------|---------|-------|--------|
+| initspec | Initialize spec system | Project info | .spec_system/ structure |
+| createprd | Generate master PRD | Requirements doc | PRD/PRD.md |
+| createuxprd | Generate UX PRD | Design docs | PRD/PRD_UX.md |
+| plansession | Analyze, spec, task list | state.json, PRD | spec.md + tasks.md |
+| implement | Code implementation | spec.md, tasks.md | implementation-notes.md |
+| validate | Verify completeness | All session files | validation.md |
+| updateprd | Mark complete | validation.md | Updated state.json |
+| audit | Local dev tooling | CONVENTIONS.md | Updated tools |
+| pipeline | CI/CD workflows | CONVENTIONS.md | Workflow files |
+| infra | Production infra | CONVENTIONS.md | Config files |
+| documents | Audit/update docs | state.json, PRD | Updated docs |
+| carryforward | Capture lessons | Phase artifacts | CONSIDERATIONS.md |
+| phasebuild | Create new phase | PRD | PRD/phase_NN/ |

--- a/skills/.experimental/apex-spec/agents/openai.yaml
+++ b/skills/.experimental/apex-spec/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Apex Spec System"
+  short_description: "Specification-driven AI development workflow"
+  brand_color: "#2563EB"
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/.experimental/apex-spec/references/audit.md
+++ b/skills/.experimental/apex-spec/references/audit.md
@@ -1,0 +1,317 @@
+# audit
+
+Add and validate local dev tooling one bundle at a time.
+
+## Rules
+
+1. **One bundle per run** - add one, validate all, fix all
+2. **Never break syntax** - revert after 2 failed fix attempts
+3. **Respect known-issues.md** - don't fix intentional exceptions
+4. **Update CONVENTIONS.md** - record what was added in Local Dev Tools table
+5. **Continue on failure** - one tool failing doesn't stop the audit
+6. **Monorepo aware** - run per package, report per package
+
+### No Deferral Policy
+
+- NEVER mark a task as "pending", "requires X", or "blocked" if the blocker is something YOU can resolve
+- If a dependency needs installing, INSTALL IT
+- If a directory needs creating, CREATE IT
+- If a config file needs generating, GENERATE IT
+- "The environment isn't set up" is NOT a blocker -- setting it up IS the task
+- The ONLY valid blocker is something that requires USER input or credentials you don't have
+- If you skip a task that was executable, that is a **critical failure**
+
+## Master List (7 Bundles)
+
+Industry standard order (fast to slow, format before validate):
+
+| Priority | Bundle | Contents |
+|----------|--------|----------|
+| 1 | **Formatting** | Formatter (Prettier, Biome, Black, Ruff format) |
+| 2 | **Linting** | Linter (ESLint, Biome, Ruff, Clippy) |
+| 3 | **Type Safety** | Type checker (TypeScript, mypy, Pyright) |
+| 4 | **Testing** | Test runner + coverage (Jest, Vitest, pytest, pytest-cov) |
+| 5 | **Observability** | Structured logger + error capture (structlog, pino, tracing, slog) |
+| 6 | **Git Hooks** | Pre-commit hooks (husky, pre-commit, lefthook) |
+| 7 | **Database** | Migration framework + seed script + test DB config |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | false | Preview what would happen without changes |
+| `--skip-install` | false | Don't install missing tools |
+| `--verbose` | false | Show full tool output |
+
+## Flow
+
+### Step 1: DETECT
+
+1. Check for `.spec_system/CONVENTIONS.md`
+   - If missing: Run initspec yourself to create it. Only ask the user if initspec requires user input you don't have.
+   - Read Stack section for languages/runtimes
+   - Read Local Dev Tools table for configured tools
+   - Read Workspace Structure table (if present) for per-package tool status
+
+2. Read `.spec_system/state.json` for monorepo context:
+   - `monorepo` field: `true` / `false` / `null`
+   - `packages` array (when `monorepo: true`): each entry has `name`, `path`, `type`, `stack`
+
+3. Check for `.spec_system/audit/known-issues.md`
+   - If found, load ignore patterns
+   - Note: "Known issues loaded (N paths, N rules, N tests)"
+
+4. Check git status
+   - If dirty: Warn "Uncommitted changes exist. Fixes will mix with existing changes."
+
+5. If `--dry-run`: Skip to Dry Run Output
+
+### Step 1a: Enumerate Packages (Monorepo Only)
+
+**Skip this step if** `monorepo` is not `true` in state.json.
+
+When `monorepo: true`, build a per-package tool matrix:
+
+1. Read the `packages` array from state.json
+2. For each package, note its `stack` field (determines which tools apply)
+3. Group packages by stack (packages sharing a stack share tool configs)
+4. Determine installation strategy per tool:
+   - **Shared at root**: When all packages use the same stack, or the tool is stack-agnostic (e.g., git hooks)
+   - **Per-package**: When packages have different stacks (e.g., Python API + TypeScript frontend)
+
+Example package matrix:
+```
+Packages detected (monorepo: true):
+| Package | Path | Stack | Formatter | Linter | Types |
+|---------|------|-------|-----------|--------|-------|
+| web | apps/web | TypeScript | Biome | Biome | tsc |
+| api | apps/api | Python | Ruff | Ruff | mypy |
+| shared | packages/shared | TypeScript | Biome | Biome | tsc |
+```
+
+### Step 2: COMPARE
+
+Compare Local Dev Tools table against 6-bundle master list:
+- For each bundle, check if Tool column has a value or shows "not configured" / "-"
+- Build list of missing bundles in priority order
+
+If all bundles configured: "All recommended local dev tools configured. Jumping to Step 5."
+
+### Step 3: SELECT
+
+Pick the highest-priority missing bundle from Step 2.
+
+Output: "Selected: [Bundle Name] - not yet configured"
+
+### Step 4: IMPLEMENT
+
+Install and configure the single selected bundle missing.
+
+**Detection by language** (from CONVENTIONS.md Stack section):
+
+| Language | Formatter | Linter | Type Checker | Test Framework | Logger | Git Hooks |
+|----------|-----------|--------|--------------|----------------|--------|-----------|
+| Python | Ruff | Ruff | mypy | pytest + pytest-cov | structlog | pre-commit |
+| TypeScript | Biome | Biome | tsc (strict) | Vitest | pino | husky + lint-staged |
+| JavaScript | Biome | Biome | - | Vitest | pino | husky + lint-staged |
+| Rust | rustfmt | Clippy | (built-in) | cargo test | tracing | pre-commit |
+| Go | gofmt | golangci-lint | (built-in) | go test | log/slog | pre-commit |
+
+**Monorepo installation strategy** (when `monorepo: true`):
+- **Same stack across all packages**: Install and configure at repo root. One config file shared.
+- **Mixed stacks**: Install per-package. Each package gets its own config file in its directory.
+- **Git hooks**: Always install at repo root (hooks are repo-wide). Configure to run tools per-package via workspace commands (e.g., `pnpm -r run lint`, `turbo run lint`).
+- **Observability bundle**: Create `logs/` at repo root (shared). Logger configs go per-package in each package's source directory (e.g., `apps/api/src/logging_config.py`, `apps/web/src/logger.ts`).
+
+**Single-repo**: Install and configure at project root as usual.
+
+1. Install tool via detected package manager
+2. Generate config file with sensible defaults
+3. **Monorepo**: When installing per-package, use workspace commands where available (e.g., `pnpm --filter web add -D biome`, `cargo add -p api tracing`)
+4. If install fails and not `--skip-install`: Try alternative install methods (different package manager, build from source, etc.). Only document for manual install if you have exhausted all automated options and the failure requires sudo or credentials you don't have.
+
+#### Observability Bundle Implementation ("Logger")
+
+**Purpose**: Set up structured logging with AI-friendly error capture.
+
+**For all languages, create:**
+1. `logs/` directory in project root
+2. Proper `logs/.gitignore` with content
+3. Logger configuration file (language-specific)
+4. Error handler that writes to `logs/last_error_<timestamp>.json`, ex: `logs/last_error_2025-01-01T12:00:00.000Z.json`
+
+**last_error.json schema** (AI-friendly structured error context):
+```json
+{
+  "timestamp": "2025-01-01T12:00:00.000Z",
+  "level": "error",
+  "msg": "Error description",
+  "error": {
+    "type": "ErrorClassName",
+    "message": "Detailed error message",
+    "stack": "Stack trace..."
+  },
+  "context": {}
+}
+```
+
+**Language-specific setup examples:**
+
+| Language | Install | Config File | Error Handler |
+|----------|---------|-------------|---------------|
+| Python | `pip install structlog` | `src/logging_config.py` | `write_last_error()` processor |
+| TypeScript | `npm install pino` | `src/logger.ts` | `logMethod` hook |
+| JavaScript | `npm install pino` | `src/logger.js` | `logMethod` hook |
+| Rust | Add `tracing`, `tracing-subscriber` to Cargo.toml | `src/logging.rs` | `capture_error()` function |
+| Go | (stdlib) | `internal/logging/logging.go` | `CaptureError()` function |
+
+#### Database Bundle Implementation
+
+**Activation**: Only when database signals detected (docker-compose DB service, `.env` with `DATABASE_URL`/`DB_*`, migration tool config files, ORM in dependencies, vector DB in dependencies).
+
+**Steps:**
+1. Detect DB type and existing migration tool from project signals
+2. If no migration tool found, recommend one based on detected stack (prompt user to confirm)
+3. Verify migration tool is installed and configured
+4. Create seed script if none exists (location based on stack conventions)
+5. Create test DB configuration if none exists (`.env.test` or equivalent with separate `DATABASE_URL`)
+6. Validate: run migrations (up + down + up to verify reversibility), run seed, run test suite
+
+**Monorepo**: Prompt user for DB ownership model (shared / per-package / hybrid). Install migration tool in owner package or per-package as appropriate. Update CONVENTIONS.md Database Ownership table.
+
+**Detection signals:**
+
+| Signal | Source |
+|--------|--------|
+| `docker-compose.yml` with DB service | Project root |
+| `.env` with `DATABASE_URL` or `DB_*` vars | Project/package root |
+| `prisma/schema.prisma`, `drizzle.config.*`, `alembic.ini`, `knexfile.*` | Package root |
+| ORM in dependency manifest | Package root |
+| `pgvector`, `chromadb`, `pinecone-client` in deps | Package root |
+
+### Step 5: VALIDATE
+
+Run ALL configured tools (not just the new one):
+
+1. **Formatter** (if configured): Run with auto-fix flag
+2. **Linter** (if configured): Run with auto-fix flag
+3. **Type checker** (if configured): Run in check mode
+4. **Tests** (if configured): Run full suite
+5. **Observability** (if configured): Verify logger and error capture
+6. **Git hooks** (if configured): Verify hooks are installed
+7. **Database** (if configured): Run migrations (up, down, up), run seed script, verify test DB connects
+8. **Local dev startup** (if applicable): Verify the app starts locally (`docker compose up -d` or framework dev command), confirm it responds (e.g., `curl http://localhost:[port]`), then shut down. If no start command is known, skip.
+
+**Observability validation:**
+- Run logger initialization (language-specific)
+- Trigger test error to verify capture
+- Confirm `logs/` directory exists
+- Confirm `logs/.gitignore` has correct patterns
+- Confirm `logs/last_error_<timestamp>.json` is created with valid JSON
+
+**Database validation:**
+- Run migration tool's status/pending command to verify no drift
+- Run up migration, then down, then up again (verify reversibility)
+- Run seed script (verify idempotency -- run twice)
+- Verify test DB configuration connects successfully
+- If vector DB configured: verify extension/service is available
+
+**Local dev startup validation:**
+- If `docker-compose.yml` / `compose.yml` exists: run `docker compose config --quiet` (validate config), then `docker compose up -d`, wait for healthy, `curl` the dev URL, then `docker compose down`
+- If no compose file: use the framework's dev command (e.g., `npm run dev`, `python manage.py runserver`) in background, verify it binds to the expected port, then stop it
+- Record the working start command in CONVENTIONS.md Local Dev Tools table as `| Dev Server | [command] | [config] |`
+- **Monorepo**: Verify each deployable package starts independently
+
+**Monorepo validation** (when `monorepo: true`):
+- Run each configured tool **per package** using workspace commands or by changing into the package directory
+- Examples: `pnpm --filter web run lint`, `cd apps/api && ruff check .`, `turbo run typecheck`
+- Also run repo-root checks for root-level configs (e.g., root `tsconfig.json` references)
+- Collect results per package for the Step 8 report
+- A tool failing in one package does not skip other packages -- run all, then report all
+
+**Single-repo**: Run each tool from the project root as usual.
+
+Capture all output. Parse for errors, warnings, fixes applied.
+
+### Step 6: FIX
+
+For each issue found in Step 5:
+
+1. **Auto-fixable** (format, some lint): Already fixed in Step 5
+2. **Type errors**: Attempt fix, verify syntax still valid
+3. **Test failures**: Attempt fix, re-run affected test
+4. **Unfixable after 3 attempts**: Try a different approach. Only log for manual review if the fix requires sudo or credentials you don't have. Revert if syntax broken.
+
+**Guardrail**: After any fix, verify syntax/compilation. If broken after 2 retries, revert.
+
+Filter out issues matching known-issues.md patterns - report separately as "Known".
+
+### Step 7: RECORD
+
+If a new bundle was added, update `.spec_system/CONVENTIONS.md`:
+
+Update the Local Dev Tools table:
+```markdown
+| Category | Tool | Config |
+|----------|------|--------|
+| Formatter | Ruff | ruff.toml |  <-- was "not configured"
+```
+
+**Monorepo only**: Also update the Workspace Structure table with per-package tool status where stacks differ:
+```markdown
+## Workspace Structure
+
+| Package | Path | Type | Stack | Formatter | Linter |
+|---------|------|------|-------|-----------|--------|
+| web | apps/web | Frontend | TypeScript | Biome | Biome |
+| api | apps/api | Backend | Python | Ruff | Ruff |
+| shared | packages/shared | Library | TypeScript | Biome | Biome |
+```
+
+If the Workspace Structure table does not yet have tool columns, add them. If the table already exists (from initspec or createprd), extend it with the new columns rather than replacing it.
+
+### Step 8: REPORT
+
+**For monorepos**, show per-package:
+```
+[apps/web] Formatter: 12 fixed | Linter: 3 remain
+[apps/api] Formatter: 8 fixed | Types: 2 errors
+```
+
+**For single repos**:
+```
+REPORT
+- Added: Formatting (Ruff)
+- Config: ruff.toml created
+- Fixed: 47 format issues, 12 lint errors
+- Remaining: 3 type errors in src/api/handlers.ts:45, :67, :89
+- Known: 5 issues in src/legacy/** (ignored per known-issues.md)
+```
+
+### Step 9: RECOMMEND
+
+- **If issues remain**: List required actions, prompt user to rerun audit after fixing
+- **If all configured tools pass**: Recommend pipeline as next step
+- **If all 6 bundles configured and passing**: Confirm completion, recommend pipeline
+
+## Dry Run Output
+
+```
+AUDIT PREVIEW (DRY RUN)
+
+Repository: monorepo (Turborepo)
+Packages: apps/web, apps/api, packages/shared
+Stack: Python 3.12, Node 20
+Package managers: uv, pnpm
+
+Configured: Formatting, Linting, Type Safety, Testing
+Missing: Observability, Git Hooks
+
+Would add: Observability
+Would install: structlog (apps/api), pino (apps/web, packages/shared)
+Would create: logs/ directory with .gitignore
+Would create: src/logging_config.py (apps/api), src/logger.ts (apps/web)
+Would run: ruff format, ruff check, biome format, biome lint, mypy, tsc, pytest, vitest
+
+Run without --dry-run to apply.
+```

--- a/skills/.experimental/apex-spec/references/carryforward.md
+++ b/skills/.experimental/apex-spec/references/carryforward.md
@@ -1,0 +1,380 @@
+# carryforward
+
+Extract key insights from the just-completed phase and update two living documents:
+- `.spec_system/CONSIDERATIONS.md` - institutional memory for AI assistants working on future phases
+- `.spec_system/SECURITY-COMPLIANCE.md` - cumulative security posture and GDPR compliance record
+
+Be ruthlessly selective: only the most impactful lessons deserve space.
+
+Run after completing a phase, before phasebuild. Optional but recommended for phases with significant discoveries, novel problems, or 4+ sessions.
+
+## Rules
+
+1. **CONSIDERATIONS.md: 600-line limit STRICT** - trim older/less relevant items if needed
+2. **SECURITY-COMPLIANCE.md: 1000-line limit STRICT** - synthesize, don't append raw session reports
+3. **Active Concerns**: max 20 items total (5 per subcategory)
+4. **Lessons Learned**: max 30 items total
+5. **Resolved**: max 15 items, rotate out after 2 phases
+6. **Conciseness**: each item 1-3 lines max, include phase number `[PNN]`
+7. **ASCII-only characters** and Unix LF line endings
+
+## Steps
+
+### 1. Verify Phase Completion
+
+Check `.spec_system/state.json`:
+- Confirm current phase status is "complete"
+- Get phase number and name
+- If phase not complete, inform user and exit
+- Read `monorepo` field: `true` / `false` / `null`
+- If `monorepo: true`: read `packages` array and `completed_sessions` (object format with `package` field)
+
+### 2. Gather Phase Artifacts
+
+Read all implementation summaries from the completed phase:
+
+```bash
+# Find all IMPLEMENTATION_SUMMARY.md files for completed phase
+ls .spec_system/archive/phases/phase_NN_*/IMPLEMENTATION_SUMMARY.md
+```
+
+Also read:
+- `.spec_system/audit/` - recent audit reports
+- `.spec_system/PRD/phase_NN/` - phase requirements (before archive)
+- Any `implementation-notes.md` files with blockers or discoveries
+- All `security-compliance.md` files from the completed phase's sessions
+- Current `.spec_system/SECURITY-COMPLIANCE.md` (if exists from prior phases)
+
+**Monorepo only**: For each session's artifacts, note the `Package:` field from its spec.md header. This associates insights with the package they originated from. Cross-cutting sessions (package: null) produce project-wide insights.
+
+### 3. Extract Insights
+
+From each session's IMPLEMENTATION_SUMMARY.md, identify:
+
+**Active Concerns** (things that affect upcoming work):
+- Unresolved technical debt
+- Known limitations or constraints
+- External dependencies with risks
+- Performance thresholds to monitor
+- Security considerations
+- Database concerns (schema debt, missing indexes, query performance, migration ordering)
+- Deployment concerns (local dev startup issues, deploy failures, rollback gaps, environment drift)
+
+**Lessons Learned** (patterns to follow or avoid):
+- Technical decisions that worked well (and why)
+- Approaches that failed (and why)
+- Useful patterns discovered
+- Tool/library insights
+- Architecture insights
+
+**Items to Resolve** (move from Active Concerns if addressed):
+- Check if previous Active Concerns were addressed this phase
+- Move them to Resolved with brief resolution note
+
+**Monorepo only**: Tag each extracted insight with its source package:
+- **Package-specific**: Concerns/lessons that apply to one package (e.g., `[P05-apps/web]` for a frontend-specific issue)
+- **Cross-package**: Concerns that span multiple packages or affect package interactions (e.g., `[P05-apps/web+apps/api]` for an API contract issue)
+- **Project-wide**: Concerns that apply regardless of package (e.g., `[P05]` for a CI/CD or tooling lesson)
+
+### 4. Read Current CONSIDERATIONS.md
+
+Read `.spec_system/CONSIDERATIONS.md`:
+- Parse existing sections
+- Note current line count
+- Identify stale items in each section
+
+### 5. Update CONSIDERATIONS.md
+
+Update `.spec_system/CONSIDERATIONS.md` following the format below. Add new items, remove resolved ones, merge similar entries, and enforce the limits in Rules above.
+
+**Monorepo only**: When tagging items, use the package-qualified format: `[PNN-package/path]` for package-specific items, `[PNN]` for project-wide items. This helps future sessions identify which concerns apply to their target package. Do NOT create separate per-package sections -- keep the existing flat structure but use the tags to indicate scope. This avoids section bloat within the 600-line limit.
+
+### 6. Synthesize SECURITY-COMPLIANCE.md
+
+Read every `security-compliance.md` from the just-completed phase's sessions. Merge them into `.spec_system/SECURITY-COMPLIANCE.md` following the format below.
+
+**Synthesis rules:**
+- **Don't append** -- re-synthesize the entire document each time by merging new phase findings with the existing file
+- **Remediated findings**: Move to the Resolved Findings section with resolution date and phase. Compress after 2 phases (keep one-line summary only)
+- **Open findings**: Keep full detail (severity, file, description, remediation steps)
+- **Personal Data Inventory**: Accumulate across phases -- add new data elements, update existing ones if storage/purpose changed, remove if data collection was removed
+- **Dependency audit**: Keep only the current state -- drop resolved dependency issues, add new ones
+- **Phase summary**: Add a row to the Phase History table, keep last 5 phases of detail
+
+**Monorepo only**: When synthesizing findings:
+- Include the package path in finding IDs (e.g., `[P05-apps/web-S03]` for a finding from session 03 scoped to apps/web)
+- In the Personal Data Inventory, add a Package column to indicate which package collects/stores each data element
+- In the Phase History table, note per-package session counts if sessions were distributed across packages
+- Group related findings by package when it aids readability, but keep within the flat document structure
+
+### 7. Report Summary
+
+Tell the user what was updated.
+
+## CONSIDERATIONS.md Format
+
+```markdown
+# Considerations
+
+> Institutional memory for AI assistants. Updated between phases via carryforward.
+> **Line budget**: 600 max | **Last updated**: Phase NN (YYYY-MM-DD)
+
+---
+
+## Active Concerns
+
+Items requiring attention in upcoming phases. Review before each session.
+
+### Technical Debt
+<!-- Max 5 items -->
+
+- [P05] **Item name**: Brief description of the concern and why it matters.
+
+### External Dependencies
+<!-- Max 5 items -->
+
+- [P08] **Item name**: Brief description of risk or constraint.
+
+### Performance / Security
+<!-- Max 5 items -->
+
+- [P11] **Item name**: Threshold or requirement to monitor.
+
+### Architecture
+<!-- Max 5 items -->
+
+- [P03] **Item name**: Constraint or consideration for design decisions.
+
+---
+
+## Lessons Learned
+
+Proven patterns and anti-patterns. Reference during implementation.
+
+### What Worked
+<!-- Max 15 items -->
+
+- [P02] **Pattern name**: What it is and when to use it.
+
+### What to Avoid
+<!-- Max 10 items -->
+
+- [P04] **Anti-pattern name**: What went wrong and why to avoid.
+
+### Tool/Library Notes
+<!-- Max 5 items -->
+
+- [P07] **Tool name**: Key insight about usage or configuration.
+
+---
+
+## Resolved
+
+Recently closed items (buffer - rotates out after 2 phases).
+
+| Phase | Item | Resolution |
+|-------|------|------------|
+| P10 | Item name | How it was resolved |
+| P09 | Item name | How it was resolved |
+
+---
+
+*Auto-generated by carryforward. Manual edits allowed but may be overwritten.*
+```
+
+## SECURITY-COMPLIANCE.md Format
+
+```markdown
+# Security & Compliance
+
+> Cumulative security posture and GDPR compliance record. Updated between phases via carryforward.
+> **Line budget**: 1000 max | **Last updated**: Phase NN (YYYY-MM-DD)
+
+---
+
+## Current Security Posture
+
+### Overall: CLEAN / AT RISK / CRITICAL
+
+| Metric | Value |
+|--------|-------|
+| Open Findings | N |
+| Critical/High | N |
+| Medium/Low | N |
+| Phases Audited | N |
+| Last Clean Phase | PNN |
+
+---
+
+## Open Findings
+
+Active security or GDPR issues requiring attention. Ordered by severity.
+
+### Critical / High
+
+- **[PNN-S01] Finding title**
+  - Severity: Critical / High
+  - File: `path/file:line`
+  - Description: Brief description of the issue.
+  - Remediation: Steps to fix.
+  - Status: Open | In Progress
+  - Opened: PNN (YYYY-MM-DD)
+
+### Medium / Low
+
+- **[PNN-S02] Finding title**
+  - Severity: Medium / Low
+  - File: `path/file:line`
+  - Description: Brief description.
+  - Remediation: Steps to fix.
+  - Opened: PNN (YYYY-MM-DD)
+
+[Or "No open findings."]
+
+---
+
+## GDPR Compliance Status
+
+### Overall: COMPLIANT / NON-COMPLIANT / N/A
+
+### Personal Data Inventory
+
+| Data Element | Source | Storage | Purpose | Legal Basis | Retention | Deletion Path | Since |
+|-------------|--------|---------|---------|-------------|-----------|---------------|-------|
+| [e.g., email] | [user input] | [db.users] | [auth] | [consent] | [account lifetime] | [DELETE /api/user] | PNN |
+
+[Or "No personal data collected or processed."]
+
+### Compliance Checklist
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Data collection has documented purpose | PASS/FAIL/N/A | [notes] |
+| Consent obtained before data storage | PASS/FAIL/N/A | [notes] |
+| Data minimization verified | PASS/FAIL/N/A | [notes] |
+| Deletion/erasure path exists | PASS/FAIL/N/A | [notes] |
+| No PII in application logs | PASS/FAIL/N/A | [notes] |
+| Third-party transfers documented | PASS/FAIL/N/A | [notes] |
+
+---
+
+## Dependency Security
+
+### Current Vulnerabilities
+
+| Package | Version | Severity | CVE | Status |
+|---------|---------|----------|-----|--------|
+| [package] | [ver] | High | [CVE-YYYY-NNNNN] | Open / Mitigated |
+
+[Or "No known vulnerable dependencies."]
+
+---
+
+## Resolved Findings
+
+Recently closed items. Compressed after 2 phases.
+
+| ID | Finding | Severity | Resolved | Phase | Resolution |
+|----|---------|----------|----------|-------|------------|
+| PNN-S01 | Finding title | High | YYYY-MM-DD | PNN | How it was fixed |
+
+[Or "No resolved findings yet."]
+
+---
+
+## Phase History
+
+| Phase | Sessions | Security | GDPR | Findings Opened | Findings Closed |
+|-------|----------|----------|------|-----------------|-----------------|
+| PNN | N | PASS/FAIL | PASS/FAIL/N/A | N | N |
+
+---
+
+## Recommendations
+
+Actionable items for upcoming phases based on cumulative findings.
+
+1. [Recommendation with context]
+
+[Or "None -- project is currently compliant."]
+
+---
+
+*Auto-generated by carryforward. Manual edits allowed but may be overwritten.*
+```
+
+## SECURITY-COMPLIANCE.md Line Budget Guidance
+
+Target allocation within 1000 lines:
+- Header/metadata: ~20 lines
+- Open Findings: ~300 lines (detailed entries with remediation steps)
+- GDPR Compliance: ~200 lines (inventory + checklist)
+- Dependency Security: ~100 lines
+- Resolved Findings: ~150 lines (compressed table)
+- Phase History: ~80 lines
+- Recommendations/spacing: ~150 lines
+
+### Trimming Strategy
+
+When approaching 1000 lines, trim in this order:
+1. Resolved findings older than 2 phases (compress to one-line table row)
+2. Phase History detail older than 5 phases (keep only the summary row)
+3. Dependency issues that have been resolved
+4. Merge similar open findings
+5. Shorten verbose remediation descriptions
+
+---
+
+## CONSIDERATIONS.md Line Budget Guidance
+
+Target allocation within 600 lines (CONSIDERATIONS.md):
+- Header/metadata: ~15 lines
+- Active Concerns: ~150 lines (20 items x ~7 lines avg)
+- Lessons Learned: ~250 lines (30 items x ~8 lines avg)
+- Resolved: ~100 lines (15 items in table)
+- Section headers/spacing: ~85 lines
+
+### Trimming Strategy
+
+When approaching 600 lines, trim in this order:
+1. Resolved items older than 2 phases
+2. Lessons Learned items older than 5 phases (unless still highly relevant)
+3. Active Concerns that have become irrelevant
+4. Merge similar items within sections
+5. Shorten verbose descriptions
+
+## Output
+
+**Single-repo:**
+```
+Phase NN Carryforward Complete
+
+Updated .spec_system/CONSIDERATIONS.md:
+- Active Concerns: +N new, -N resolved, N total
+- Lessons Learned: +N new, N total
+- Resolved: +N added, -N rotated out, N total
+- Line count: NNN/600
+
+Updated .spec_system/SECURITY-COMPLIANCE.md:
+- Open Findings: N (N critical/high, N medium/low)
+- GDPR Status: COMPLIANT / NON-COMPLIANT / N/A
+- Findings opened this phase: N
+- Findings closed this phase: N
+- Personal data elements tracked: N
+- Line count: NNN/1000
+
+Key additions:
+- [Active] Brief description
+- [Lesson] Brief description
+- [Security] Brief description (if any new findings)
+
+Ready for the documents workflow step to maintain project documentation.
+```
+
+**Monorepo** (add package breakdown after Key additions):
+```
+Package breakdown:
+- apps/web: N sessions, N concerns, N findings
+- apps/api: N sessions, N concerns, N findings
+- (cross-cutting): N sessions, N concerns, N findings
+```

--- a/skills/.experimental/apex-spec/references/copush.md
+++ b/skills/.experimental/apex-spec/references/copush.md
@@ -1,0 +1,94 @@
+# copush
+
+Pull the latest from origin, increment the project version, commit all non-gitignored
+changes, and push to origin. Designed as a single command to bundle routine
+commit-and-push workflows without manual version tracking.
+
+## Rules
+
+1. **Origin only** - Pull and push to `origin` remote only; never touch `upstream`
+2. **Clean merge or halt** - If the pull results in conflicts or a non-fast-forward situation that cannot be cleanly auto-merged, stop immediately and explain the situation to the user
+3. **No attributions** - Do NOT add co-author lines, signed-off-by, or any attribution metadata to the commit
+4. **Commit everything** - Stage and commit ALL non-gitignored changes in the repo, not just files you touched in the current session
+5. **Read-only on spec system** - Never modify state.json, session specs, or task checklists (version files are fine)
+6. **ASCII only** - Commit messages use characters 0-127 only
+
+## Steps
+
+### 1. Pull from origin
+
+Run `git pull origin <current-branch>` to fetch and merge the latest changes.
+
+If the merge is clean (fast-forward or auto-merge with no conflicts), proceed.
+
+If there are merge conflicts or the merge cannot complete cleanly:
+- Abort the merge with `git merge --abort`
+- Report the conflict details to the user
+- HALT -- do not continue to subsequent steps
+
+### 2. Increment the project version
+
+Look for version strings in the project. Common locations include:
+- `README.md` (e.g., `**Version: X.Y.Z**`)
+- `package.json` (`"version": "X.Y.Z"`)
+- `plugin.json` / `marketplace.json`
+- `SKILL.md`
+- Any files listed in project instructions under version update instructions
+
+Increment the **patch** version (e.g., `1.0.3` becomes `1.0.4`). If the version
+contains a pre-release tag (e.g., `1.0.3-beta`), increment the patch but preserve
+the tag (e.g., `1.0.4-beta`).
+
+If no version string can be found anywhere in the project, initialize versioning
+at `0.1.0` in all standard locations appropriate for the project type:
+- **Node/JS/TS projects**: `package.json` (`"version": "0.1.0"`)
+- **Python projects**: `pyproject.toml` or `setup.py`
+- **Rust projects**: `Cargo.toml`
+- **Go projects**: Add a `VERSION` file (Go lacks a manifest version field)
+- **Ruby projects**: `Gemfile` or `.gemspec`
+- **Java projects**: `pom.xml` or `build.gradle`
+- **Always**: `README.md` (add a `**Version: 0.1.0**` line near the top)
+- **Plugin projects**: `plugin.json`, `marketplace.json`, `SKILL.md` if they exist
+
+Only add to locations that already exist or are standard for the detected stack.
+Do not create manifest files that the project does not already have.
+Note the initialization in the commit message.
+
+### 3. Stage all changes
+
+Before staging, review `git status` output for files that should NOT be committed.
+Watch for and exclude:
+
+- **Secrets/credentials**: `.env`, `*.pem`, `*.key`, credentials files, API keys
+- **Build artifacts**: `__pycache__/`, `*.pyc`, `node_modules/`, `dist/`, `build/`
+- **OS/editor junk**: `.DS_Store`, `Thumbs.db`, `.vscode/settings.json`, `*.swp`
+- **Large binaries**: database files, media assets, compiled binaries
+
+If any of these are present and not already covered by `.gitignore`, add the
+appropriate entries to `.gitignore` BEFORE staging. Then run `git add -A` to stage
+every non-gitignored file in the repository. This includes work from outside the
+current session that the user may have pending.
+
+After staging, run `git diff --cached --stat` and scan the file list one more time
+to confirm nothing sensitive or unintended slipped through.
+
+### 4. Commit
+
+Create a single commit with a concise, descriptive message summarizing the changes.
+Do NOT include any co-author, signed-off-by, or attribution lines.
+
+### 5. Push to origin
+
+Run `git push origin <current-branch>`.
+
+If the push is rejected (e.g., remote has new commits since the pull), report the
+situation and HALT. Do not force-push.
+
+## Output
+
+Report:
+- Whether the pull was clean
+- Which files had the version bumped (and from/to values)
+- The commit hash and message
+- Whether the push succeeded
+- Any warnings, errors, or issues encountered at any step

--- a/skills/.experimental/apex-spec/references/createprd.md
+++ b/skills/.experimental/apex-spec/references/createprd.md
@@ -1,0 +1,399 @@
+# createprd
+
+Convert a user-provided document (notes, PRD, spec, RFC, meeting notes) into the Apex Spec System master PRD at `.spec_system/PRD/PRD.md`.
+
+Downstream workflow steps (phasebuild, plansession, documents) depend on this PRD as the source of truth.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--skip-conventions` | false | Skip CONVENTIONS.md fine-tuning |
+
+## Rules
+
+1. **Never overwrite a real PRD** without explicit user confirmation (template placeholders can be overwritten silently)
+2. **Do not invent requirements** - ask 3-8 targeted questions for missing info
+3. **ASCII-only characters** and Unix LF line endings in all output
+4. **Do not create phase directories or session stubs** - that is the phasebuild workflow step's job
+5. **CONVENTIONS.md must stay under 300 lines** - trim ruthlessly if exceeded
+6. Only add conventions with clear evidence from the tech stack - no speculative additions
+
+## Steps
+
+### 1. Confirm Spec System Is Initialized
+
+Check for `.spec_system/state.json` and `.spec_system/PRD/`. If missing, run initspec yourself to set up the spec system. Only ask the user if initspec requires user input you don't have.
+
+### 2. Get Deterministic Project State
+
+Run the analysis script to get reliable state facts. Local scripts take precedence over plugin scripts:
+
+```bash
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+Use the JSON output as ground truth for:
+- Project name (if available)
+- Current phase number
+- Existing phases list (if present)
+
+Do not parse `state.json` directly.
+
+### 3. Collect the Source Requirements Document
+
+Ask the user for the source document in one of these forms:
+- Paste the text directly into the chat
+- Provide a file path in the repo to read
+- Provide multiple snippets (if the content is long)
+
+If the user provides a file path, read it. If pasted text, treat it as the source of truth.
+
+### 4. Decide Whether to Create or Update
+
+Check whether `.spec_system/PRD/PRD.md` already exists.
+
+- If it does not exist: create it
+- If it exists: check if it is a template placeholder or real content
+
+**Detecting Template Placeholder PRD**:
+
+The initspec workflow step creates a placeholder PRD with bracket markers like `[Goal 1]`, `[PROJECT_DESCRIPTION]`, `[Objective 1]`, etc. If **2 or more** such markers are present, it's a template - overwrite without confirmation.
+
+If the PRD has real content (fewer than 2 template markers), ask for explicit user confirmation before overwriting.
+
+**If overwriting real content (confirmation given)**:
+1. Create a timestamped backup in `.spec_system/archive/PRD/` before writing
+2. Then replace `.spec_system/PRD/PRD.md`
+
+Backup naming (ASCII only):
+- `.spec_system/archive/PRD/PRD-backup-YYYYMMDD-HHMMSS.md`
+
+If overwrite is not confirmed:
+- Offer to create a new file next to it for review and stop
+
+### 5. Extract and Normalize Requirements
+
+From the source document, extract and normalize:
+- **Product overview**: 1-3 paragraphs
+- **Goals**: 3-7 bullets that are outcome-focused
+- **Non-goals**: 3-10 bullets (explicitly out of scope)
+- **Users and use cases**: primary personas and key workflows
+- **Functional requirements**: grouped by area (MVP first). Write each requirement as "[Actor] can [capability] [context]" (e.g., "User can reset password via email link"). Focus on WHAT, not HOW -- keep requirements implementation-agnostic.
+- **Non-functional requirements**: performance, security, privacy, reliability, accessibility. Each NFR must include a specific, measurable target (e.g., "API response < 200ms at p95", not "should be fast")
+- **Constraints**: tech constraints, compliance, hosting, budgets, deadlines
+- **Assumptions**: what must be true for the plan to work
+- **Risks**: major risks and mitigations
+- **Success criteria**: checkboxes that can be validated
+- **Open questions**: items requiring human confirmation
+
+Important:
+- Do not invent details. If the source doc is missing critical info, ask 3-8 targeted questions
+- Keep content high-level and stable. Session-level details belong in the plansession workflow step
+- Keep phases as planning scaffolding, not implementation plans
+
+### 6. Generate Master PRD
+
+Create `.spec_system/PRD/PRD.md` using this template. Use straight quotes only. Use hyphens, not em-dashes. ASCII-only.
+
+```markdown
+# [PROJECT_NAME] - Product Requirements Document
+
+## Overview
+
+[1-3 paragraphs describing what this product is and who it is for.]
+
+## Goals
+
+1. [Goal]
+2. [Goal]
+3. [Goal]
+
+## Non-Goals
+
+- [Non-goal]
+- [Non-goal]
+
+## Users and Use Cases
+
+### Primary Users
+
+- **[Persona]**: [short description]
+
+### Key Use Cases
+
+1. [Use case]
+2. [Use case]
+
+## Requirements
+
+### MVP Requirements
+
+- [Actor] can [capability] [context]
+- [Actor] can [capability] [context]
+
+### Deferred Requirements
+
+- [Actor] can [capability] [context]
+
+## Non-Functional Requirements
+
+- **Performance**: [specific measurable target, e.g., "API response < 200ms at p95"]
+- **Security**: [specific measurable target, e.g., "OWASP Top 10 compliance"]
+- **Reliability**: [specific measurable target, e.g., "99.9% uptime SLA"]
+- **Accessibility**: [specific measurable target, e.g., "WCAG 2.1 AA"]
+
+## Constraints and Dependencies
+
+- [Constraint or dependency]
+
+## Phases
+
+This system delivers the product via phases. Each phase is implemented via multiple 2-4 hour sessions (12-25 tasks each).
+
+| Phase | Name | Sessions | Status |
+|-------|------|----------|--------|
+| 00 | [PHASE_NAME] | TBD | Not Started |
+
+## Phase 00: [PHASE_NAME]
+
+### Objectives
+
+1. [Objective]
+2. [Objective]
+
+### Sessions (To Be Defined)
+
+Sessions are defined via phasebuild as `session_NN_name.md` stubs under `.spec_system/PRD/phase_00/`.
+
+**Note**: This command does NOT create phase directories or session stubs. Run phasebuild after creating the PRD.
+
+## Technical Stack
+
+- [Technology] - [why]
+
+## Success Criteria
+
+- [ ] [Criterion]
+- [ ] [Criterion]
+
+## Risks
+
+- **[Risk]**: [mitigation]
+
+## Assumptions
+
+- [Assumption]
+
+## Open Questions
+
+1. [Question]
+2. [Question]
+```
+
+Notes:
+- If the project already has phases beyond Phase 00 (from state analysis), update the phases table accordingly
+- Do not create phase directories here - that is the phasebuild workflow step's job
+- Use `[PHASE_NAME]` placeholder - default to "Foundation" if not specified
+
+### 6a. Monorepo Detection from PRD Content
+
+**Skip this step if** `monorepo` in state.json is already `true` or `false` (already determined by initspec or a previous run).
+
+When `monorepo` is `null` (unknown), scan for multi-package signals:
+
+1. **Check PRD content** for signals:
+   - Multiple services or applications mentioned (e.g., "web app", "API server", "worker service")
+   - Explicit monorepo language ("monorepo", "workspace", "packages")
+   - Multiple distinct tech stacks for different components
+   - References to shared libraries or cross-service code
+
+2. **Check `monorepo_detection`** from the `analyze-project.sh --json` output (Step 2):
+   - If `monorepo_detection.detected` is `true`, use it as supporting evidence
+
+3. **If signals found**: Present the user with a proposed package map:
+   ```
+   Monorepo signals detected in PRD:
+   - [signal 1]
+   - [signal 2]
+
+   Proposed package map:
+   | Package | Path | Stack |
+   |---------|------|-------|
+   | web | apps/web | TypeScript |
+   | api | apps/api | TypeScript |
+
+   Confirm / Edit / Reject?
+   ```
+
+   - **Confirmed**: Set `monorepo: true` in state.json, add `packages` array, add Package Map section to PRD after Technical Stack:
+     ```markdown
+     ## Package Map
+
+     | Package | Path | Stack | Purpose |
+     |---------|------|-------|---------|
+     | web | apps/web | TypeScript | Frontend application |
+     | api | apps/api | TypeScript | Backend API server |
+     ```
+   - **Rejected**: Set `monorepo: false` in state.json
+
+4. **If no signals found**: Set `monorepo: false` in state.json
+
+### 7. Customize CONVENTIONS.md for Tech Stack
+
+Customize `.spec_system/CONVENTIONS.md` to reflect the project's actual tech stack and domain. This is **initial customization** (more freedom to reshape) vs the audit workflow step which makes surgical edits later.
+
+#### 7.1 Detect Tech Stack
+
+From the PRD's Technical Stack section and source requirements, identify: primary language(s), framework(s), runtime, package manager, testing framework, and project domain.
+
+#### 7.2 Transform Generic Template
+
+Read `.spec_system/CONVENTIONS.md` (the generic template from initspec). Replace generic conventions with stack-specific equivalents, add new ones required by the stack, remove ones that don't apply. Keep each convention to 1-2 lines. No speculative additions.
+
+**Stack-specific transformations (examples):**
+
+| Stack | Transformations |
+|-------|-----------------|
+| TypeScript | Replace generic naming with TS conventions; add type safety rules; add `interface` vs `type` guidance |
+| React | Add component patterns; hooks conventions; state management approach; JSX style |
+| Next.js | Add App Router conventions; server/client component rules; API route patterns; file-based routing |
+| Python | Replace with PEP 8; add type hint requirements; docstring format; import ordering |
+| Go | Replace with Effective Go idioms; add error handling patterns; package naming; interface conventions |
+| Rust | Add Clippy compliance; Result/Option patterns; ownership conventions; module organization |
+| CLI | Add exit code standards; stdout vs stderr rules; flag naming; help text conventions |
+| API | Add REST conventions; status code usage; error response format; versioning approach |
+| Library | Add semantic versioning rules; public API stability; backwards compatibility; documentation requirements |
+| Monorepo | Add Workspace Structure section (package table + cross-package rules); shared dependency rules; cross-package imports; workspace alias conventions |
+| Database | Add Database Layer section: connection source, migration tool + rules, model/table naming, query safety, seed script, test DB strategy, vector/embeddings conventions (if applicable) |
+
+**Section-specific transformations:**
+
+| Section | Generic -> Stack-Specific |
+|---------|--------------------------|
+| **Naming** | Universal advice -> Language-specific casing (camelCase, snake_case, PascalCase, kebab-case) |
+| **Files & Structure** | Generic -> Framework directory conventions (src/, app/, lib/, components/, routes/) |
+| **Functions & Modules** | Universal -> Language idioms (async/await, error returns, generators, decorators) |
+| **Error Handling** | Generic -> Stack patterns (try/catch, Result types, error boundaries, panic vs error) |
+| **Testing** | Universal -> Framework patterns (describe/it, pytest fixtures, table-driven tests, mocking approach) |
+| **Dependencies** | Generic -> Package manager commands, lockfile rules, version pinning strategy |
+
+**Add new sections if warranted:**
+- **TypeScript**: Add "Types" section for type conventions
+- **React**: Add "Components" section for component patterns
+- **API**: Add "Endpoints" section for API design conventions
+- **Database**: Add "Database Layer" section with subsections for connection, migrations, models, queries, seeding, testing. If PRD references vector search, embeddings, or RAG, include "Vector / Embeddings" subsection. Detection: PRD mentions database, schema, any DB technology, migrations, ORM, data modeling, vector/embeddings, or RAG.
+- **Monorepo** (if confirmed in Step 6a): Add "Workspace Structure" section with package table and cross-package rules (import aliases, shared types location, test boundaries, cross-package session scope)
+
+#### 7.3 Enforce 300-Line Limit (STRICT)
+
+After transformation, verify CONVENTIONS.md stays under **300 lines maximum**.
+
+```bash
+wc -l .spec_system/CONVENTIONS.md
+```
+
+If over 300 lines:
+1. **Merge** similar conventions into single entries
+2. **Prioritize** stack-specific over generic (remove generic if redundant)
+3. **Condense** verbose explanations to single lines
+4. **Remove** lowest-impact conventions until compliant
+
+**Budget guidance**: The generic template is ~85 lines. You have ~215 lines for stack-specific customization. A well-customized CONVENTIONS.md typically lands between 120-200 lines.
+
+#### 7.4 Validate Changes
+
+After edits:
+1. Verify file is valid markdown
+2. Confirm line count <= 300
+3. Ensure no duplicate sections created
+4. Confirm ASCII-only characters
+
+```bash
+wc -l .spec_system/CONVENTIONS.md
+LC_ALL=C grep -n '[^[:print:][:space:]]' .spec_system/CONVENTIONS.md && echo "Non-ASCII found"
+```
+
+#### 7.5 Skip Conditions
+
+Skip this step entirely if:
+- `.spec_system/CONVENTIONS.md` does not exist
+- No tech stack was identified from the requirements
+- User explicitly requests `--skip-conventions`
+
+### 8. Validate Output
+
+Before reporting completion, run both encoding and content quality checks.
+
+#### 8.1 Encoding Validation
+
+- Confirm the file exists at `.spec_system/PRD/PRD.md`
+- Confirm it is ASCII-only and uses LF line endings
+
+```bash
+file .spec_system/PRD/PRD.md
+grep -n "$(printf '\r')" .spec_system/PRD/PRD.md && echo "CRLF found"
+LC_ALL=C grep -n '[^[:print:][:space:]]' .spec_system/PRD/PRD.md && echo "Non-ASCII found"
+```
+
+If checks fail, fix the PRD content and re-check.
+
+#### 8.2 Content Quality Validation
+
+Scan the generated PRD for common quality issues. For each check, fix inline if possible or flag to the user:
+
+| Check | What to look for | Action |
+|-------|-----------------|--------|
+| Template placeholders | Bracket markers like `[Goal 1]`, `[Requirement]`, `[Actor]` remaining in output | Replace with real content or remove |
+| Vague NFRs | NFRs without specific numbers (e.g., "should be fast", "highly available") | Rewrite with measurable targets |
+| Empty sections | Sections with no content below the heading | Fill in or ask user for input |
+| Weak requirements | Requirements that describe HOW (implementation) rather than WHAT (capability) | Rewrite in actor/capability form |
+| Missing sections | Any required section from the template entirely absent | Add the section |
+
+Report any issues found and fixed in the output summary.
+
+## Output
+
+Report to user:
+
+```
+createprd complete!
+
+Created:
+- .spec_system/PRD/PRD.md (master PRD)
+[If backup was made:]
+- Backup: .spec_system/archive/PRD/PRD-backup-YYYYMMDD-HHMMSS.md
+
+Summary:
+- Goals: N defined
+- MVP Requirements: N items
+- Non-Goals: N items
+- Open Questions: N items
+
+[If conventions were customized:]
+Conventions:
+- .spec_system/CONVENTIONS.md customized for [stack] (N/300 lines)
+- Key additions: [brief list, max 3]
+
+[If monorepo determined:]
+Monorepo: [true - N packages detected | false - single-repo confirmed]
+[If monorepo true:]
+- Package Map added to PRD
+- Workspace Structure added to CONVENTIONS.md
+
+[If quality issues were found and fixed:]
+Quality:
+- N issues auto-fixed (template placeholders, vague NFRs, etc.)
+
+[If quality issues remain for user:]
+Quality:
+- N issues need user input: [brief list]
+
+Next Steps:
+1. Review the generated PRD and refine as needed
+2. Run phasebuild to define Phase 00 sessions
+```

--- a/skills/.experimental/apex-spec/references/createuxprd.md
+++ b/skills/.experimental/apex-spec/references/createuxprd.md
@@ -1,0 +1,382 @@
+# createuxprd
+
+Convert user-provided design documents (wireframes, user flows, design specs, Figma notes) into the UX PRD at `.spec_system/PRD/PRD_UX.md`.
+
+This is a companion to `PRD.md` (functional requirements). plansession reads both when planning UI-focused sessions.
+
+## Rules
+
+1. **PRD.md must exist first** - run createprd if it doesn't
+2. **Never overwrite a real PRD_UX.md** without explicit user confirmation (template placeholders can be overwritten silently)
+3. **Do not invent design decisions** - ask 3-8 targeted questions for missing info
+4. **ASCII-only characters** and Unix LF line endings in all output
+5. **Reference PRD.md, don't duplicate it** - link to functional requirements, don't restate them
+6. **Keep it actionable** - every section should directly inform implementation
+7. **Design brief before structure** - always establish emotional targets and aesthetic identity before documenting screens and flows
+8. **Performance budget** - target locked 60fps; note any performance-sensitive interactions
+9. **Accessibility baseline** - WCAG AA contrast minimum, semantic HTML, focus states, reduced-motion support
+
+## Steps
+
+### 1. Confirm Spec System and PRD Exist
+
+Check for `.spec_system/PRD/PRD.md`. If missing, tell the user to run createprd first -- the UX PRD depends on functional requirements being defined.
+
+Read `.spec_system/PRD/PRD.md` to understand the product context, users, and requirements.
+
+### 2. Get Deterministic Project State
+
+Run the analysis script:
+
+```bash
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+Use the JSON output for project name and current state.
+
+### 3. Determine Source Mode
+
+The command accepts three input modes:
+
+**Mode A: Text provided** -- The user pastes or types design notes, user flow descriptions, screen lists, or UX requirements directly in the prompt.
+
+**Mode B: File reference provided** -- The user provides a file path (design spec, exported Figma notes, wireframe descriptions). Read the file and use its contents as the source material.
+
+**Mode C: No source provided (autonomous)** -- The user runs createuxprd with no additional input. Derive the entire UX PRD autonomously from:
+1. `.spec_system/PRD/PRD.md` (functional requirements, use cases, user personas)
+2. The existing codebase (if any UI code exists, infer patterns, routes, components)
+3. `state.json` project context (name, phase, tech stack)
+
+In Mode C, do NOT ask clarifying questions. Make confident, opinionated decisions for every section. Use PRD.md personas to define emotional targets. Infer aesthetic identity from the product domain. Choose a distinctive design direction rather than defaulting to safe/generic. Document all autonomous decisions clearly so the user can review and override.
+
+**For Modes A and B only** -- if the source is sparse, ask 3-8 targeted questions covering:
+
+**Structural questions:**
+- Primary user flows (what are the critical paths?)
+- Screen/page inventory (what screens exist?)
+- Navigation structure (how do users move between screens?)
+- Key interaction patterns (forms, modals, drag-drop, real-time?)
+- Device/responsive strategy (mobile-first? desktop-only? both?)
+- Accessibility requirements (WCAG level? specific needs?)
+
+**Design identity questions** (ask when no visual design assets are provided):
+- Who are the real people using this? What is their emotional state when they arrive? (stressed founder at midnight? curious teenager? professional making high-stakes decisions?)
+- What should users FEEL? Define 2-3 emotional targets (e.g., "calm authority + subtle delight," "raw energy + controlled chaos," "intimate warmth + precision")
+- Is there a reference domain outside web design that fits the product's personality? (architecture, fashion editorial, scientific instruments, aerospace interfaces, museum exhibitions, vintage packaging, botanical illustrations...)
+- What material metaphor describes how this interface should feel? (brushed steel? handmade paper? wet ink? polished marble? frosted glass? worn leather?)
+- What is the ONE interaction or moment that should make someone pause or screenshot?
+
+### 4. Decide Whether to Create or Update
+
+Check whether `.spec_system/PRD/PRD_UX.md` already exists.
+
+- If it does not exist: create it
+- If it exists with template placeholders (2+ bracket markers like `[Screen Name]`): overwrite silently
+- If it exists with real content: ask for confirmation, backup to `.spec_system/archive/PRD/PRD_UX-backup-YYYYMMDD-HHMMSS.md` before overwriting
+
+### 5. Extract and Normalize UX Requirements
+
+From the source material (Modes A/B) or PRD.md alone (Mode C), extract:
+
+**Design identity:**
+- **Emotional targets**: 2-3 feeling words that define the experience
+- **Aesthetic identity**: reference domain + era/movement + material metaphor
+- **Signature moment**: the ONE hero interaction worth screenshotting
+- **Micro-narrative arc**: Arrival -> Orientation -> Engagement -> Action -> Resolution
+
+**Structure and behavior:**
+- **User flows**: critical paths through the application
+- **Screen inventory**: every distinct screen/page/view
+- **Navigation structure**: how screens connect
+- **Interaction patterns**: forms, modals, notifications, real-time elements
+
+**Design system:**
+- **Color architecture**: dominant surface (60%), secondary (25%), accent (10%), signal (5%)
+- **Typography**: display font (personality carrier), body font (legible partner), monospace (if needed) -- with modular scale ratio
+- **Spacing scale**: consistent spacing values as a defined scale
+- **Elevation model**: how depth works (shadows, layers, blur, transparency, borders)
+
+**Motion and animation:**
+- **Entrance choreography**: how elements reveal on load and scroll
+- **Interaction feedback**: hover states, click responses, focus rings
+- **Scroll-driven moments**: transformations triggered by scroll position
+- **Performance budget**: 60fps target, max 3 simultaneous animations per viewport region
+
+**Responsive and accessibility:**
+- **Responsive strategy**: breakpoints, layout changes per context (not just shrinking)
+- **Accessibility**: WCAG targets, keyboard nav, screen reader needs, reduced-motion strategy
+- **Component patterns**: reusable UI patterns identified
+
+Important:
+- Derive flows from PRD.md use cases -- don't invent new ones
+- **Modes A/B**: If design details are missing, note them in Open Questions rather than guessing
+- **Mode C**: Make opinionated decisions for ALL sections -- do not leave Open Questions for things you can reasonably decide. Only list questions that genuinely require user input (e.g., brand colors already chosen, legal/compliance constraints)
+- The Design Brief can be populated even without visual design assets -- it captures intent and direction
+
+### 6. Generate UX PRD
+
+Create `.spec_system/PRD/PRD_UX.md`:
+
+```markdown
+# [PROJECT_NAME] - UX Requirements Document
+
+**Companion to**: [PRD.md](PRD.md)
+**Created**: [YYYY-MM-DD]
+
+---
+
+## 1. Design Brief
+
+### Emotional Targets
+[2-3 feeling words that define the experience. Examples: "calm authority + subtle delight," "raw energy + controlled chaos." These drive every downstream design decision.]
+
+### Aesthetic Identity
+- **Reference domain**: [A domain outside web design: architecture, fashion editorial, scientific instruments, aerospace interfaces, museum exhibitions, vintage packaging...]
+- **Era / movement**: [Bauhaus, Swiss International, Memphis Group, Streamline Moderne, Y2K...]
+- **Material metaphor**: [How the interface should FEEL to touch: brushed steel, handmade paper, wet ink, polished marble, frosted glass, worn leather...]
+
+*The intersection of these three creates an identity that cannot be generic.*
+
+### Signature Moment
+[The ONE interaction or visual moment someone would screenshot or share. Be specific: a mesmerizing loading sequence? A hover interaction that reveals hidden depth? A scroll-triggered transformation? A typography treatment that stops someone mid-scroll? A data visualization that makes complexity feel elegant?]
+
+### Micro-Narrative
+[The arc users experience: Arrival -> Orientation -> Engagement -> Action -> Resolution. Think of the interface as a physical space users navigate through -- architectural, intentional, editorial in pacing.]
+
+*Note: Omit this section only if the project is purely utilitarian (admin panels, internal tools). Even minimal consumer-facing products benefit from a brief.*
+
+---
+
+## 2. User Flows
+
+### Flow 1: [Flow Name]
+**Trigger**: [What starts this flow]
+**Goal**: [What the user accomplishes]
+
+```
+[Step 1] --> [Step 2] --> [Step 3] --> [Outcome]
+     |
+     v
+  [Alt path] --> [Recovery]
+```
+
+**Happy path**: [Brief description]
+**Error states**: [Key error scenarios and recovery]
+
+### Flow 2: [Flow Name]
+[Same structure]
+
+---
+
+## 3. Screen Inventory
+
+| Screen | Route/Path | Purpose | Key Components |
+|--------|------------|---------|----------------|
+| [Screen] | [/path] | [Purpose] | [Components] |
+
+---
+
+## 4. Navigation Structure
+
+```
+[Root]
+|-- [Section 1]
+|   |-- [Screen A]
+|   \-- [Screen B]
+|-- [Section 2]
+|   \-- [Screen C]
+\-- [Settings/Profile]
+```
+
+**Navigation pattern**: [tabs, sidebar, breadcrumb, etc.]
+**Deep linking**: [supported routes]
+
+---
+
+## 5. Interaction Patterns
+
+### Forms
+- Validation: [inline, on-submit, or both]
+- Error display: [pattern]
+- Success feedback: [pattern]
+
+### Modals/Dialogs
+- [When modals are used vs inline]
+- Confirmation dialogs: [destructive actions that need confirmation]
+
+### Loading States
+- [Skeleton screens, spinners, progressive loading]
+
+### Notifications
+- [Toast, banner, inline -- when each is used]
+
+---
+
+## 6. Motion and Animation Strategy
+
+### Philosophy
+[One sentence: what role does motion play in this product? Storytelling? Wayfinding? Delight? Physicality?]
+
+### Entrance Choreography
+- Page load: [How do elements appear? Staggered reveals? Fade-in? Slide from edge?]
+- Scroll reveals: [How do below-fold elements enter? Direction, timing, triggers]
+
+### Interaction Feedback
+- Hover states: [What happens? Scale, color shift, shadow change, content reveal?]
+- Click/tap responses: [Physical feedback -- bounce, press, ripple?]
+- Focus rings: [Style that matches the aesthetic identity]
+
+### Scroll-Driven Moments
+- [Key scroll-triggered transformations, parallax effects, or narrative beats]
+
+### Animation Constraints
+- Maximum 3 elements animating simultaneously per viewport region
+- Minimum 0.6s duration for scroll-triggered reveals
+- No linear easing -- use power, expo, or custom cubic-bezier curves
+- Respect `prefers-reduced-motion` with graceful alternatives (subtle opacity/position shifts, not "off")
+- Target 60fps -- test with 6x CPU throttling
+
+*Note: Omit this section for static/utilitarian interfaces. Include it for any consumer-facing product.*
+
+---
+
+## 7. Layout Philosophy
+
+### Composition Approach
+[How should layouts feel? Symmetric and ordered? Asymmetric and energetic? Grid-breaking and editorial? Dense and information-rich? Spacious and cinematic?]
+
+### Visual Hierarchy
+- Scale contrast: [How dramatically do sizes vary between primary, secondary, tertiary content?]
+- Negative space: [Generous breathing room or dense information display?]
+- Section rhythm: [Do sections vary in height/density, or maintain uniform pacing?]
+
+### Section Transitions
+[How do sections flow into each other? Hard cuts, color shifts, overlap zones, element migration?]
+
+*Note: Omit for simple form-based or CRUD interfaces.*
+
+---
+
+## 8. Responsive Strategy
+
+| Breakpoint | Target | Layout Approach |
+|------------|--------|-----------------|
+| [< 640px] | Mobile | [Not just shrunk -- redesigned: thumb-friendly, simplified hierarchy, swipe affordances] |
+| [640-1024px] | Tablet | [Own composition, not just "between phone and desktop"] |
+| [> 1024px] | Desktop | [Full cinematic layout, wider is an opportunity not just more padding] |
+
+**Approach**: [mobile-first / desktop-first / adaptive]
+**Touch targets**: minimum 44x44px with generous spacing between interactive elements
+
+---
+
+## 9. Accessibility
+
+**Target**: [WCAG 2.1 AA / AAA / custom]
+
+- Keyboard navigation: [requirements]
+- Screen reader: [ARIA labels, semantic HTML, live regions]
+- Color contrast: [WCAG AA minimum -- bold palettes, not washed-out]
+- Focus management: [Focus states as creative expression, not just blue outlines]
+- Reduced motion: [`prefers-reduced-motion` strategy -- subtle alternatives, not blank removal]
+
+---
+
+## 10. Design System (if available)
+
+### Color Architecture
+- **Dominant surface** (60%): [The canvas. Sets the mood.]
+- **Secondary surfaces** (25%): [Depth, cards, sections. Relate to dominant.]
+- **Accent** (10%): [Sharp, intentional, memorable. ONE visible accent element at a time per viewport.]
+- **Signal colors** (5%): [Success, warning, error. Functional but still on-brand.]
+
+Palette character: [WARM or COOL? NATURAL or SYNTHETIC? LOUD or QUIET?]
+
+### Typography
+- **Display font**: [The personality carrier. Must be distinctive.]
+- **Body font**: [Highly legible with character. The quiet partner.]
+- **Monospace** (if needed): [For data, code, or utilitarian accents.]
+- **Scale ratio**: [e.g., 1.25 minor third, 1.414 augmented fourth, or custom]
+- **Minimum body size**: 18px on desktop
+
+### Spacing Scale
+[Consistent values: 4px, 8px, 12px, 16px, 24px, 32px, 48px, 64px, 96px, 128px -- or project-specific scale]
+
+### Elevation and Depth
+[How depth works: shadows, layers, blur, transparency, borders. Commit to a model -- flat with sharp borders? Deep with soft shadows? Layered with frosted glass?]
+
+### Texture and Atmosphere
+[Background treatment: gradient meshes, subtle noise/grain, geometric patterns, light effects? Or clean and minimal?]
+
+*Note: Omit this section if no design direction has been established. Add it when design assets or direction become available. Even verbal descriptions of "how it should feel" belong here.*
+
+---
+
+## 11. Component Patterns
+
+| Component | Used In | Behavior |
+|-----------|---------|----------|
+| [Component] | [Screens] | [Key behavior] |
+
+---
+
+## 12. Anti-Patterns to Avoid
+
+[Project-specific anti-patterns based on the aesthetic identity. Examples:]
+- [If aesthetic is warm/organic: avoid sharp geometric grids, cold blue gradients]
+- [If aesthetic is minimal: avoid decorative elements, excessive animation]
+- [If aesthetic is bold/editorial: avoid symmetric layouts, safe color choices]
+
+*Note: Include 3-5 specific anti-patterns derived from the Design Brief. These help implementation stay on-brand.*
+
+---
+
+## 13. Open UX Questions
+
+1. [Question requiring designer/user input]
+2. [Question]
+```
+
+Notes:
+- Omit sections that have no content rather than leaving placeholders
+- Sections 1 (Design Brief), 6 (Motion), 7 (Layout), 10 (Design System), and 12 (Anti-Patterns) are optional for purely utilitarian interfaces (admin panels, internal CRUD tools) but recommended for any consumer-facing product
+- Keep flows as ASCII diagrams, not verbose prose
+- The Design Brief can be populated even without visual design assets -- it captures intent and direction
+
+### 7. Validate Output
+
+```bash
+file .spec_system/PRD/PRD_UX.md
+LC_ALL=C grep -n '[^[:print:][:space:]]' .spec_system/PRD/PRD_UX.md && echo "Non-ASCII found"
+```
+
+If checks fail, fix and re-check.
+
+## Output
+
+```
+createuxprd complete!
+
+Created:
+- .spec_system/PRD/PRD_UX.md (UX requirements)
+[If backup was made:]
+- Backup: .spec_system/archive/PRD/PRD_UX-backup-YYYYMMDD-HHMMSS.md
+
+Summary:
+- Design Brief: [populated / omitted (utilitarian)]
+- User Flows: N defined
+- Screens: N inventoried
+- Interaction Patterns: N documented
+- Motion Strategy: [populated / omitted]
+- Design System: [populated / partial / omitted]
+- Open UX Questions: N items
+
+Next Steps:
+1. Review the UX PRD and refine as needed
+2. Run plansession -- it will use both PRD.md and PRD_UX.md for UI sessions
+
+```

--- a/skills/.experimental/apex-spec/references/dockbuild.md
+++ b/skills/.experimental/apex-spec/references/dockbuild.md
@@ -1,0 +1,40 @@
+# dockbuild
+
+Run `sudo docker compose up -d --build` with full output piped to both stderr and
+stdout, then report every issue, warning, error, or notice from the build process.
+
+Note: Docker commands MAY require `sudo` if you are not in the `docker` group.
+
+## Rules
+
+1. **Report everything** - Surface ALL issues, warnings, errors, deprecation notices, update notices, and informational messages regardless of severity -- even cosmetic, expected, or harmless ones
+2. **Full output capture** - Pipe build output through `tee /dev/stderr` so nothing is lost
+3. **Read-only on spec system** - Never modify state.json, session specs, or task checklists
+4. **Sudo required** - Prefix docker commands with `sudo`
+
+## Steps
+
+### 1. Run Docker Compose build
+
+Execute:
+```bash
+sudo docker compose up -d --build 2>&1 | tee /dev/stderr
+```
+
+Capture the complete output.
+
+### 2. Verify container status
+
+Run `sudo docker compose ps` to confirm all containers are running.
+
+### 3. Report results
+
+Present:
+- The full build output
+- Final container status (name, state, ports)
+- Every warning, error, deprecation notice, update notice, or informational message found in the output -- no matter the severity level
+
+## Output
+
+The user sees the full build output followed by a summary of container status and a
+categorized list of every issue found (errors, warnings, deprecations, notices, etc.).

--- a/skills/.experimental/apex-spec/references/dockcleanbuild.md
+++ b/skills/.experimental/apex-spec/references/dockcleanbuild.md
@@ -1,0 +1,90 @@
+# dockcleanbuild
+
+Perform a full Docker cleanup and rebuild cycle: clear build cache, remove stale images,
+stop and remove the project's containers (preserving volumes/data), rebuild all images
+from scratch with no cache, bring containers back up, and clean up leftover artifacts.
+
+Note: Docker commands MAY require `sudo` if you are not in the `docker` group.
+
+## Rules
+
+1. **Preserve volumes** - Never remove Docker volumes or their data; only containers and images are cleaned
+2. **No cache on rebuild** - All image builds must use `--no-cache` to ensure a clean build
+3. **Build order matters** - Build the primary Dockerfile (repo image) first, then any secondary Dockerfiles (e.g., Dockerfile.local, Dockerfile.dev, or other customizations)
+4. **Report everything** - Surface ALL issues, warnings, errors, deprecation notices, and update notices regardless of severity -- even cosmetic or expected ones
+5. **Read-only on spec system** - Never modify state.json, session specs, or task checklists
+6. **Sudo required** - Prefix all docker/docker-compose commands with `sudo`
+
+## Steps
+
+### 1. Clean Docker build cache
+
+Run `sudo docker builder prune -af` to remove all build cache entries.
+
+Report the amount of space reclaimed.
+
+### 2. Remove stale images
+
+Run `sudo docker image prune -f` to remove dangling images.
+
+Report the number of images removed and space reclaimed.
+
+### 3. Stop and remove project containers
+
+Identify the project's Docker Compose file(s) (`docker-compose.yml`, `docker-compose.yaml`,
+`compose.yml`, `compose.yaml`, or variants).
+
+Run `sudo docker compose down` (without `-v` to preserve volumes) to stop and remove
+the project's containers and networks.
+
+Report which containers were stopped and removed.
+
+### 4. Build from source
+
+Run the project's build step if one exists (e.g., `npm run build`, `cargo build`, etc.).
+If no build step is apparent, skip this step and note it.
+
+### 5. Rebuild Docker images from scratch
+
+First, build the primary Dockerfile:
+```bash
+sudo docker compose build --no-cache
+```
+
+If additional Dockerfiles exist (e.g., `Dockerfile.local`, `Dockerfile.dev`,
+`Dockerfile.production`), build each one:
+```bash
+sudo docker build --no-cache -f <Dockerfile> -t <appropriate-tag> .
+```
+
+Report the full build output for each image, including any warnings or notices.
+
+### 6. Bring containers back up
+
+Run `sudo docker compose up -d` to start the containers in detached mode.
+
+Verify containers are running with `sudo docker compose ps`.
+
+**If any container fails to start, investigate the root cause (port conflicts,
+missing dependencies, config errors, etc.), resolve it, and retry
+`sudo docker compose up -d` until ALL containers are running or healthy.
+Do not proceed until every service is up.**
+
+Report the status of each container.
+
+### 7. Final cleanup
+
+Run `sudo docker image prune -f` to remove any intermediate or dangling images
+left over from the build process.
+
+Report the number of images cleaned and space reclaimed.
+
+## Output
+
+Provide a full report including:
+- Space reclaimed from cache and image cleanup
+- Containers stopped/removed
+- Build output for each Dockerfile (including ALL warnings, errors, notices)
+- Container status after restart
+- Final cleanup results
+- Any issues encountered at any step, no matter how minor

--- a/skills/.experimental/apex-spec/references/documents.md
+++ b/skills/.experimental/apex-spec/references/documents.md
@@ -1,0 +1,480 @@
+# documents
+
+Audit, create, and update project documentation. Documentation is code - stale docs are worse than no docs.
+
+## Rules
+
+1. **Never invent technical details** - only document what actually exists in the codebase
+2. **ASCII-only characters** and Unix LF line endings
+3. **Current over complete** - a smaller, accurate doc beats a comprehensive stale one
+4. **One source of truth** - don't duplicate information; link instead
+5. **README naming** - only root gets `README.md`; subdirectories use `README_<dirname>.md`
+6. **One command runs everything** - document it prominently in root README
+
+## Steps
+
+### 1. Get Project State (REQUIRED FIRST STEP)
+
+Run the analysis script to understand current project progress:
+
+```bash
+# Check for local scripts first, fall back to plugin
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+The JSON output includes:
+- `current_phase` - Current phase number
+- `completed_sessions` - List of completed session IDs
+- `monorepo` - true/false/null from state.json
+- `packages` - Array of registered packages (empty if not monorepo)
+- `active_package` - Resolved package context (null if not applicable)
+
+Also read:
+- `.spec_system/state.json` - Project state and phase/session progress
+- `.spec_system/PRD/PRD.md` - Product requirements for context
+
+### 2. Determine Audit Scope (Phase-Focused vs Full)
+
+Check if a phase was recently completed:
+
+1. **Identify recently completed phase**: Look at `completed_sessions` in state.json - if all sessions for a phase are complete but the next phase hasn't started, that phase was "just completed"
+2. **Collect phase artifacts**: For the completed phase, read all `implementation-notes.md` files from `.spec_system/specs/phaseNN-session*/`
+3. **Extract change manifest**: Build a list of files/directories created or modified during that phase
+
+**Phase-Focused Mode** (when a phase was just completed):
+- Prioritize documenting changes from the completed phase
+- Focus README updates on newly added packages/services
+- Update ARCHITECTURE.md with new components added in the phase
+- Still verify all standard files exist, but deep-audit only changed areas
+- **Monorepo**: Check which packages had sessions in the completed phase. Focus per-package README updates on packages that changed.
+
+**Full Audit Mode** (initial setup, major milestones, or explicit request):
+- Audit all documentation comprehensively
+- Use when: first run, after multiple phases, or user requests full audit
+- **Monorepo**: Verify all packages have README files and that root documentation covers workspace structure
+
+Report the audit mode to the user before proceeding.
+
+### 3. Audit Existing Documentation
+
+Check for the presence and quality of standard documentation files.
+
+> **Naming Convention**: `README.md` is reserved for project root only. All other README files use `README_<directory-name>.md` (e.g., `apps/web/README_web.md`).
+
+#### Root Level (Required)
+
+| File | Purpose | Check |
+|------|---------|-------|
+| `README.md` | What this is, repo map, one-command quickstart | Exists? Current? |
+| `CONTRIBUTING.md` | Branch conventions, PR rules, commit style | Exists? Current? |
+| `LICENSE` | Legal clarity | Exists? |
+
+#### /docs/ Directory
+
+```
+docs/
+|-- ARCHITECTURE.md        # System diagram, service relationships, tech stack
+|-- CODEOWNERS             # Who owns what
+|-- onboarding.md          # Zero-to-hero checklist
+|-- development.md         # Local environment, dev scripts
+|-- environments.md        # Dev/staging/prod differences
+|-- deployment.md          # CI/CD pipelines, release process
+|-- adr/                   # Architecture Decision Records
+|   \-- NNNN-title.md
+|-- runbooks/              # "If X breaks, do Y"
+|   \-- incident-response.md
+\-- api/                   # API contracts, OpenAPI links
+```
+
+#### Per-Package/Service READMEs
+
+Check for `README_<dirname>.md` in each significant directory. Pattern: `[parent]/[dirname]/README_[dirname].md`
+
+**Monorepo**: Use the `packages` array from state.json as the authoritative list of packages needing READMEs.
+
+### 4. Generate Audit Report
+
+Create a mental checklist of:
+- Missing files (need to create)
+- Stale files (need to update)
+- Redundant content (need to consolidate)
+- Wordy sections (need to trim)
+
+Report findings to the user before proceeding.
+
+### 5. Create Missing Documentation
+
+For each missing required file:
+
+1. **Check for local override**: `.spec_system/doc-templates/<filename>`
+2. **If exists**: Use local template
+3. **Otherwise**: Use default templates below
+
+> **Local templates take precedence** - same pattern as scripts.
+
+#### README.md Template
+
+```markdown
+# [PROJECT_NAME]
+
+[One-line description of what this project does]
+
+## Quick Start
+
+```bash
+# One command to run everything
+[COMMAND]
+```
+
+## Repository Structure
+
+```
+.
+|-- [dir1]/          # [Purpose]
+|-- [dir2]/          # [Purpose]
+\-- [dir3]/          # [Purpose]
+```
+
+## Documentation
+
+- [Getting Started](docs/onboarding.md)
+- [Development Guide](docs/development.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Contributing](CONTRIBUTING.md)
+
+## Tech Stack
+
+- [Technology 1] - [Why]
+
+[MONOREPO ONLY]
+## Packages
+
+| Package | Path | Description | Stack |
+|---------|------|-------------|-------|
+| [name] | [path] | [Purpose] | [Stack] |
+[END MONOREPO ONLY]
+
+## Project Status
+
+See [PRD](.spec_system/PRD/PRD.md) for current progress and roadmap.
+```
+
+#### CONTRIBUTING.md Template
+
+```markdown
+# Contributing
+
+## Branch Conventions
+
+- `main` - Production-ready code
+- `develop` - Integration branch
+- `feature/*` - New features
+- `fix/*` - Bug fixes
+
+## Commit Style
+
+Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
+
+## Pull Request Process
+
+1. Create feature branch from `develop`
+2. Make changes with clear commits
+3. Write/update tests and documentation
+4. Open PR with description
+5. Address review feedback, squash and merge
+```
+
+#### docs/ARCHITECTURE.md Template
+
+```markdown
+# Architecture
+
+## System Overview
+
+[High-level description of the system]
+
+## Dependency Graph
+
+```
+[Service A] --> [Service B] --> [Database]
+```
+
+## Components
+
+### [Component 1]
+- **Purpose**: [What it does]
+- **Tech**: [Technology used]
+- **Location**: `[path/]`
+
+## Tech Stack Rationale
+
+| Technology | Purpose | Why Chosen |
+|------------|---------|------------|
+| [Tech 1] | [Purpose] | [Rationale] |
+
+## Data Layer
+
+- **Database**: [Type, hosting, extensions]
+- **Migration Tool**: [Name, location, naming convention]
+
+## Data Flow
+
+[Describe how data moves through the system]
+
+[MONOREPO ONLY]
+## Package Dependencies
+
+| Package | Depends On | Depended By |
+|---------|-----------|-------------|
+| [name] | [list] | [list] |
+[END MONOREPO ONLY]
+
+## Key Decisions
+
+See [Architecture Decision Records](docs/adr/) for detailed decision history.
+```
+
+#### docs/onboarding.md Template
+
+```markdown
+# Onboarding
+
+## Prerequisites
+
+- [ ] [Tool 1] installed
+- [ ] [Tool 2] installed
+- [ ] Access to [System/Service]
+
+## Setup Steps
+
+1. Clone: `git clone [repo-url] && cd [project-name]`
+2. Install: `[install command]`
+3. Configure: `cp .env.example .env` (edit with your values)
+4. Start: `[start command]`
+
+## Required Secrets
+
+| Variable | Where to Get | Description |
+|----------|--------------|-------------|
+| `API_KEY` | [Location] | [Purpose] |
+
+## Verify Setup
+
+- [ ] App runs at `http://localhost:[port]`
+- [ ] Tests pass: `[test command]`
+```
+
+#### docs/development.md Template
+
+```markdown
+# Development Guide
+
+## Required Tools
+
+- [Tool 1] v[version]+
+- [Tool 2] v[version]+
+
+## Port Mappings
+
+| Service | Port | URL |
+|---------|------|-----|
+| [Service 1] | [port] | http://localhost:[port] |
+
+## Dev Scripts
+
+| Command | Purpose |
+|---------|---------|
+| `[cmd]` | [Description] |
+
+## Database
+
+1. Start: `[start command]`
+2. Migrate: `[migration command]`
+3. Seed: `[seed command]`
+4. Reset: `[reset command]`
+
+## Testing
+
+```bash
+[test command]          # Run all tests
+[coverage command]      # Run with coverage
+```
+```
+
+#### docs/environments.md Template
+
+```markdown
+# Environments
+
+| Environment | URL | Purpose |
+|-------------|-----|---------|
+| Development | localhost | Local development |
+| Staging | [url] | Pre-production testing |
+| Production | [url] | Live system |
+
+## Configuration Differences
+
+| Config | Dev | Staging | Prod |
+|--------|-----|---------|------|
+| [Setting 1] | [value] | [value] | [value] |
+
+## Required Environment Variables
+
+- `[VAR_1]`: [Description]
+```
+
+#### docs/deployment.md Template
+
+```markdown
+# Deployment
+
+## Local Dev
+
+```bash
+[one-command start]     # Start everything
+curl localhost:[port]/health  # Verify
+[stop command]          # Stop
+```
+
+## CI/CD Pipeline
+
+```
+Push --> Build --> Test --> [Staging] --> [Production]
+```
+
+## Release Process
+
+1. Merge to `main`
+2. CI runs tests and builds artifacts
+3. Deploy to staging, run smoke tests
+4. Deploy to production, verify health
+
+## Rollback
+
+```bash
+[rollback command]
+```
+
+**When to rollback**: Health check fails post-deploy, error rate spikes, or critical bug reported.
+```
+
+#### docs/adr/0000-template.md (ADR Template)
+
+```markdown
+# [Number]. [Title]
+
+**Status:** Proposed | Accepted | Deprecated | Superseded
+**Date:** YYYY-MM-DD
+
+## Context
+What prompted this decision?
+
+## Options Considered
+1. [Option A] - [pros/cons]
+2. [Option B] - [pros/cons]
+
+## Decision
+What we chose and why.
+
+## Consequences
+Trade-offs, what this enables, what it prevents.
+```
+
+#### docs/runbooks/incident-response.md Template
+
+```markdown
+# Incident Response
+
+| Level | Description | Response Time |
+|-------|-------------|---------------|
+| P0 | Complete outage | Immediate |
+| P1 | Major feature broken | < 1 hour |
+| P2 | Minor feature broken | < 4 hours |
+| P3 | Cosmetic/minor | Next business day |
+
+## Common Incidents
+
+### [Incident Type]
+**Symptoms**: [What you'll see]
+**Resolution**: [Steps to fix]
+```
+
+#### README_[dirname].md Template (Per-Package/Service)
+
+```markdown
+# [PACKAGE_NAME]
+
+[One-line description]
+
+## Usage
+
+```bash
+[import/install command]
+```
+
+## Run Commands
+
+| Command | Purpose |
+|---------|---------|
+| `[cmd]` | [Description] |
+
+## Key Dependencies
+
+- [Dependency 1] - [Why]
+```
+
+### 6. Update Existing Documentation
+
+For each existing documentation file:
+
+1. Read current content
+2. Compare against project state from `.spec_system/`
+3. Identify discrepancies: features documented but not implemented, features implemented but not documented, outdated instructions, broken links
+4. Update to reflect current state
+5. Remove redundancy and wordiness
+
+### 7. Sync with Spec System Progress
+
+Cross-reference documentation with completed sessions, current phase objectives, technical stack decisions, and architecture choices made in specs. Ensure README and ARCHITECTURE reflect actual implemented state, not planned future state.
+
+#### Phase-Focused Sync (when applicable)
+
+When in Phase-Focused Mode, use implementation-notes.md files as the primary source:
+
+1. Read all implementation notes for the completed phase
+2. Extract structured changes: files created, files modified, dependencies added, APIs changed
+3. Prioritize documentation updates based on change type:
+
+| Change Type | Documentation Action |
+|-------------|---------------------|
+| New package/service | Create README_<name>.md |
+| New API endpoints | Update docs/api/ |
+| New dependencies | Update tech stack in README, ARCHITECTURE |
+| Config changes | Update onboarding.md, environments.md |
+| New scripts | Update development.md |
+
+4. Skip deep-audit for unchanged areas - verify file exists, don't rewrite content
+
+### 8. Quality Checks
+
+For all documentation files:
+
+- **Accuracy**: All commands work, all paths exist, all links valid, version numbers current
+- **Conciseness**: No redundant sections, no verbose explanations where a command suffices
+- **Completeness**: All required files present, all sections filled in (no TODO placeholders left)
+
+### 9. Generate Documentation Report
+
+Create `.spec_system/docs-audit.md` with: audit date, project name, audit mode, a summary table (root files, /docs/ files, ADRs, package READMEs -- each with required/found/status counts), sections for files created, files updated, files verified as current, and any remaining documentation gaps requiring human input.
+
+### 10. Report to User
+
+Show files created/updated, documentation coverage, and gaps requiring human input.
+
+## Output
+
+Report: audit mode used, files created/updated, documentation coverage, gaps requiring human input, and link to `.spec_system/docs-audit.md`. If all documents are satisfactory, recommend phasebuild for the next phase.

--- a/skills/.experimental/apex-spec/references/guidance.md
+++ b/skills/.experimental/apex-spec/references/guidance.md
@@ -1,0 +1,312 @@
+# Apex Spec System Usage Guidance
+
+Practical guidance for getting the most out of the Apex Spec System.
+
+---
+
+## When to Use Apex Spec
+
+### Ideal Projects (Strong Fit)
+
+| Scenario | Why It Works |
+|----------|--------------|
+| **Greenfield development** | New projects benefit most from structured phases |
+| **From Quality Boilerplates** | This is the best! |
+| **Medium-to-large scope** | Projects spanning 3+ sessions (6+ hours total) |
+| **Solo developer + AI** | The primary design target |
+| **Well-defined requirements** | Clear enough to write a PRD, although createprd can do lifting |
+| **Learning new tech** | Structure helps when exploring unfamiliar territory |
+| **Monorepo projects** | Per-package session scoping keeps work focused |
+
+**Real example**: The NJ Title Intelligence Platform (see [walkthrough.md](walkthrough.md)) used Apex Spec to build a 4M+ parcel system across 16 phases and 79+ sessions in ~3 weeks.
+
+### Acceptable Projects (Moderate Fit)
+
+- **Feature additions** - Adding major features to existing codebases
+- **Refactoring projects** - Large-scale restructuring with clear goals
+- **Proof of concepts** - When you want documentation of decisions
+
+### Poor Fit (Consider Alternatives)
+
+| Scenario | Why It Doesn't Fit |
+|----------|-------------------|
+| **Quick bug fixes** | Overhead exceeds value for <1 hour tasks |
+| **Exploratory prototyping** | Constant pivoting conflicts with session structure |
+| **Team projects with existing workflows** | May conflict with established processes |
+| **Urgent/time-critical work** | Structure adds latency |
+
+### Quick Self-Assessment
+
+**Use Apex Spec if you answer YES to 2+ of these:**
+
+- [ ] Have you started AI-assisted projects that lost coherence after a few sessions?
+- [ ] Do you find yourself re-explaining context to Claude repeatedly?
+- [ ] Do your projects lack documentation because "you'll do it later"?
+- [ ] Have you shipped code without proper testing/linting setup?
+- [ ] Do you want a repeatable process for AI-assisted development?
+
+**Skip Apex Spec if:**
+
+- The task will take less than 2 hours total
+- You're not sure what you're building yet
+- You need to ship something in the next hour
+- Your team has a working process already
+
+---
+
+## Workflow
+
+The project is initiated, then iterates through phases. Each phase consists of sessions. Between phases, the system is hardened.
+
+### Start a Project
+
+Ran once at the beginning of the project.
+
+```
+initspec -> createprd -> createuxprd (optional) -> phasebuild
+```
+
+**Artifacts created:**
+- PRD.md (master requirements document)
+- state.json
+- Folder structure and templates
+- 1st Phase and Sessions
+
+### Session
+
+Ran repeatedly until all the sessions of the Phase are completed.
+
+```
+plansession -> implement -> validate -> updateprd
+```
+
+**Artifacts created:**
+- spec.md (detailed specification)
+- tasks.md (12-25 task checklist)
+- implementation-notes.md (progress log)
+- security-compliance.md (security & GDPR review)
+- validation.md (quality verification)
+- IMPLEMENTATION_SUMMARY.md (completion record)
+
+### Between Phases
+
+Ran once after all sessions of a Phase are completed, between each Phase.
+
+```
+audit -> pipeline -> infra -> carryforward -> documents -> phasebuild
+```
+
+**Artifacts created:**
+- CONSIDERATIONS.md
+- CONVENTIONS.md
+- SECURITY-COMPLIANCE.md
+- Documentation, potentially .github workflows, etc
+- Next Phase and Sessions
+
+---
+
+## Team Usage Patterns
+
+Apex Spec is designed for **solo developer + AI** workflows. However, teams can adapt the system with these patterns.
+
+### Pattern 1: Shared PRD, Individual Sessions
+
+```
+Team                          Individual
+-----                         ----------
+Collaborate on PRD     ->     Developer claims session
+Define phases          ->     Runs session workflow solo
+Review phase structure ->     Commits via standard git
+                       ->     carryforward captures lessons
+```
+
+**Coordination**: Add `Assigned: @username` to session stub files in PRD.
+
+**Merge strategy**: Standard git workflow - each developer works on their branch, PRs for review.
+
+### Pattern 2: Pair Programming with AI
+
+```
+Developer A (Driver)          Developer B (Navigator)
+--------------------          -------------------------
+Runs Claude commands          Reviews output
+Executes implementation       Catches issues early
+Marks tasks complete          Suggests improvements
+```
+
+**Benefits**:
+- Knowledge transfer
+- Real-time review
+- Reduced errors
+- Shared context
+
+### Pattern 3: Review Checkpoints
+
+```
+Developer                     Team
+---------                     ----
+Complete session       ->
+validate              ->     Review validation.md
+                       <-     Feedback
+Incorporate feedback   ->
+updateprd             ->     Merge approved
+```
+
+**Adds human review gate** before marking sessions complete.
+
+### What Apex Spec Does NOT Handle
+
+| Need | Solution |
+|------|----------|
+| Real-time collaboration | Use other tools (VS Code Live Share, etc.) |
+| Session conflict resolution | Coordinate via PRD assignment |
+| Team velocity tracking | Use external tools |
+| Cross-session dependencies between developers | Plan in PRD, communicate |
+
+### Team Best Practice
+
+Treat Apex Spec as a **personal workflow tool** that produces **shareable artifacts**:
+- specs, tasks, validation reports are reviewable
+- implementation-notes.md provides context
+- CONSIDERATIONS.md captures institutional memory
+- SECURITY-COMPLIANCE.md tracks cumulative security posture and GDPR compliance
+- Git commits provide natural integration points
+
+---
+
+## Monorepo Usage
+
+### When Monorepo Support Helps
+
+| Scenario | Why |
+|----------|-----|
+| Multiple packages with different stacks | Per-package tool validation and session scoping |
+| Large codebase with clear boundaries | Sessions stay focused on one package at a time |
+| Shared libraries consumed by multiple apps | Cross-cutting sessions handle shared code |
+| Different deploy targets per package | `infra` and `pipeline` adapt per deployable unit |
+
+### Session Scoping Best Practices
+
+**Prefer single-package sessions.** Most sessions should target one package. This keeps scope tight and makes validation straightforward.
+
+**Use cross-cutting sessions sparingly.** Reserve `package: null` sessions for work that genuinely spans packages:
+- Initial project scaffolding and workspace config
+- Shared type definitions consumed by multiple packages
+- CI/CD pipeline setup
+- Integration tests between services
+
+**Order sessions by dependency.** If `apps/web` needs types from `packages/shared`, plan the shared session first (lower session number within the phase).
+
+**Scope task paths to the package.** Task file paths should use full repo-root-relative paths:
+```
+- [ ] T001 [S0102] Create auth module (`apps/web/src/auth/index.ts`)
+```
+Not:
+```
+- [ ] T001 [S0102] Create auth module (`src/auth/index.ts`)
+```
+
+### Package Context Flow
+
+You do not need to remember to specify the package every time. The system resolves it automatically:
+
+1. **From session stubs**: `phasebuild` annotates stubs with `Package: apps/web`
+2. **From spec.md**: Once planned, the spec header carries the package context
+3. **From user input**: Say "plan for apps/web" during `plansession`
+4. **As fallback**: Claude prompts you to select from the packages list
+
+### Monorepo + Team Patterns
+
+Combine monorepo support with team patterns for larger projects:
+
+```
+Developer A                    Developer B
+-------------                  -------------
+Claims session for apps/web    Claims session for apps/api
+Runs session workflow solo     Runs session workflow solo
+Both share same state.json     Both share same .spec_system/
+```
+
+**Coordination tip**: Assign sessions by package ownership. Add `Assigned: @username` and `Package: apps/web` to session stub files. This prevents conflicts.
+
+---
+
+## Future Enhancements
+
+The following features are under consideration but require implementation work:
+
+### Metrics Tracking (Not Yet Implemented)
+
+**Concept**: Track session duration, task counts, and estimation accuracy over time.
+
+```
+metrics
+
+Session Velocity:
+- Average session duration: 2.3 hours
+- Estimation accuracy: 92%
+- Total sessions completed: 5
+```
+
+**Status**: Would require state.json schema changes and new metrics command.
+
+### Project Templates (Not Yet Implemented)
+
+**Concept**: Pre-configured PRD structures for common project types.
+
+```
+initspec --template cli
+initspec --template web-app
+initspec --template api-server
+```
+
+**Status**: Would require template files and initspec command changes.
+
+### Export Capabilities (Not Yet Implemented)
+
+**Concept**: Generate shareable status reports.
+
+```
+export --format markdown
+export --format html
+```
+
+**Status**: Would require new export command.
+
+---
+
+## Quick Reference
+
+### Command Cheat Sheet
+
+| Goal | Command |
+|------|---------|
+| Start new project | `initspec` |
+| Generate PRD from requirements | `createprd "description"` or `createprd @file.md` |
+| Generate UX PRD from design docs | `createuxprd "description"` or `createuxprd @file.md` |
+| Create phase structure | `phasebuild` |
+| Analyze, spec, and generate tasks | `plansession` |
+| Implement tasks | `implement` |
+| Verify completion | `validate` |
+| Mark session complete | `updateprd` |
+| Add dev tooling | `audit` |
+| Add CI/CD | `pipeline` |
+| Add infrastructure | `infra` |
+| Update documentation | `documents` |
+| Capture lessons & security posture | `carryforward` |
+
+### Session Limits
+
+| Limit | Value |
+|-------|-------|
+| Maximum tasks | 25 |
+| Maximum duration | 4 hours |
+| Ideal task count | 12-25 (sweet spot: 20) |
+| Ideal duration | 2-3 hours |
+| Objectives | Single clear objective |
+
+### Recovery
+
+Every `updateprd` commits and pushes. Git is your safety net:
+- Undo completed session: `git revert <commit>`
+- Mid-session issues: Resume `implement` or delete session directory

--- a/skills/.experimental/apex-spec/references/implement.md
+++ b/skills/.experimental/apex-spec/references/implement.md
@@ -1,0 +1,298 @@
+# implement
+
+Execute each task in the session's task list, updating progress as you go.
+
+## RULES
+
+1. **Make NO assumptions.** Before editing, read the relevant code and comments; pattern-match precisely, validate systematically.
+2. **Follow `CONVENTIONS.md`.** All code must follow project-specific coding standards.
+3. **ASCII-only characters** and Unix LF line endings in all output.
+4. **Never lie and implement exactly what's in the spec** -- no lying, no extra features, no refactoring unrelated code.
+5. **Update `tasks.md` immediately** after completing each task -- never batch checkbox updates.
+6. **Write tests as specified** -- ensure they pass before moving on.
+7. **Ensure logging and error handling** -- no silent failures.
+8. **Prefer cohesive, moderately sized modules** -- avoid multi-thousand-line god files; if a file grows beyond ~400-600 LOC or multiple responsibilities, schedule a refactor.
+9. **Behavioral correctness over speed** - Code must handle edge cases, cleanup, and failure paths before a task is marked done. A checked task with a behavioral bug costs 10x more to find in a later audit.
+
+### No Deferral Policy
+
+- NEVER mark a task as "pending", "requires X", or "blocked" if the blocker is something YOU can resolve
+- If a service needs to be running, START IT (e.g., `docker compose up -d db`)
+- If a dependency needs installing, INSTALL IT
+- If a directory needs creating, CREATE IT
+- "The environment isn't set up" is NOT a blocker -- setting it up IS the task
+- The ONLY valid blocker is something that requires USER input or credentials you don't have
+- If you skip a task that was executable, that is a **critical failure**
+
+## Steps
+
+### 1. Get Deterministic Project State (REQUIRED FIRST STEP)
+
+Run the analysis script to get reliable state facts. Local scripts (`.spec_system/scripts/`) take precedence over plugin scripts if they exist:
+
+```bash
+# Check for local scripts first, fall back to skill directory
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+This returns structured JSON including:
+- `current_session` - The session to implement
+- `current_session_dir_exists` - Whether specs directory exists
+- `current_session_files` - Files already in the session directory
+- `monorepo` - true/false/null from state.json
+- `packages` - Array of registered packages (empty if not monorepo)
+- `active_package` - Resolved package context (null if not applicable)
+
+**IMPORTANT**: Use the `current_session` value from this output. If `current_session` is `null`, run plansession yourself to set one up. Only ask the user if that command requires user input.
+
+### 1a. Determine Package Context (Monorepo Only)
+
+**Skip this step if** `monorepo` is not `true` in the JSON output.
+
+Resolve the active package for this session:
+
+1. **spec.md header**: Read the `Package:` field from the session's spec.md (set during plansession)
+2. **active_package from script**: If spec.md has no Package field, use `active_package` from the JSON output
+3. **Prompt user**: If neither resolves a package, ask the user which package this session targets (or whether it is cross-cutting)
+
+Store the resolved package path for use in Steps 2, 4, and 5. A `null` package means this is a cross-cutting session.
+
+### 2. Verify Environment Prerequisites (REQUIRED)
+
+Run the prerequisite checker to verify the environment is ready. Use the same local-first pattern:
+
+```bash
+# Check for local scripts first, fall back to skill directory
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/check-prereqs.sh --json --env
+else
+  bash scripts/check-prereqs.sh --json --env
+fi
+```
+
+This verifies:
+- `.spec_system/` directory and `state.json` are valid
+- `jq` is installed (required for scripts)
+- `git` availability (optional)
+
+**Monorepo**: If a package was resolved in Step 1a, add `--package <path>` to verify package-specific prerequisites and workspace tooling:
+
+```bash
+# Example: check-prereqs.sh --json --env --package apps/web
+```
+
+**If any environment check fails**: FIX the issues yourself. Install missing tools, create missing directories, start required services. The ONLY reason to stop is if you need credentials or input only the user can provide.
+
+**Optional - Tool Verification**: After reading spec.md (next step), if the Prerequisites section lists required tools, also run:
+
+```bash
+# Check for local scripts first, fall back to skill directory
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/check-prereqs.sh --json --tools "tool1,tool2,tool3"
+else
+  bash scripts/check-prereqs.sh --json --tools "tool1,tool2,tool3"
+fi
+```
+
+This catches missing tools BEFORE implementation starts, preventing mid-session failures.
+
+**Optional - Database Prerequisites**: If `.spec_system/CONVENTIONS.md` has a "Database Layer" section, verify:
+1. Database service is running (`docker compose ps` or connection test)
+2. Migrations are current (no pending migrations)
+If checks fail, resolve them (start services, run migrations) before proceeding.
+
+### 3. Read Session Context
+
+Using the `current_session` value from the script output, read:
+- `.spec_system/specs/[current-session]/spec.md` - Full specification
+- `.spec_system/specs/[current-session]/tasks.md` - Task checklist
+- `.spec_system/specs/[current-session]/implementation-notes.md` - Progress log (if exists)
+- `.spec_system/specs/[current-session]/security-compliance.md` - Prior security report (if exists from previous validation run)
+- `.spec_system/CONVENTIONS.md` - Project coding conventions (if exists)
+
+**Resuming?** If `implementation-notes.md` and completed tasks already exist, read them to understand current state and resume from the next incomplete task.
+
+### 3a. Load Behavioral Quality Checklist (BQC)
+
+BQC applies when the session produces application code (not pure configuration, documentation, or infrastructure-as-code). If the session is entirely non-code work, skip to Step 4.
+
+---
+
+#### Behavioral Quality Checklist
+
+**Mandatory edge-case checklist** -- verify applicable items before marking EACH task complete:
+
+- [ ] **Resource cleanup**: Every resource acquired in a scoped lifecycle is released when that scope ends. No leaked timers, dangling subscriptions, unclosed connections, or orphaned async tasks.
+- [ ] **Duplicate action prevention**: Every state-mutating operation is protected against duplicate triggers while in-flight. No double-submits, no unguarded retries, no concurrent write races.
+- [ ] **State freshness on re-entry**: When a context is re-entered (reopened, revisited, reconnected, retried), state is explicitly reset or revalidated. No stale data from a prior lifecycle.
+- [ ] **Trust boundary enforcement**: All inputs crossing a trust boundary are validated with explicit schema or type checks, and all access is authorized at the enforcement point closest to the protected resource. Never trust upstream callers.
+- [ ] **Failure path completeness**: Every operation that can fail has an explicit, caller-visible failure path. No silent swallows, no blank screens, no infinite spinners, no generic 500s.
+- [ ] **Concurrency safety**: Shared mutable state accessed from multiple execution contexts is protected against races. No unguarded read-modify-write sequences.
+- [ ] **External dependency resilience**: Every call to an external system has a timeout, a retry/backoff strategy, and a defined failure path. No unbounded waits.
+- [ ] **Contract alignment**: Interfaces between components match their declared contracts. Response shapes match client types. Event payloads match schemas. Enum handling is exhaustive.
+- [ ] **Error information boundaries**: Errors exposed to external callers reveal only stable, intentional information. No stack traces, internal paths, or secrets in responses or logs.
+- [ ] **Accessibility and platform compliance**: Interactive elements participate in the platform's accessibility model with appropriate labels, focus management, and input method support.
+
+**How to apply**: After each task, check ONLY the items relevant to the code you touched. A task adding a timed background operation must satisfy resource cleanup + failure path. A task adding a write endpoint must satisfy duplicate prevention + trust boundaries + error information boundaries. A task adding an interactive dialog must satisfy state freshness + accessibility. Not every item applies to every task -- but every item applies somewhere.
+
+### 4. Initialize Implementation Notes
+
+If `implementation-notes.md` doesn't exist, create it:
+
+```markdown
+# Implementation Notes
+
+**Session ID**: `phaseNN-sessionNN-name`
+[MONOREPO ONLY - include when monorepo: true]
+**Package**: [package-path]
+[END MONOREPO ONLY]
+**Started**: [YYYY-MM-DD HH:MM]
+**Last Updated**: [YYYY-MM-DD HH:MM]
+
+---
+
+## Session Progress
+
+| Metric | Value |
+|--------|-------|
+| Tasks Completed | 0 / N |
+| Estimated Remaining | X hours |
+| Blockers | 0 |
+
+---
+
+## Task Log
+
+### [YYYY-MM-DD] - Session Start
+
+**Environment verified**:
+- [x] Prerequisites confirmed
+- [x] Tools available
+- [x] Directory structure ready
+[IF DATABASE SESSION]
+- [x] Database running
+- [x] Migrations current
+[END IF]
+
+---
+```
+
+### 5. Work Through Tasks
+
+For each incomplete task:
+
+#### A. Identify Next Task
+Find the first unchecked `- [ ]` task in tasks.md
+
+#### B. Implement Task
+- Read the task description carefully
+- Read surrounding code to match existing patterns before writing new code
+- Follow the spec's technical approach and CONVENTIONS.md standards
+- If `docs/adr/` exists, review relevant Architecture Decision Records and follow their decisions
+- Implement the required changes
+- **Monorepo path validation**: If a package was resolved in Step 1a, verify that files being created or modified fall within the declared package directory (e.g., `apps/web/...`). Warn if a task references files outside the package scope -- this may indicate scope creep. Exception: cross-cutting sessions (package: null) may touch any file.
+- **Behavioral quality verification** (if BQC loaded in Step 3a): Before marking this task complete, scan your code against the applicable checklist items. Fix violations now -- do not defer. Note any BQC fixes in the task log entry (Step 5D).
+
+#### C. Update Task Status
+In `tasks.md`, change:
+```markdown
+- [ ] T001 [S0101] Task description
+```
+To:
+```markdown
+- [x] T001 [S0101] Task description
+```
+
+#### D. Log Progress
+Add to `.spec_system/specs/[current-session]/implementation-notes.md`:
+```markdown
+### Task TNNN - [Description]
+
+**Started**: [YYYY-MM-DD HH:MM]
+**Completed**: [YYYY-MM-DD HH:MM]
+**Duration**: [X] minutes
+
+**Notes**:
+- [Implementation details]
+- [Decisions made]
+
+**Files Changed**:
+- `path/to/file` - [changes made]
+
+**BQC Fixes** (if any):
+- [Category]: [What was caught and fixed] (`path/to/file`)
+
+[MONOREPO ONLY - include if any files fall outside the declared package scope]
+**Out-of-Scope Files** (files outside declared package):
+- `other-package/path/file` - [justification]
+[END MONOREPO ONLY]
+```
+
+### 6. Handle Blockers
+
+If you encounter an obstacle, RESOLVE IT YOURSELF before documenting:
+
+- **Service not running?** Start it (e.g., `docker compose up -d db`)
+- **Dependency missing?** Install it
+- **Directory missing?** Create it
+- **Config file missing?** Generate it from the spec
+- **Database not running?** Start it (`docker compose up -d [service]`)
+- **Migrations pending?** Run migration tool to apply them
+- **Connection refused?** Check `DATABASE_URL` in `.env`, verify port
+- **"The environment isn't set up"** is NOT a blocker -- setting it up IS the task
+
+The ONLY valid reason to pause and ask the user is when you need credentials, API keys, or decisions only a human can make. If you skip a task that was executable, that is a **critical failure**.
+
+After resolving, document in implementation-notes.md:
+```markdown
+## Blockers & Solutions
+
+### Blocker N: [Title]
+
+**Description**: [What was blocking]
+**Impact**: [Which tasks affected]
+**Resolution**: [How YOU resolved it]
+**Time Lost**: [Duration]
+```
+
+### 7. Track Design Decisions
+
+When making implementation choices:
+
+```markdown
+## Design Decisions
+
+### Decision N: [Title]
+
+**Context**: [Why decision needed]
+**Options Considered**:
+1. [Option A] - [pros/cons]
+2. [Option B] - [pros/cons]
+
+**Chosen**: [Option]
+**Rationale**: [Why]
+```
+
+### 8. Track Progress and Checkpoint
+
+After each task:
+- Update Progress Summary table in tasks.md
+- Update implementation-notes.md
+- Report status to user: tasks done (X of Y), next task
+
+**Checkpoint every 3-5 tasks minimum** and before any risky operations. If approaching context limits, document current state and next task in implementation-notes.md.
+
+## Output
+
+When all tasks complete:
+```
+Session implementation complete!
+Tasks: N/N (100%)
+BQC: [X] fixes applied across [Y] tasks [or "N/A - no application code in session"]
+
+Run the validate workflow step to verify session completeness.
+```

--- a/skills/.experimental/apex-spec/references/infra.md
+++ b/skills/.experimental/apex-spec/references/infra.md
@@ -1,0 +1,343 @@
+# infra
+
+Add and validate production infrastructure one bundle at a time.
+
+## Rules
+
+1. **One bundle per run** - add one, validate all
+2. **Stack agnostic** - read platform from CONVENTIONS.md, adapt
+3. **Document manual steps** - only for things that genuinely require UI access or sudo you don't have
+4. **Don't store secrets** - document required env vars, don't create them
+5. **Validate everything** - verify infra actually works, not just exists
+6. **Respect known-issues.md** - skip items marked as manual-only
+
+### No Deferral Policy
+
+- NEVER mark a task as "pending", "requires X", or "blocked" if the blocker is something YOU can resolve
+- If a service needs to be running, START IT (e.g., `docker compose up -d db`)
+- If a dependency needs installing, INSTALL IT
+- If a config file needs generating, GENERATE IT
+- "The environment isn't set up" is NOT a blocker -- setting it up IS the task
+- The ONLY valid blocker is something that requires USER input, credentials you don't have, or sudo access
+- If you skip a task that was executable, that is a **critical failure**
+
+## Master List (4 Bundles)
+
+Industry standard order (availability to automation):
+
+| Priority | Bundle | Contents |
+|----------|--------|----------|
+| 1 | **Health** | /health endpoint + platform probes |
+| 2 | **Security** | WAF rules + rate limiting |
+| 3 | **Backup** | DB backup + storage + retention policy |
+| 4 | **Deploy** | CD webhook/trigger from main branch |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | false | Preview what would happen without changes |
+| `--skip-install` | false | Don't create configs or scripts |
+| `--verbose` | false | Show full command output |
+
+## Flow
+
+### Step 1: DETECT
+
+1. Check for `.spec_system/CONVENTIONS.md`
+   - If missing: Run initspec yourself to create it. Only ask the user if initspec requires user input you don't have.
+   - Read Infrastructure table for configured components
+   - Identify: CDN, hosting platform, database, cache, backup, deploy
+
+2. Read `.spec_system/state.json` for monorepo context:
+   - `monorepo` field: `true` / `false` / `null`
+   - `packages` array (when `monorepo: true`): each entry has `name`, `path`, `type`, `stack`
+
+3. Detect infrastructure from existing files/configs:
+   - `wrangler.toml` = Cloudflare
+   - `docker-compose.yml`, `coolify.json` = Coolify/Docker
+   - `vercel.json` = Vercel
+   - `fly.toml` = Fly.io
+   - Terraform/Pulumi files = IaC detected
+   - **Monorepo**: Also check for per-package infra configs (e.g., `apps/web/vercel.json`, `apps/api/fly.toml`, `apps/api/Dockerfile`)
+
+4. Check for `.spec_system/audit/known-issues.md`
+   - Load Skipped Infra section
+   - Note: "Known issues loaded (N infra items skipped)"
+
+5. If `--dry-run`: Skip to Dry Run Output
+
+### Step 1a: Identify Deployment Topology (Monorepo Only)
+
+**Skip this step if** `monorepo` is not `true` in state.json.
+
+When `monorepo: true`, classify each package by deployment role:
+
+1. **Deployable units**: Packages with `type` of frontend, backend, or service -- these need their own health endpoints, deploy triggers, and potentially their own backup/security configs
+2. **Shared libraries**: Packages with `type` of library -- these are built and consumed by other packages, not deployed independently
+3. **Shared infrastructure**: Components used by multiple packages (e.g., a single database, shared cache) -- configured once at repo level
+
+Example deployment topology:
+```
+Deployment topology (monorepo: true):
+| Package | Path | Type | Deploys Independently | Platform |
+|---------|------|------|-----------------------|----------|
+| web | apps/web | Frontend | Yes | Vercel |
+| api | apps/api | Backend | Yes | Coolify |
+| shared | packages/shared | Library | No | (built only) |
+
+Shared infra: PostgreSQL (apps/api), Valkey cache (apps/api)
+```
+
+### Step 2: COMPARE
+
+Compare Infrastructure table against 4-bundle master list:
+- Health: Is there a /health endpoint? Platform probe configured?
+- Security: WAF rules present? Rate limiting configured?
+- Backup: Backup script/job exists? Storage configured?
+- Deploy: CD trigger configured?
+
+Build list of missing bundles in priority order.
+
+If all bundles configured: "All infrastructure configured. Jumping to Step 5 to Validate."
+
+### Step 3: SELECT
+
+Pick the highest-priority missing bundle from Step 2.
+
+Output: "Selected: [Bundle Name] - not yet configured"
+
+### Step 4: IMPLEMENT
+
+Add configuration for the selected bundle.
+
+**Stack-agnostic implementations:**
+
+| Bundle | Component | Implementation varies by platform |
+|--------|-----------|-----------------------------------|
+| Health | Endpoint | FastAPI, Express, Go handler, etc. |
+| Health | Probe | Coolify, Kubernetes, ECS, Vercel, etc. |
+| Security | WAF | Cloudflare, AWS WAF, Vercel Firewall |
+| Security | Rate Limit | slowapi, express-rate-limit, in-platform |
+| Backup | Script | pg_dump, mongodump, mysqldump |
+| Backup | Storage | R2, S3, GCS, local |
+| Backup | Schedule | Cron, GitHub Actions, platform scheduler |
+| Deploy | Trigger | Webhook, Git push, platform integration |
+
+**Monorepo implementation strategy** (when `monorepo: true`):
+
+Use the deployment topology from Step 1a to scope each bundle:
+
+- **Health**: Each deployable package gets its own `/health` endpoint. Shared libraries do not need health endpoints.
+- **Security**: WAF/rate limiting applies per deployable package. Shared WAF rules go at CDN level if all packages share a domain; per-package if separate domains.
+- **Backup**: Scope to databases -- if all packages share one DB, one backup script. If packages have separate databases, per-database backups.
+- **Deploy**: Each deployable package gets its own deploy trigger. Shared libraries trigger rebuilds of dependent packages (handled by CI, not infra).
+
+**Single-repo**: All bundles apply to the single deployment target.
+
+**Implementation by detected stack:**
+
+**Health Bundle:**
+```python
+# FastAPI example
+@app.get("/health")
+async def health():
+    return {
+        "status": "healthy",
+        "database": await check_db(),
+        "cache": await check_cache(),
+        "timestamp": datetime.utcnow().isoformat()
+    }
+```
+
+1. Create /health endpoint in detected framework
+2. Add DB and cache connectivity checks
+3. Configure platform health probe (if platform detected)
+4. **Monorepo**: Repeat for each deployable package using its stack. Skip library packages.
+
+**Security Bundle:**
+1. If Cloudflare: Document WAF ruleset to enable (OWASP Core)
+2. Add rate limiting middleware to application
+3. Document rate limit configuration
+4. **Monorepo**: Add rate limiting per deployable package using its framework's middleware
+
+**Backup Bundle:**
+1. Create backup script for detected database
+2. Configure storage destination
+3. Create schedule (cron or GitHub Action)
+4. Document retention policy
+5. **Monorepo**: If packages use separate databases, create per-database backup scripts. Note which package owns which database.
+6. Verify backup: restore to ephemeral DB and run a sanity query to confirm data integrity
+
+**Deploy Bundle:**
+1. Configure webhook URL (Coolify, Render, etc.)
+2. Or configure Git-based deploy (Vercel, Netlify)
+3. Add deploy step to release workflow
+4. Document rollback procedure (platform revert, previous image tag, or git revert + redeploy)
+5. **Monorepo**: Configure per-package deploy triggers. Ensure shared library changes trigger dependent package deploys.
+
+**Local Dev Environment** (verified alongside Deploy bundle):
+1. If `docker-compose.yml` or `compose.yml` exists, verify `docker compose up -d` brings all services to healthy state
+2. If no compose file but the project has services (DB, cache, queue), document the local start procedure in CONVENTIONS.md
+3. Verify the app responds locally (e.g., `curl http://localhost:[port]/health`)
+4. Record the local start command in CONVENTIONS.md Infrastructure table: `| Local Dev | [command] | [details] |`
+
+### Step 5: VALIDATE
+
+Verify all configured infrastructure:
+
+1. **Health**: `curl` the /health endpoint, verify 200 + JSON
+2. **Security**: Verify rate limiting works (test with rapid requests)
+3. **Backup**: Verify backup runs, check storage for recent backup
+4. **Deploy**: Trigger test deploy or verify webhook connectivity
+
+**Monorepo**: Validate each deployable package independently. A health check failing in one package does not skip validation of others. Report per-package results.
+
+**Validation commands by component:**
+
+| Component | Validation |
+|-----------|------------|
+| Health endpoint | `curl -f https://domain.com/health` |
+| Rate limiting | Rapid requests should get 429 |
+| Backup | Check storage for file < 24h old; optionally restore to ephemeral DB and run sanity query |
+| Deploy webhook | `curl -X POST webhook_url` (dry-run if possible) |
+| Local dev | `docker compose up -d` + `curl http://localhost:[port]/health` |
+| Rollback | Verify documented rollback procedure is executable |
+
+### Step 6: FIX
+
+For each validation failure:
+
+1. **Health endpoint missing**: Create it (Step 4)
+2. **Health returns error**: Fix DB/cache connectivity
+3. **Rate limiting not working**: Check middleware order, config
+4. **Backup missing/stale**: Run backup manually, fix schedule
+5. **Deploy webhook fails**: Verify URL, check platform logs
+
+**After 3 failed attempts**: Try a different approach entirely. Only log for manual review if the fix requires sudo, platform UI access, or credentials you don't have.
+
+Filter out items in known-issues.md Skipped Infra section.
+
+### Step 7: RECORD
+
+Update `.spec_system/CONVENTIONS.md` Infrastructure table:
+
+```markdown
+| Component | Provider | Details |
+|-----------|----------|---------|
+| CDN/DNS | Cloudflare | - |
+| WAF | Cloudflare | OWASP ruleset enabled |
+| Hosting | Coolify | 8GB VPS |
+| Database | PostgreSQL 16 | Coolify-managed |
+| Backup | R2 | pg_dump, daily, 7-day retention |
+| Deploy | Coolify webhook | On push to main |
+```
+
+**Monorepo only**: When packages have different deployment targets, add a Package column to distinguish per-package infra:
+
+```markdown
+| Component | Package | Provider | Details |
+|-----------|---------|----------|---------|
+| CDN/DNS | (shared) | Cloudflare | - |
+| Hosting | apps/web | Vercel | Git-based deploy |
+| Hosting | apps/api | Coolify | Docker, 8GB VPS |
+| Database | apps/api | PostgreSQL 16 | Coolify-managed |
+| Health | apps/web | Vercel | Automatic (serverless) |
+| Health | apps/api | Coolify | /health, 30s interval |
+| Deploy | apps/web | Vercel | On push to main |
+| Deploy | apps/api | Coolify webhook | On push to main |
+```
+
+Use `(shared)` for components that serve multiple packages.
+
+### Step 8: REPORT
+
+**Single-repo:**
+```
+REPORT
+- Added: Health bundle
+- Created: src/api/health.py
+- Configured: Coolify health probe (HTTP, /health, 30s interval)
+- Validated: Endpoint returns 200, DB check passes, cache check passes
+- Response time: 45ms
+
+Platform notes:
+- Coolify probe configured via UI (manual step documented)
+```
+
+**Monorepo:**
+```
+REPORT
+- Added: Health bundle
+
+[apps/api] Health: /health endpoint created (FastAPI)
+  - Configured: Coolify probe (HTTP, /health, 30s)
+  - Validated: 200 OK, DB pass, cache pass (45ms)
+
+[apps/web] Health: Automatic (Vercel serverless)
+  - Validated: 200 OK (120ms)
+
+[packages/shared] Skipped (library, not deployed)
+```
+
+**If secrets/manual steps required:**
+```
+Required setup:
+1. In Coolify dashboard, set health check path to /health
+2. Set health check interval to 30 seconds
+3. Enable "Restart on unhealthy" option
+```
+
+### Step 9: RECOMMEND
+
+- **Validation failures remain**: List required actions, prompt rerun of infra
+- **Bundles remain**: Note remaining bundles, recommend rerun of infra
+- **All 4 bundles configured and validated**: Recommend documents
+
+## Dry Run Output
+
+```
+INFRA PREVIEW (DRY RUN)
+
+Stack detected:
+- CDN: Cloudflare
+- Platform: Coolify
+- Database: PostgreSQL 16
+- Cache: Valkey
+
+Configured: Health, Security
+Missing: Backup, Deploy
+
+Would add: Backup
+Would create: scripts/backup.sh
+Would configure: Cron schedule (daily 02:00 UTC)
+Would store: Cloudflare R2 (bucket: backups)
+
+Required setup:
+- R2_ACCESS_KEY_ID in environment
+- R2_SECRET_ACCESS_KEY in environment
+
+Run without --dry-run to apply.
+```
+
+## Platform-Specific Notes
+
+**Cloudflare:**
+- WAF rules configured via dashboard or Terraform
+- Document which rulesets to enable
+- R2 for backup storage
+
+**Coolify:**
+- Health probes configured via UI
+- Webhook URL available in deployment settings
+- Supports Docker and static deploys
+
+**Vercel:**
+- Health checks automatic for serverless
+- Rate limiting via Edge Config or middleware
+- Git-based deploys, no webhook needed
+
+**AWS/ECS:**
+- Health checks via target group
+- WAF via AWS WAF
+- Backups via RDS snapshots or custom scripts

--- a/skills/.experimental/apex-spec/references/initspec.md
+++ b/skills/.experimental/apex-spec/references/initspec.md
@@ -1,0 +1,499 @@
+# initspec
+
+Set up the complete `.spec_system/` directory structure and initial files for a new or existing project.
+
+## Rules
+
+1. **Never overwrite existing `.spec_system/state.json`** without explicit user confirmation
+2. **ASCII-only characters** (0-127) in all generated files
+3. **Unix LF line endings** only
+4. **Minimal structure** - don't over-engineer the initial setup
+
+## Steps
+
+### 1. Check Current State
+
+First, check if the spec system is already initialized:
+- Look for `.spec_system/state.json`
+- Check for `.spec_system/PRD/` directory
+- Check for `.spec_system/specs/` directory
+
+If already initialized, ask the user if they want to reinitialize (this will reset state).
+
+### 2. Gather Project Information
+
+Ask the user for:
+- **Project name**: Name of the project
+- **Project description**: Brief description of what the project does
+- **First phase name**: Name for Phase 00 (default: "Foundation")
+
+### 3. Create Directory Structure
+
+Create the following directories:
+
+```bash
+mkdir -p .spec_system/PRD/phase_00
+mkdir -p .spec_system/specs
+mkdir -p .spec_system/audit
+mkdir -p .spec_system/archive/backups
+mkdir -p .spec_system/archive/sessions
+mkdir -p .spec_system/archive/planning
+mkdir -p .spec_system/archive/PRD
+mkdir -p .spec_system/archive/phases
+```
+
+### 3a. Brownfield Monorepo Detection
+
+Detect whether the project is a monorepo. **Skip this step entirely for greenfield (empty) projects** -- leave `monorepo: null` in state.json.
+
+For brownfield projects (existing code present):
+
+1. Source common.sh and call `detect_monorepo()` to check for workspace config files (pnpm-workspace.yaml, turbo.json, nx.json, package.json workspaces, Cargo.toml workspace, go.work, lerna.json)
+
+2. If `detect_monorepo()` returns `detected: true`:
+   - Display the detected indicator and discovered packages to the user
+   - Ask the user to **confirm**, **edit** (add/remove packages), or **skip** (leave as null)
+   - **Confirmed**: Set `monorepo: true` and store the packages array in state.json (Step 4)
+   - **Edited**: Set `monorepo: true` with user-adjusted packages array
+   - **Skipped**: Leave `monorepo: null` -- can be resolved later by createprd
+
+3. If `detect_monorepo()` returns `detected: false`:
+   - Leave `monorepo: null` (do NOT set to false here -- createprd may detect monorepo intent from PRD content)
+
+**Important**: Never set `monorepo: false` during initspec. Only `null` (unknown) or `true` (confirmed). The createprd workflow step handles the `false` determination.
+
+### 4. Create state.json
+
+Create `.spec_system/state.json`:
+
+```json
+{
+  "version": "2.0",
+  "project_name": "[PROJECT_NAME]",
+  "description": "[PROJECT_DESCRIPTION]",
+  "current_phase": 0,
+  "current_session": null,
+  "monorepo": null,
+  "phases": {
+    "0": {
+      "name": "[PHASE_NAME]",
+      "status": "not_started",
+      "session_count": 0
+    }
+  },
+  "completed_sessions": [],
+  "next_session_history": []
+}
+```
+
+**If monorepo confirmed in Step 3a**, set `"monorepo": true` and add the packages array:
+
+```json
+{
+  "monorepo": true,
+  "packages": [
+    {"name": "web", "path": "apps/web", "stack_hint": "TypeScript"},
+    {"name": "api", "path": "apps/api", "stack_hint": "TypeScript"}
+  ]
+}
+```
+
+Otherwise, `"monorepo": null` and no `packages` field.
+
+### 5. Create PRD Template
+
+Create `.spec_system/PRD/PRD.md` with a starter template:
+
+```markdown
+# [PROJECT_NAME] - Product Requirements Document
+
+## Overview
+
+[PROJECT_DESCRIPTION]
+
+## Goals
+
+1. [Goal 1]
+2. [Goal 2]
+3. [Goal 3]
+
+## Phases
+
+| Phase | Name | Sessions | Status |
+|-------|------|----------|--------|
+| 00 | [PHASE_NAME] | TBD | Not Started |
+
+## Phase 00: [PHASE_NAME]
+
+### Objectives
+
+1. [Objective 1]
+2. [Objective 2]
+
+### Sessions (To Be Defined)
+
+Use plansession to get recommendations for sessions to implement.
+
+## Technical Stack
+
+- [Technology 1]
+- [Technology 2]
+
+## Success Criteria
+
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+```
+
+### 6. Create CONSIDERATIONS.md
+
+Create `.spec_system/CONSIDERATIONS.md` (institutional memory for AI assistants):
+
+```markdown
+# Considerations
+
+> Institutional memory for AI assistants. Updated between phases via carryforward.
+> **Line budget**: 600 max | **Last updated**: Phase 00 (YYYY-MM-DD)
+
+---
+
+## Active Concerns
+
+Items requiring attention in upcoming phases. Review before each session.
+
+### Technical Debt <!-- Max 5 items -->
+*None yet - add items as technical debt accumulates.*
+
+### External Dependencies <!-- Max 5 items -->
+*None yet - add items when external API/service risks are identified.*
+
+### Performance / Security <!-- Max 5 items -->
+*None yet - add items when thresholds or security requirements emerge.*
+
+### Architecture <!-- Max 5 items -->
+*None yet - add items when architectural constraints are discovered.*
+
+---
+
+## Lessons Learned
+
+Proven patterns and anti-patterns. Reference during implementation.
+
+### What Worked <!-- Max 15 items -->
+*None yet - add patterns that prove effective.*
+
+### What to Avoid <!-- Max 10 items -->
+*None yet - add anti-patterns discovered during implementation.*
+
+### Tool/Library Notes <!-- Max 5 items -->
+*None yet - add key insights about tools and libraries.*
+
+---
+
+## Resolved
+
+Recently closed items (buffer - rotates out after 2 phases).
+
+| Phase | Item | Resolution |
+|-------|------|------------|
+| - | *No resolved items yet* | - |
+
+*Auto-generated by initspec. Updated by carryforward between phases.*
+```
+
+### 7. Create SECURITY-COMPLIANCE.md
+
+Create `.spec_system/SECURITY-COMPLIANCE.md` (cumulative security posture and GDPR compliance record):
+
+```markdown
+# Security & Compliance
+
+> Cumulative security posture and GDPR compliance record. Updated between phases via carryforward.
+> **Line budget**: 1000 max | **Last updated**: Phase 00 (YYYY-MM-DD)
+
+---
+
+## Current Security Posture
+
+### Overall: CLEAN
+
+| Metric | Value |
+|--------|-------|
+| Open Findings | 0 |
+| Critical/High | 0 |
+| Medium/Low | 0 |
+| Phases Audited | 0 |
+| Last Clean Phase | -- |
+
+## Open Findings
+
+### Critical / High
+*No open findings.*
+
+### Medium / Low
+*No open findings.*
+
+## GDPR Compliance Status
+
+### Overall: N/A
+
+### Personal Data Inventory
+*No personal data collected or processed.*
+
+### Compliance Checklist
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Data collection has documented purpose | N/A | No data collection yet |
+| Consent obtained before data storage | N/A | No data collection yet |
+| Data minimization verified | N/A | No data collection yet |
+| Deletion/erasure path exists | N/A | No data collection yet |
+| No PII in application logs | N/A | No logging yet |
+| Third-party transfers documented | N/A | No external services yet |
+
+## Dependency Security
+*No dependencies audited yet.*
+
+## Resolved Findings
+*No resolved findings yet.*
+
+## Phase History
+
+| Phase | Sessions | Security | GDPR | Findings Opened | Findings Closed |
+|-------|----------|----------|------|-----------------|-----------------|
+| -- | -- | -- | -- | -- | -- |
+
+## Recommendations
+*None -- initial setup. Security review begins with first validate run.*
+
+*Auto-generated by initspec. Updated by carryforward between phases.*
+```
+
+### 8. Create CONVENTIONS.md
+
+Create `.spec_system/CONVENTIONS.md` (coding standards and team conventions):
+
+```markdown
+# CONVENTIONS.md
+
+## Guiding Principles
+
+- Optimize for readability over cleverness
+- Code is written once, read many times
+- Consistency beats personal preference
+- If it can be automated, automate it
+- When writing code: Make NO assumptions. Do not be lazy. Pattern match precisely. Do not skim when you need detailed info from documents. Validate systematically.
+
+## Naming
+
+- Be descriptive over concise: `getUserById` > `getUser` > `fetch`
+- Booleans read as questions: `isActive`, `hasPermission`, `shouldRetry`
+- Functions describe actions: `calculateTotal`, `validateInput`, `sendNotification`
+- Avoid abbreviations unless universally understood (`id`, `url`, `config` are fine)
+- Match domain language--use the same terms as product/design/stakeholders
+
+## Files & Structure
+
+- One concept per file where practical
+- File names reflect their primary export or purpose
+- Group by feature/domain, not by type (prefer `/orders/api.ts` over `/api/orders.ts`)
+- Keep nesting shallow--if you're 4+ levels deep, reconsider
+
+## Functions & Modules
+
+- Functions do one thing
+- If a function needs a comment explaining what it does, consider renaming it
+- Keep functions short enough to read without scrolling
+- Avoid side effects where possible; be explicit when they exist
+
+## Comments
+
+- Explain *why*, not *what*
+- Delete commented-out code--that's what git is for
+- TODOs include context: `// TODO(name): reason, ticket if applicable`
+- Update or remove comments when code changes
+
+## Error Handling
+
+- Fail fast and loud in development
+- Fail gracefully in production
+- Errors should be actionable--include context for debugging
+- Don't swallow errors silently
+
+## Database Layer
+
+### Connection
+- Connection string source: [env var name -- never hardcoded]
+- Pool size: [N]; separate URLs for: app, migrations, tests
+
+### Migrations
+- Tool: [detected] | Location: [path] | Naming: [pattern]
+- CRITICAL: Never modify a migration already applied to shared environments
+- Every migration must have a reverse/down
+
+### Models / Schema
+- Location: [path] | Naming: [convention] | Required columns: [timestamps, soft delete, etc.]
+
+### Queries
+- Parameterized only (no string concatenation)
+- N+1 prevention: [chosen approach] | Transaction boundaries: [when to wrap]
+
+### Seeding
+- Script: [path] | Must be idempotent (safe to re-run)
+
+### Testing
+- Strategy: [separate DB / transaction rollback / in-memory] | Fixtures: [path]
+
+### Vector / Embeddings (if applicable)
+- Store: [pgvector / standalone] | Model: [name + dimensions]
+- Index: [HNSW / IVFFlat] | Distance: [cosine / L2 / inner product]
+
+## Testing
+
+- Test behavior, not implementation
+- A test's name should describe the scenario and expectation
+- If it's hard to test, the design might need rethinking
+- Flaky tests get fixed or deleted--never ignored
+
+## Git & Version Control
+
+- Commit messages: imperative mood, concise (`Add user validation` not `Added some validation stuff`)
+- One logical change per commit
+- Branch names: `type/short-description` (e.g., `feat/user-auth`, `fix/cart-total`)
+- Keep commits atomic enough to revert safely
+
+## Pull Requests
+
+- Small PRs get better reviews
+- Description explains the *what* and *why*--reviewers can see the *how*
+- Link relevant tickets/context
+- Review your own PR before requesting others
+
+## Code Review
+
+- Critique code, not people; ask questions rather than make demands
+- Approve when it's good enough, not perfect; label nitpicks as such
+
+## Dependencies
+
+- Fewer dependencies = less risk
+- Justify additions; prefer well-maintained, focused libraries
+- Pin versions; update intentionally
+
+## Local Dev Tools
+
+| Category | Tool | Config |
+|----------|------|--------|
+| Formatter | not configured | - |
+| Linter | not configured | - |
+| Type Safety | not configured | - |
+| Testing | not configured | - |
+| Observability | not configured | - |
+| Git Hooks | not configured | - |
+| Database | not configured | - |
+
+**Conditional**: The "Database Layer" section above is only included when DB signals are detected during brownfield initspec (docker-compose with DB service, `.env` with `DATABASE_URL`, migration tool config files present). For greenfield projects, this section is deferred to createprd.
+
+## When In Doubt
+
+- Ask
+- Leave it better than you found it
+- Ship, learn, iterate
+```
+
+**If monorepo confirmed in Step 3a**, append a Workspace Structure section to CONVENTIONS.md:
+
+```markdown
+## Workspace Structure
+
+| Package | Path | Stack |
+|---------|------|-------|
+| [name] | [path] | [stack_hint] |
+
+### Cross-Package Rules
+
+- Import from sibling packages via workspace aliases, not relative paths
+- Shared types live in a dedicated shared/common package
+- Each package owns its own tests; integration tests live at repo root
+- Changes spanning multiple packages require explicit cross-package session scope
+
+### Database Ownership
+| Database | Owner Package | Type | Shared By |
+| [name] | [package path] | [type] | [consumers] |
+
+- Migrations live in the owner package
+- Consuming packages use the owner's API, not direct DB access
+```
+
+### 9. Create Phase PRD
+
+Create `.spec_system/PRD/phase_00/PRD_phase_00.md`:
+
+```markdown
+# Phase 00: [PHASE_NAME]
+
+**Status**: Not Started
+**Progress**: 0/0 sessions (0%)
+
+## Overview
+
+[Phase description - to be filled in]
+
+## Progress Tracker
+
+| Session | Name | Status | Validated |
+|---------|------|--------|-----------|
+| - | No sessions defined | - | - |
+
+## Next Steps
+
+Run plansession to get the first session recommendation.
+```
+
+### 10. Copy Scripts Locally (Optional)
+
+Ask user: "Copy scripts locally for customization, or use skill scripts (recommended)?"
+
+- **Skill** (default): `scripts/` directory bundled with this skill - auto-updates with skill
+- **Local**: `.spec_system/scripts/` - per-project customization, won't auto-update
+
+If user wants local scripts:
+
+```bash
+mkdir -p .spec_system/scripts
+cp scripts/*.sh .spec_system/scripts/
+chmod +x .spec_system/scripts/*.sh
+```
+
+### 11. Report Success
+
+Tell the user:
+
+```
+Apex Spec System initialized!
+
+Created:
+- .spec_system/state.json (project state tracking)
+- .spec_system/PRD/PRD.md (product requirements document)
+- .spec_system/PRD/phase_00/PRD_phase_00.md (phase tracker)
+- .spec_system/CONSIDERATIONS.md (institutional memory for AI)
+- .spec_system/SECURITY-COMPLIANCE.md (security posture & GDPR compliance)
+- .spec_system/CONVENTIONS.md (coding standards and team conventions)
+- .spec_system/specs/ (session specifications directory)
+- .spec_system/audit/ (audit reports directory)
+- .spec_system/archive/ (completed work archive)
+
+[If monorepo detected and confirmed:]
+Monorepo: Detected via [indicator] with N packages
+[If monorepo not detected:]
+Monorepo: Not detected (can be set later via createprd)
+
+Next Steps:
+1. Edit .spec_system/PRD/PRD.md with your project requirements
+2. Customize .spec_system/CONVENTIONS.md with your project's coding standards (optional but recommended)
+3. Run phasebuild to define sessions for Phase 00 (recommended for new projects)
+   OR run plansession directly if you already know your first session
+4. Follow the workflow: plansession -> implement -> validate -> updateprd
+5. Repeat step 4 until all sessions in the phase are complete
+6. Run carryforward (optional) to capture lessons learned, then phasebuild for next phase
+```

--- a/skills/.experimental/apex-spec/references/phasebuild.md
+++ b/skills/.experimental/apex-spec/references/phasebuild.md
@@ -1,0 +1,273 @@
+# phasebuild
+
+Create the directory structure, phase PRD, and session stubs for a new phase. Ensures alignment with completed work and lessons learned.
+
+## Rules
+
+1. **ASCII-only characters** and Unix LF line endings in all output
+2. **Resolve misalignment before building** - as projects progress, later phases may drift from reality. Reconcile with actual progress before creating artifacts.
+3. **If interrupted mid-process**, delete partial artifacts before retrying
+4. Each session must have a single clear objective, 12-25 tasks, 2-4 hours scope
+
+## Steps
+
+### 1. Assess Current State
+
+Read `.spec_system/state.json` and `.spec_system/PRD/` to understand:
+- What has been accomplished
+- Next sequential phase number
+- High-level objectives remaining
+
+If `.spec_system/CONSIDERATIONS.md` exists, review it for:
+- **Active Concerns** that should influence session ordering or scope
+- **Lessons Learned** (patterns to follow or avoid)
+- **Tool/Library Notes** relevant to this phase
+
+If `.spec_system/SECURITY-COMPLIANCE.md` exists, review it for:
+- **Open Findings** that should be addressed in this phase's sessions
+- **GDPR Status** that may affect data-handling session scope
+
+**Monorepo Checkpoint** (skip if `monorepo` is already `true` or `false`):
+- If the PRD references multiple packages/services but `state.json` has no `packages` array, alert the user:
+  ```
+  Warning: PRD references multiple packages but monorepo is not configured.
+  Consider running createprd to detect and configure monorepo settings,
+  or manually update state.json with monorepo: true and a packages array.
+  ```
+- This is advisory only -- do not block phase creation
+
+### 2. Create Phase Directory and PRD Markdown
+
+Create directory `.spec_system/PRD/phase_NN/` and markdown `.spec_system/PRD/phase_NN/PRD_phase_NN.md`:
+
+```markdown
+# PRD Phase NN: Phase Name
+
+**Status**: Not Started
+**Sessions**: N (initial estimate)
+**Estimated Duration**: X-Y days
+
+**Progress**: 0/N sessions (0%)
+
+---
+
+## Overview
+
+[Phase description]
+
+---
+
+## Progress Tracker
+
+| Session | Name | Status | Est. Tasks | Validated |
+|---------|------|--------|------------|-----------|
+| 01 | [Name] | Not Started | ~12-25 | - |
+| 02 | [Name] | Not Started | ~12-25 | - |
+| 03 | [Name] | Not Started | ~12-25 | - |
+| ... | ... | ... | ... | ... |
+
+---
+
+## Completed Sessions
+
+[None yet]
+
+---
+
+## Upcoming Sessions
+
+- Session 01: [Name]
+
+---
+
+## Objectives
+
+1. [Primary objective]
+2. [Secondary objective]
+3. [Tertiary objective]
+
+---
+
+## Prerequisites
+
+- Phase NN-1 completed (omit for Phase 01)
+- [Other prerequisites]
+
+---
+
+## Technical Considerations
+
+### Architecture
+[Architecture notes for this phase]
+
+### Technologies
+- [Technology 1]
+- [Technology 2]
+
+### Risks
+- [Risk 1]: [Mitigation]
+
+### Relevant Considerations
+<!-- From CONSIDERATIONS.md - remove section if none apply -->
+- [P##] **[Item from Active Concerns]**: How it affects this phase
+- [P##] **[Lesson Learned]**: How we're applying it
+
+---
+
+## Success Criteria
+
+Phase complete when:
+- [ ] All N sessions completed
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+---
+
+## Dependencies
+
+### Depends On
+- Phase NN-1: [Name]
+
+### Enables
+- Phase NN+1: [Name]
+```
+
+### 3. Create All Session Stubs
+
+For each session, create `session_NN_name.md` (use `snake_case` for name):
+
+.spec_system/PRD/phase_NN/
+|-- PRD_phase_NN.md
+|-- session_01_name.md
+|-- session_02_name.md
+\-- ...
+
+```markdown
+# Session NN: Session Name
+
+**Session ID**: `phaseNN-sessionNN-name`
+**Status**: Not Started
+**Estimated Tasks**: ~12-25
+**Estimated Duration**: 2-4 hours
+
+---
+
+## Objective
+
+[Clear single objective for this session]
+
+---
+
+## Scope
+
+### In Scope (MVP)
+- [Feature 1]
+- [Feature 2]
+
+### Out of Scope
+- [Deferred item 1]
+
+---
+
+## Prerequisites
+
+- [ ] [Prerequisite 1]
+
+---
+
+## Deliverables
+
+1. [Deliverable 1]
+2. [Deliverable 2]
+
+---
+
+## Success Criteria
+
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+```
+
+**Monorepo package annotation** (only when `monorepo: true` in state.json):
+
+Add a `Package:` or `Packages:` line to the stub header, after the Session ID line:
+- Single-package session: `**Package**: apps/web`
+- Multi-package session: `**Packages**: apps/web, apps/api`
+- Cross-cutting or single-repo: omit the line entirely
+
+This annotation is parsed by `analyze-project.sh` to enable `--package` filtering and package-scoped workflows.
+
+**Cross-package guidance**: When a session touches multiple packages, note which package owns the primary deliverables and which are secondary dependencies. Keep cross-package sessions to 2-3 packages maximum -- split if more are needed.
+
+### 4. Update State
+
+Merge into `.spec_system/state.json` (add to existing `phases` object):
+
+```json
+{
+  "phases": {
+    "NN": {
+      "name": "Phase Name",
+      "description": "Phase description",
+      "status": "not_started",
+      "session_count": N
+    }
+  }
+}
+```
+
+### 5. Update Master PRD
+
+Add the new phase to the Phases table in `.spec_system/PRD/PRD.md`. Also update any stale info (completed phases marked as such, session counts reflecting reality):
+
+```markdown
+## Phases
+
+| Phase | Name | Sessions | Status |
+|-------|------|----------|--------|
+| ... | ... | ... | ... |
+| NN | Phase Name | N | Not Started |
+```
+
+## Phase Planning Guidelines
+
+### Session Count
+- Typical phase: 4-8 sessions
+- Small phase: 2-3 sessions
+- Large phase: Consider splitting
+
+### Session Sizing
+- Each session: 12-25 tasks
+- Each session: 2-4 hours
+- Single clear objective per session
+
+### Dependency Management
+- Sessions within phase can depend on each other
+- Early sessions provide foundation
+- Later sessions build complexity
+
+## Output
+
+Report to user:
+
+```
+Phase NN Created: Phase Name
+
+Structure:
+- .spec_system/PRD/phase_NN/
+  - PRD_phase_NN.md
+  - session_01_name.md
+  - session_02_name.md
+  - session_03_name.md
+
+State Updated:
+- Phase added to .spec_system/state.json
+- Master PRD updated
+
+Sessions Defined: N
+
+Next Steps:
+- Review session definitions
+- Adjust scope as needed
+- Run plansession to begin
+```

--- a/skills/.experimental/apex-spec/references/pipeline.md
+++ b/skills/.experimental/apex-spec/references/pipeline.md
@@ -1,0 +1,407 @@
+# pipeline
+
+Add and validate CI/CD workflows one bundle at a time.
+
+## Billing Failures
+
+CI failures can be caused by **billing/usage limits** (e.g., exhausted GitHub Actions minutes), not code issues. If CI fails and you suspect a billing issue, **run the equivalent steps locally** to validate. If local runs pass, treat the bundle as validated and proceed. Note in the REPORT that validation was done locally.
+
+## Rules
+
+1. **One bundle per run, one run per phase** - add one workflow, validate all. Bundles accumulate across phases as the project matures.
+2. **GitHub Actions first** - GitLab CI noted but limited support
+3. **Respect known-issues.md** - skip workflows marked as flaky
+4. **Document secrets, never create them** - just document requirements
+5. **3-minute timeout** - if CI still running, report and exit
+6. **Monorepo aware** - matrix builds or path filters
+7. **PR-aware** - check and fix open PRs with failing CI or pending reviews
+8. **Address reviews** - apply code changes from review comments when actionable
+9. **Questions need humans** - flag review questions for manual response, don't guess
+
+### No Deferral Policy
+
+- NEVER mark a task as "pending", "requires X", or "blocked" if the blocker is something YOU can resolve
+- If a dependency needs installing, INSTALL IT
+- If a workflow file needs creating, CREATE IT
+- If a config needs generating, GENERATE IT
+- "The environment isn't set up" is NOT a blocker -- setting it up IS the task
+- The ONLY valid blocker is something that requires USER input, credentials/secrets you don't have, or sudo access
+- If you skip a task that was executable, that is a **critical failure**
+
+## Master List (5 Bundles)
+
+Industry standard order (fast feedback to comprehensive):
+
+| Priority | Bundle | Contents |
+|----------|--------|----------|
+| 1 | **Code Quality** | Lint + format check + type check |
+| 2 | **Build & Test** | Build + unit tests + coverage reporting |
+| 3 | **Security** | Secrets scanning (gitleaks) + SAST/CodeQL + dependency review |
+| 4 | **Integration** | E2E tests + integration tests + DB migration dry-run |
+| 5 | **Operations** | Failure notifications + Dependabot/Renovate + release tagging + deploy trigger + post-deploy smoke test |
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | false | Preview what would happen without changes |
+| `--skip-install` | false | Don't create workflow files |
+| `--verbose` | true | Show full CI output |
+| `--pr <number>` | none | Focus on specific PR (fix CI failures, address reviews) |
+
+## Flow
+
+### Step 1: DETECT
+
+1. Check for `.spec_system/CONVENTIONS.md`
+   - If missing: Run initspec yourself to create it. Only ask the user if initspec requires user input you don't have.
+   - Read Stack section for languages/runtimes
+   - Read CI/CD section for platform and configured workflows
+   - Read Workspace Structure table (if present) for package list and stacks
+
+2. Read `.spec_system/state.json` for monorepo context:
+   - `monorepo` field: `true` / `false` / `null`
+   - `packages` array (when `monorepo: true`): each entry has `name`, `path`, `type`, `stack`
+
+3. Detect CI platform from existing files:
+   - `.github/workflows/` = GitHub Actions
+   - `.gitlab-ci.yml` = GitLab CI (note: limited support)
+   - If none: Default to GitHub Actions
+
+4. Check for open PRs with CI issues:
+   ```bash
+   gh pr list --state open --json number,title,statusCheckRollup,reviewDecision
+   ```
+   - Identify PRs with failing checks
+   - Identify PRs with requested changes
+   - If `--pr <number>` specified, focus on that PR
+
+5. Check for `.spec_system/audit/known-issues.md`
+   - Load Skipped Workflows section
+   - Note: "Known issues loaded (N workflows skipped)"
+
+6. If `--dry-run`: Skip to Dry Run Output
+
+### Step 1a: Determine Workflow Strategy (Monorepo Only)
+
+**Skip this step if** `monorepo` is not `true` in state.json.
+
+When `monorepo: true`, determine the CI/CD strategy based on workspace structure:
+
+1. **Identify workspace manager**: Check for turbo.json, nx.json, pnpm-workspace.yaml, Cargo.toml workspace, go.work
+2. **Determine trigger strategy**:
+   - **Path filters**: Workflows trigger only when files in the relevant package change. Use when packages are independent or loosely coupled.
+   - **Matrix builds**: A single workflow runs jobs for each package. Use when packages share the same language/toolchain.
+   - **Task runner delegation**: Delegate to turbo/nx/cargo which handles caching and dependency ordering. Use when a workspace task runner is present.
+3. **Map package dependencies**: If package B depends on package A, changes to A must trigger CI for both A and B
+
+Example workflow strategy:
+```
+Monorepo CI strategy:
+- Task runner: turbo (detected)
+- Trigger: path filters per package + shared paths trigger all
+- Quality: turbo run lint typecheck (handles per-package)
+- Test: turbo run test (handles per-package with caching)
+- Shared paths: packages/shared/**, .github/**, package.json
+```
+
+### Step 2: COMPARE
+
+Compare CI/CD table in CONVENTIONS.md against 5-bundle master list:
+- Check Bundle column for "configured" vs "not configured"
+- Scan `.github/workflows/` for existing workflow files
+- Build list of missing bundles in priority order
+
+If all bundles configured: "All CI/CD workflows configured. Jumping to Step 5"
+
+### Step 3: SELECT
+
+Pick the highest-priority missing bundle from Step 2.
+
+Output: "Selected: [Bundle Name] - not yet configured"
+
+### Step 4: IMPLEMENT
+
+Generate workflow file(s) for the selected bundle.
+
+**Workflow templates by bundle:**
+
+| Bundle | Workflow File | Triggers |
+|--------|---------------|----------|
+| Code Quality | `.github/workflows/quality.yml` | push, pull_request |
+| Build & Test | `.github/workflows/test.yml` | push, pull_request |
+| Security | `.github/workflows/security.yml` | push, pull_request, schedule |
+| Integration | `.github/workflows/integration.yml` | pull_request (to main) |
+| Operations | `.github/workflows/release.yml` + `deploy.yml` + dependabot.yml | push to main, tags |
+
+**Monorepo workflow generation** (when `monorepo: true`):
+
+- **With task runner (turbo/nx)**: Use the task runner as the build orchestrator. It handles per-package execution, caching, and dependency ordering automatically.
+  ```yaml
+  # Example: turbo-based quality workflow
+  jobs:
+    quality:
+      steps:
+        - run: pnpm install
+        - run: pnpm turbo run lint typecheck
+  ```
+- **Without task runner**: Use path filters per package to trigger targeted jobs, plus a shared trigger for common files.
+  ```yaml
+  # Example: path-filtered triggers
+  on:
+    push:
+      paths:
+        - 'apps/web/**'
+        - 'packages/shared/**'    # shared dependency
+        - '.github/workflows/**'  # workflow changes
+  ```
+- **Mixed stacks**: Use matrix strategy to run language-specific jobs per package.
+  ```yaml
+  # Example: matrix for mixed stacks
+  strategy:
+    matrix:
+      include:
+        - package: apps/web
+          lang: node
+          commands: "biome ci && vitest run"
+        - package: apps/api
+          lang: python
+          commands: "ruff check . && pytest"
+  ```
+- **Cross-package dependencies**: Changes to shared packages (type: library) must trigger CI for all dependent packages. Map these via workspace config or the `packages` array in state.json.
+
+**Single-repo**: Generate standard single-target workflows.
+
+**Language-specific jobs** (from CONVENTIONS.md Stack):
+
+| Language | Quality | Build & Test | Security |
+|----------|---------|--------------|----------|
+| Python | ruff check, ruff format --check, mypy | pytest --cov | CodeQL, gitleaks, pip-audit |
+| TypeScript | biome ci | vitest run --coverage | CodeQL, gitleaks, npm audit |
+| Rust | cargo fmt --check, cargo clippy | cargo test | cargo audit |
+| Go | gofmt -d, golangci-lint | go test | govulncheck |
+
+**Database migration testing** (when migration tool detected in CONVENTIONS.md):
+- Add DB service to integration workflow (PostgreSQL, MySQL, etc. matching project's DB type)
+- Migration validation steps: run all migrations from scratch, run down migrations (verify rollback), run up again (verify idempotency)
+- Optionally run seed script to verify seed data loads against fresh schema
+- Scope: Add to Integration bundle workflow (`.github/workflows/integration.yml`)
+
+**Deployment workflow** (when Operations bundle is selected):
+- Create `.github/workflows/deploy.yml` triggered on push to main (after tests pass)
+- If the infra workflow step has configured a deploy target (webhook, Git-based, or platform integration), wire it into the workflow
+- Add a post-deploy smoke test step: `curl -f https://[production-url]/health` (or equivalent health endpoint)
+- If smoke test fails, the workflow should report failure (rollback is manual unless platform supports automatic rollback)
+- If no deploy target is configured yet, generate a placeholder workflow with a `TODO` comment and document in REPORT
+- **Monorepo**: Create per-package deploy jobs (triggered by path filters) or a single orchestrated deploy using the task runner
+
+1. Generate workflow YAML with appropriate jobs
+2. **Monorepo**: Include path filters, matrix strategy, or task runner delegation as determined in Step 1a
+3. Commit and push to current branch
+4. If secrets required, document in output (don't create secrets)
+
+### Step 5: VALIDATE
+
+Trigger and monitor CI:
+
+1. Push triggers workflows
+2. Poll `gh run list --limit 5` for up to 3 minutes
+3. Check status of ALL workflows, not just the new one
+4. `gh run view <id> --log` for failures
+
+**If `--pr` specified or open PRs detected:**
+
+1. Check PR CI status:
+   ```bash
+   gh pr checks <number>
+   ```
+
+2. Get PR review comments:
+   ```bash
+   gh pr view <number> --json reviews,comments
+   ```
+
+3. Identify actionable items:
+   - Failing CI checks on PR branch
+   - Review comments requesting changes
+   - Unresolved review threads
+
+**If CI fails due to billing/usage limits** (see Billing Failures above):
+- Run the workflow's steps locally (lint, test, build, etc.) to validate
+- If local runs pass, treat as validated and continue to Step 7
+
+**If still running after 3 minutes:**
+```
+CI still running. Validate locally and proceed.
+```
+
+### Step 6: FIX
+
+**For CI failures:**
+
+1. Parse error logs from `gh run view --log`
+2. Identify failing file and line
+3. Attempt fix locally
+4. Commit, push, re-poll
+
+**For each category:**
+- **Lint/format errors**: Run local tools with fix flag, commit
+- **Type errors**: Attempt fix, verify locally first
+- **Test failures**: Attempt fix, run locally to verify
+- **Security findings**: Evaluate severity, fix or add to known-issues.md
+
+**For PR review comments** (when `--pr` or PRs detected):
+
+1. Fetch review comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{number}/comments
+   ```
+
+2. For each actionable comment:
+   - Parse file path and line number from comment
+   - Read the code context
+   - Apply the requested change
+   - Commit with message: "Address review: <summary>"
+
+3. For review threads:
+   - Group related comments by thread
+   - Address the root issue
+   - Reply to confirm resolution (if possible via API)
+
+**Review comment categories:**
+- **Code style**: Apply formatting/naming changes
+- **Logic issues**: Fix bugs or improve implementation
+- **Missing tests**: Add requested test cases
+- **Documentation**: Add/update comments or docs
+- **Questions**: If clarification needed, note in report for manual response
+
+**After 3 failed attempts per issue**: Try a completely different approach. Only log for manual review if the fix requires secrets, platform access, or credentials you don't have.
+
+Filter out workflows in known-issues.md Skipped Workflows section.
+
+### Step 7: RECORD
+
+Update `.spec_system/CONVENTIONS.md` CI/CD table:
+
+```markdown
+| Bundle | Status | Workflow |
+|--------|--------|----------|
+| Code Quality | configured | .github/workflows/quality.yml |
+| Build & Test | configured | .github/workflows/test.yml |
+| Security | not configured | - |
+```
+
+**Monorepo only**: If workflows use per-package triggers or matrix builds, note the strategy in the table:
+
+```markdown
+| Bundle | Status | Workflow | Strategy |
+|--------|--------|----------|----------|
+| Code Quality | configured | quality.yml | turbo run lint typecheck |
+| Build & Test | configured | test.yml | matrix (per-package) |
+```
+
+### Step 8: REPORT
+
+```
+REPORT
+- Added: Code Quality workflow
+- File: .github/workflows/quality.yml
+- Jobs: lint (ruff), format (ruff), typecheck (mypy)
+- Fixed: 23 lint errors, 8 format issues
+- Remaining: 0
+- CI Status: All workflows passing
+
+Required setup (if any):
+- Add CODECOV_TOKEN to repository secrets for coverage upload
+```
+
+**For PRs** (when `--pr` or PRs addressed):
+```
+REPORT
+- PR #42: "Add user authentication"
+- CI Status: All checks passing (was: 3 failing)
+- Fixed: 2 type errors, 1 test failure
+- Reviews addressed: 4 comments resolved
+- Remaining reviews: 1 (question - needs manual response)
+- Review status: Changes requested -> Ready for re-review
+```
+
+**For monorepos:**
+```
+[apps/web] Quality: passing | Test: 2 failures
+[apps/api] Quality: passing | Test: passing
+```
+
+### Step 9: RECOMMEND
+
+- **CI failures remain**: List required actions, validate locally and fix within this run
+- **PR has unresolved items**: Report status, note what needs manual response
+- **PR is ready**: Confirm all checks passing and reviews addressed, recommend merge
+- **Bundles remain**: Note which bundle comes next (it will be added in a future phase's pipeline run)
+- **All 5 bundles configured and passing**: Recommend infra
+
+## Dry Run Output
+
+```
+PIPELINE PREVIEW (DRY RUN)
+
+Repository: monorepo (Turborepo)
+Platform: GitHub Actions
+Stack: Python 3.12, TypeScript
+
+Configured: Code Quality, Build & Test
+Missing: Security, Integration, Operations
+
+Would add: Security
+Would create: .github/workflows/security.yml
+Would include: gitleaks, CodeQL (python, typescript), dependency review
+
+Open PRs with issues:
+- #42 "Add auth" - 2 failing checks, 3 review comments
+- #38 "Fix bug" - 1 failing check
+
+Required secrets:
+- None for this bundle
+
+Run without --dry-run to apply.
+```
+
+**With `--pr 42`:**
+```
+PIPELINE PREVIEW (DRY RUN) - PR #42
+
+PR: #42 "Add user authentication"
+Branch: feature/auth -> main
+CI Status: 2 failing (quality, test)
+Reviews: 3 comments (2 actionable, 1 question)
+
+Would fix:
+- src/auth.ts:23 - type error (missing null check)
+- src/auth.ts:45 - lint error (unused import)
+- tests/auth.test.ts - failing assertion
+
+Would address reviews:
+- src/auth.ts:30 - "Add error handling" (actionable)
+- src/auth.ts:52 - "Rename variable" (actionable)
+- src/auth.ts:67 - "Why this approach?" (question - manual response needed)
+
+Run without --dry-run to apply.
+```
+
+## Secrets Handling
+
+When a workflow requires secrets:
+
+1. Generate workflow file with secret references
+2. Document required secrets in REPORT
+3. Workflow will fail until secrets configured
+
+```
+Required setup:
+1. Add CODECOV_TOKEN to repository secrets
+2. Add SLACK_WEBHOOK_URL for failure notifications
+
+Workflows will fail until secrets are configured.
+```
+
+Do NOT attempt to create or manage secrets.

--- a/skills/.experimental/apex-spec/references/plansession.md
+++ b/skills/.experimental/apex-spec/references/plansession.md
@@ -1,0 +1,469 @@
+# plansession
+
+Analyze project state, recommend the next session, create its specification, and generate the task checklist -- all in one step.
+
+## Rules
+
+1. **Script first** - Always run `analyze-project.sh --json` before any analysis
+2. **Trust the script** - Use JSON output as authoritative state; do not parse `state.json` directly
+3. **One session at a time** - Only recommend one session
+4. **Respect dependencies** - Don't skip prerequisites
+5. **MVP focus** - Recommend core features before polish
+6. **Scope discipline** - Sessions must be 12-25 tasks, 2-4 hours
+7. **Hard limits**: max 25 tasks, max 4 hours, single clear objective
+8. **Do not invent scope** - derive everything from PRD and session stub
+9. **Incorporate CONVENTIONS.md** - naming, file structure, and testing philosophy must be reflected in the spec
+10. **Incorporate CONSIDERATIONS.md** - address relevant active concerns and lessons learned
+11. **ASCII-only characters** and Unix LF line endings in all output
+12. **Task sizing**: ~20-25 minutes each, single file focus when possible, clear atomic action
+13. **Every task must have**: task ID (`TNNN`), session ref (`[SPPSS]`), action verb, target file path
+14. **Mark `[P]`** when tasks create independent files with no interdependency
+15. **Sequence by**: dependencies first, then setup -> foundation -> implementation -> testing
+16. **Behavioral quality by design** - When a Behavioral Quality Checklist (BQC) applies (session produces application code), embed edge-case handling into task descriptions. "Create delete dialog" becomes "Create delete dialog (with typed confirmation, disable-while-pending, state reset on close)". Explicit requirements get implemented; implicit ones get skipped.
+
+## Steps
+
+### 1. Get Deterministic Project State (REQUIRED FIRST STEP)
+
+Run the analysis script to get reliable state facts. Local scripts (`.spec_system/scripts/`) take precedence over plugin scripts if they exist:
+
+```bash
+# Check for local scripts first, fall back to skill directory
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+This returns structured JSON with:
+- `current_phase` - Current phase number
+- `current_session` - Active session (or null)
+- `completed_sessions` - List of completed session IDs
+- `candidate_sessions` - Sessions in current phase with completion status; each candidate includes a `package` field (parsed from stub `Package:` annotation, or null)
+- `phases` - All phases with status and session counts
+- `monorepo` - true/false/null from state.json
+- `packages` - Array of registered packages (empty if not monorepo)
+- `active_package` - Resolved package context from `--package` flag or CWD (null if not applicable)
+- `monorepo_detection` - Auto-detection result when monorepo is null (null otherwise)
+
+**IMPORTANT**: Use this JSON output as ground truth for all state facts. Do not re-read state.json directly - the script provides authoritative state data.
+
+### 1a. Determine Package Context (Monorepo Only)
+
+**Skip this step if** `monorepo` is not `true` in the JSON output.
+
+When working in a monorepo, resolve the active package for this session. Priority order:
+
+1. **User statement**: If the user explicitly names a package (e.g., "plan a session for apps/web"), use that
+2. **Stub annotation**: If the selected candidate has a `package` field from its stub, use that
+3. **active_package from script**: If `analyze-project.sh` resolved a package via `--package` flag or CWD inference, use that
+4. **Prompt user**: If none of the above resolves a package, ask the user which package this session targets (or whether it is cross-cutting)
+
+Store the resolved package path for use in Steps 4 and 5.
+
+### 2. Read PRD Content for Semantic Analysis
+
+With the state facts established, read these files for context:
+- `.spec_system/PRD/PRD.md` - Master project requirements
+- `.spec_system/PRD/PRD_UX.md` - UX requirements (if exists -- use for UI-focused sessions)
+- Candidate session files from the JSON output (use the `path` field)
+- `.spec_system/CONSIDERATIONS.md` - Institutional memory (if exists)
+- `.spec_system/SECURITY-COMPLIANCE.md` - Security posture and GDPR compliance (if exists)
+- `.spec_system/CONVENTIONS.md` - Project coding conventions (if exists)
+
+Focus on understanding:
+- Session objectives and scope
+- Prerequisites and dependencies
+- Logical ordering
+- **Active Concerns** that may influence session priority or approach
+- **Lessons Learned** relevant to candidate sessions
+- **Open security findings** that may affect session scope or approach
+- Naming, file placement, and testing approach from CONVENTIONS.md
+- If CONVENTIONS.md has a "Database Layer" section and the session involves data layer work (new tables, schema changes, migrations), ensure task planning includes migration, seed update, and DB integration test tasks
+
+### 3. Analyze and Recommend
+
+Using the deterministic state + semantic understanding:
+
+**Determine:**
+- Which candidates have unmet prerequisites (based on `completed_sessions`)
+- Natural next session based on dependencies
+- Complexity and scope assessment
+
+**Evaluate each candidate by:**
+- Prerequisites met (check against `completed_sessions` array)
+- Dependencies completed
+- Logical flow in project progression
+
+If multiple sessions ready: Choose based on dependencies, complexity, project flow.
+If session blocked: Recommend alternative with explanation.
+If phase complete: Suggest running phasebuild for the next phase.
+
+### 4. Create Session Directory and Specification
+
+Create the session directory and generate `spec.md`:
+
+```
+.spec_system/specs/phaseNN-sessionNN-name/
+|-- spec.md
+\-- (tasks.md created in next step)
+```
+
+Generate `spec.md` with all sections filled in:
+
+```markdown
+# Session Specification
+
+**Session ID**: `phaseNN-sessionNN-name`
+**Phase**: NN - Phase Name
+**Status**: Not Started
+**Created**: [YYYY-MM-DD]
+[MONOREPO ONLY - include these lines when monorepo: true]
+**Package**: [package-path]
+**Package Stack**: [stack]
+[END MONOREPO ONLY - omit both lines for single-repo projects]
+
+---
+
+## 1. Session Overview
+
+[2-3 paragraphs explaining what this session accomplishes, why it matters, and how it fits into the larger project]
+
+---
+
+## 2. Objectives
+
+1. [Specific, measurable objective]
+2. [Specific, measurable objective]
+3. [Specific, measurable objective]
+4. [Specific, measurable objective]
+
+---
+
+## 3. Prerequisites
+
+### Required Sessions
+- [x] `phaseNN-sessionNN-name` - [what it provides]
+
+### Required Tools/Knowledge
+- [tool/knowledge item]
+
+### Environment Requirements
+- [environment requirement]
+
+---
+
+## 4. Scope
+
+### In Scope (MVP)
+- [PRD requirement in actor/capability form] - [brief implementation note]
+- [PRD requirement in actor/capability form] - [brief implementation note]
+
+### Out of Scope (Deferred)
+- [PRD requirement] - *Reason: [why deferred]*
+
+---
+
+## 5. Technical Approach
+
+### Architecture
+[Describe the technical architecture and design]
+
+### Design Patterns
+- [Pattern]: [Why using it]
+
+### Technology Stack
+- [Technology and version]
+
+---
+
+## 6. Deliverables
+
+### Files to Create
+| File | Purpose | Est. Lines |
+|------|---------|------------|
+| `path/to/file` | Description | ~100 |
+
+### Files to Modify
+| File | Changes | Est. Lines |
+|------|---------|------------|
+| `path/to/file` | Description | ~20 |
+
+---
+
+## 7. Success Criteria
+
+### Functional Requirements
+- [ ] [Testable requirement]
+
+### Testing Requirements
+- [ ] Unit tests written and passing
+- [ ] Manual testing completed
+
+### Non-Functional Requirements
+- [ ] [Relevant NFR from PRD with measurable target]
+
+### Quality Gates
+- [ ] All files ASCII-encoded
+- [ ] Unix LF line endings
+- [ ] Code follows project conventions
+
+---
+
+## 8. Implementation Notes
+
+### Key Considerations
+- [Important consideration]
+
+### Potential Challenges
+- [Challenge]: [Mitigation]
+
+### Relevant Considerations
+<!-- From CONSIDERATIONS.md - omit section if none apply -->
+- [P##] **[Active Concern]**: How it affects this session and mitigation
+- [P##] **[Lesson Learned]**: How we're applying it in this implementation
+
+### Behavioral Quality Focus
+<!-- Include when session produces application code. Omit if no BQC applies. -->
+Checklist active: Yes
+Top behavioral risks for this session:
+- [Risk 1 relevant to this session's deliverables]
+- [Risk 2 relevant to this session's deliverables]
+- [Risk 3 relevant to this session's deliverables]
+
+---
+
+## 9. Testing Strategy
+
+### Unit Tests
+- [What to test]
+
+### Integration Tests
+- [What to test]
+
+### Manual Testing
+- [Test scenario]
+
+### Edge Cases
+- [Edge case to handle]
+
+---
+
+## 10. Dependencies
+
+### External Libraries
+- [Library]: [version]
+
+### Other Sessions
+- **Depends on**: [sessions]
+- **Depended by**: [sessions]
+
+---
+
+## Next Steps
+
+Run the implement workflow step to begin AI-led implementation.
+```
+
+### 4a. Enrich Task Descriptions with BQC
+
+**Skip if** the session produces no application code.
+
+When BQC applies, enrich task descriptions in Step 5 using this table:
+
+| If task involves... | Append to description... |
+|---------------------|--------------------------|
+| Scoped lifecycle with async work or subscriptions | "with cleanup on scope exit for all acquired resources" |
+| State-mutating action (submit, delete, send, write) | "with duplicate-trigger prevention while in-flight" |
+| View or screen that fetches or displays remote data | "with explicit loading, empty, error, and offline states" |
+| Handler for external input (endpoint, consumer, deep link, event) | "with schema-validated input and explicit error mapping" |
+| Write path (create/update/delete, single or multi-step) | "with idempotency protection, transaction boundaries, and compensation on failure" |
+| Call to external system (API, database, third-party service) | "with timeout, retry/backoff, and failure-path handling" |
+| Access-controlled resource or action | "with authorization enforced at the boundary closest to the resource" |
+| Query or list returning unbounded results | "with bounded pagination, validated filters, and deterministic ordering" |
+| Reopenable or revisitable context (dialog, form, screen, connection) | "with state reset or revalidation on re-entry" |
+| Permission-gated feature | "with denied/restricted/revoked handling and fallback behavior" |
+| Interactive control or element | "with platform-appropriate accessibility labels, focus management, and input support" |
+| Optimistic state update | "with scoped rollback on error" |
+| Component consuming external contract (API response, event payload) | "with types matching declared contract; exhaustive enum handling" |
+
+These add 5-15 words per task but prevent the 10x-cost bugs found in later audits.
+
+### 5. Generate Task Checklist
+
+From the spec, identify deliverables, success criteria, technical approach, testing requirements, and dependencies between tasks. Then create `tasks.md` in the session directory:
+
+```markdown
+# Task Checklist
+
+**Session ID**: `phaseNN-sessionNN-name`
+**Total Tasks**: [N]
+**Estimated Duration**: [X-Y] hours
+**Created**: [YYYY-MM-DD]
+
+---
+
+## Legend
+
+- `[x]` = Completed
+- `[ ]` = Pending
+- `[P]` = Parallelizable (can run with other [P] tasks)
+- `[SNNMM]` = Session reference (NN=phase number, MM=session number)
+- `TNNN` = Task ID
+
+---
+
+## Progress Summary
+
+| Category | Total | Done | Remaining |
+|----------|-------|------|-----------|
+| Setup | N | 0 | N |
+| Foundation | N | 0 | N |
+| Implementation | N | 0 | N |
+| Testing | N | 0 | N |
+| **Total** | **N** | **0** | **N** |
+
+---
+
+## Setup (N tasks)
+
+Initial configuration and environment preparation.
+
+- [ ] T001 [SPPSS] Verify prerequisites met (tools, dependencies)
+- [ ] T002 [SPPSS] Create directory structure for deliverables
+
+---
+
+## Foundation (N tasks)
+
+Core structures and base implementations.
+
+- [ ] T003 [SPPSS] [P] Create [component] (`path/to/file`)
+- [ ] T004 [SPPSS] [P] Define [interface/type] (`path/to/file`)
+- [ ] T005 [SPPSS] Implement [base functionality] (`path/to/file`)
+
+---
+
+## Implementation (N tasks)
+
+Main feature implementation.
+
+- [ ] T006 [SPPSS] Implement [feature part 1] (`path/to/file`)
+- [ ] T007 [SPPSS] Implement [feature part 2] (`path/to/file`)
+- [ ] T008 [SPPSS] [P] Add [component A] (`path/to/file`)
+- [ ] T009 [SPPSS] [P] Add [component B] (`path/to/file`)
+- [ ] T010 [SPPSS] Wire up [integration] (`path/to/file`)
+- [ ] T011 [SPPSS] Add error handling (`path/to/file`)
+
+---
+
+## Testing (N tasks)
+
+Verification and quality assurance.
+
+- [ ] T012 [SPPSS] [P] Write unit tests for [component] (`tests/path`)
+- [ ] T013 [SPPSS] [P] Write unit tests for [component] (`tests/path`)
+- [ ] T014 [SPPSS] Run test suite and verify passing
+- [ ] T015 [SPPSS] Validate ASCII encoding on all files
+- [ ] T016 [SPPSS] Manual testing and verification
+
+---
+
+## Completion Checklist
+
+Before marking session complete:
+
+- [ ] All tasks marked `[x]`
+- [ ] All tests passing
+- [ ] All files ASCII-encoded
+- [ ] implementation-notes.md updated
+- [ ] Ready for the validate workflow step
+
+---
+
+## Next Steps
+
+Run the implement workflow step to begin AI-led implementation.
+```
+
+### Path Scoping Rules (Monorepo Only)
+
+When `monorepo: true`, apply these path conventions in tasks.md:
+
+- **All file paths must be package-relative from the repo root** (e.g., `apps/web/src/auth.ts`, not `src/auth.ts`)
+- **Single-package sessions**: All paths should start with the package path prefix
+- **Cross-package sessions**: Group tasks by package using subheadings within each category:
+
+```markdown
+## Implementation (N tasks)
+
+### apps/web
+
+- [ ] T006 [SPPSS] Implement auth page (`apps/web/src/pages/auth.tsx`)
+- [ ] T007 [SPPSS] Add auth hook (`apps/web/src/hooks/useAuth.ts`)
+
+### apps/api
+
+- [ ] T008 [SPPSS] Implement auth endpoint (`apps/api/src/routes/auth.ts`)
+```
+
+For single-repo projects, paths remain unchanged (relative to project root as usual).
+
+## Category Budgets
+
+| Category | Tasks | Purpose |
+|----------|-------|---------|
+| Setup | 2-4 | Environment, directories, config |
+| Foundation | 4-8 | Core types, interfaces, base classes |
+| Implementation | 8-15 | Main feature logic |
+| Testing | 3-5 | Tests, validation, verification |
+
+### 6. Update State
+
+Update `.spec_system/state.json`:
+
+```json
+{
+  "current_session": "phaseNN-sessionNN-name",
+  "next_session_history": [
+    {
+      "date": "YYYY-MM-DD",
+      "session": "phaseNN-sessionNN-name",
+      "status": "planned"
+    }
+  ]
+}
+```
+
+- Set `current_session` to the session ID
+- Add a single entry to `next_session_history` with status `planned`
+- **Monorepo only**: Include an optional `package` field in the history entry when a package was resolved in Step 1a:
+  ```json
+  {
+    "date": "YYYY-MM-DD",
+    "session": "phaseNN-sessionNN-name",
+    "package": "apps/web",
+    "status": "planned"
+  }
+  ```
+  Omit the `package` field for single-repo projects or cross-cutting sessions.
+
+### 7. Archive Stale Specs
+
+Keep `.spec_system/specs/` lean by archiving old session specs. **Retention rule**: only keep specs from the current phase and one phase back. Move everything older to `.spec_system/archive/sessions/`.
+
+Example: If currently on Phase 3, keep Phase 2 and Phase 3 specs. Archive Phase 0 and Phase 1 specs.
+
+---
+
+## Output
+
+After creating spec.md and tasks.md, summarize to the user:
+- Recommended session name and why it's next
+- Key deliverables
+- Total task count and category breakdown
+- Estimated duration
+- Key parallelization opportunities
+
+Prompt them to run the implement workflow step to begin.

--- a/skills/.experimental/apex-spec/references/pullndoc.md
+++ b/skills/.experimental/apex-spec/references/pullndoc.md
@@ -1,0 +1,116 @@
+# pullndoc
+
+Perform a git pull on an upstream/original codebase directory and generate a comprehensive
+markdown document cataloging every change that was pulled in. Designed for teams
+maintaining forks that need a detailed record of upstream evolution.
+
+## Usage
+
+```
+pullndoc <upstream-dir>
+```
+
+- `<upstream-dir>` -- Path to the upstream/original repo directory
+  (e.g., `.001_ORIGINAL`)
+
+## Rules
+
+1. **Document everything** -- Every changed file must appear in the output document;
+   never omit, skip, or summarize away any file from the diff
+2. **Read full diffs** -- Read complete file diffs, not just stat summaries; if the
+   diff is very large, paginate through it completely before writing the doc
+3. **Explain intent** -- Describe the functional purpose of changes (bug fix, new
+   feature, refactor, config change), not just "lines added/removed"
+4. **Stop if current** -- If the pull brings no new commits, report "Already up to
+   date" and stop
+5. **Read-only on spec system** -- Never modify state.json, session specs, or task
+   checklists
+6. **ASCII only** -- Output file uses characters 0-127 only
+
+## Steps
+
+### 1. Snapshot current state before pulling
+
+Change into the upstream directory provided by the user.
+
+Record the current HEAD commit hash:
+```bash
+git rev-parse HEAD
+```
+Save this as `$BEFORE_SHA`.
+
+Record the current branch name.
+
+### 2. Execute the pull
+
+Run `git pull`.
+
+Record the new HEAD commit hash as `$AFTER_SHA`.
+
+If `$BEFORE_SHA == $AFTER_SHA`, report "Already up to date" and HALT -- do not
+continue to subsequent steps.
+
+### 3. Analyze ALL changes between $BEFORE_SHA and $AFTER_SHA
+
+Run all three of these to build a complete picture:
+
+```bash
+git log --oneline $BEFORE_SHA..$AFTER_SHA
+```
+List every commit pulled in.
+
+```bash
+git diff --stat $BEFORE_SHA..$AFTER_SHA
+```
+Get the full file-level change summary.
+
+```bash
+git diff $BEFORE_SHA..$AFTER_SHA
+```
+Read the **complete diff** for every changed file. Do not skip or summarize any
+file. If the diff is very large, paginate through it completely.
+
+### 4. Generate the documentation
+
+Create a markdown file at:
+```
+<upstream-dir>/docs/upstream-pull-<YYYY-MM-DD>.md
+```
+
+Create the `docs/` directory inside the upstream dir if it does not exist.
+
+Structure the document as follows:
+
+```
+# Upstream Pull -- <date>
+
+## Summary
+- Branch: <branch name>
+- Previous HEAD: <short sha + commit message>
+- New HEAD: <short sha + commit message>
+- Total commits pulled: N
+- Files changed: N | Insertions: N | Deletions: N
+
+## Commit Log
+(List each commit: sha, author, date, message)
+
+## Changes by File
+For EVERY changed file, document:
+- File path and change type (added / modified / deleted / renamed)
+- What changed and why -- describe the functional purpose of the diff:
+  new features, bug fixes, refactors, config changes, dependency updates, etc.
+- Key code changes -- quote or paraphrase the most significant hunks
+
+## Breaking Changes & Migration Notes
+(Flag anything that could affect downstream code: renamed exports, changed
+function signatures, removed features, dependency version bumps, schema changes,
+altered env vars, etc. State "None detected" if applicable.)
+```
+
+## Output
+
+The generated markdown file path is reported to the user along with a brief summary:
+- Number of commits pulled
+- Number of files changed
+- Whether any breaking changes were detected
+- The full path to the documentation file

--- a/skills/.experimental/apex-spec/references/qbackenddev.md
+++ b/skills/.experimental/apex-spec/references/qbackenddev.md
@@ -1,0 +1,153 @@
+# qbackenddev
+
+Run an autonomous backend, infrastructure, or general engineering session guided by a
+work file. The work file defines the goals (implement, audit, plan, refactor, document,
+convert, or review a partner's work) and serves as the running workspace for
+cross-session continuity. Covers backend code, infrastructure, DevOps, CLI commands,
+API layers, databases, and any non-frontend engineering work.
+
+## Usage
+
+```
+qbackenddev <work-file>
+```
+
+- `<work-file>` -- Path to the markdown file that defines the session goals and
+  tracks progress (e.g., `docs/backend/backend-audit.md`, `docs/infrastructure/infra-plan.md`,
+  `tmp/final-plan.md`, `docs/ongoing_projects/MY_TECH_PRD.md`)
+
+The work file determines the mode of work. It might contain:
+- Implementation tasks to execute (session-by-session or phase-by-phase)
+- An audit scope to analyze (backend files, infrastructure, CLI commands)
+- A plan to create, refine, or merge from multiple draft plans
+- A refactoring roadmap with architecture improvements
+- Documentation to write or verify (API docs, pseudo-code conversions, changelogs)
+- A partner engineer's work to review and validate
+
+## Rules
+
+1. **Senior engineer mindset** -- Obsess over pristine code with zero errors, warnings,
+   or issues. Approach implementation like a craftsperson: methodical, patient, and
+   uncompromising on quality.
+2. **Work file is your hub** -- Read goals from the work file, write results and
+   progress back to it. The work file persists across sessions.
+3. **Work file is a guide, not gospel** -- You own the implementation. Verify its
+   details against the actual codebase and adapt as needed.
+4. **Work autonomously** -- Complete all tasks/sessions/phases in the work file
+   without stopping to ask permission. Work through each item sequentially.
+5. **Session resource discipline** -- Stop after approximately 30 tool executions
+   or when the session feels overloaded. Quality degrades in overloaded sessions.
+6. **No assumptions, no shortcuts, no lying** -- Never guess. Never skim when details
+   are needed. Pattern match precisely. Validate systematically. Look up and verify
+   any details you are not confident in. If something feels off, it probably is --
+   investigate rather than hand-wave.
+7. **Trust code over docs** -- When documentation seems stale or ambiguous, verify
+   behavior in the actual codebase. Code is the single source of truth.
+8. **Measure twice, cut once** -- Fully understand before implementing. Read the
+   relevant files, understand the patterns, then make changes.
+9. **Read-only on spec system** -- Never modify state.json, session specs, or task
+   checklists.
+10. **ASCII only** -- All generated/modified files use characters 0-127 only.
+
+## Steps
+
+### 1. Orient
+
+Read the work file provided by the user. Identify:
+- The goal(s) of the session (implement, audit, plan, refactor, document, review)
+- Any prior progress or context from previous sessions
+- The current phase/session/task to work on
+- Any notes, constraints, or decisions from earlier sessions
+
+If the work file references other documents (PRDs, changelogs, audit reports,
+partner work, design docs, blueprint files), read those too for full context.
+
+### 2. Analyze existing patterns
+
+Before making any changes, study the codebase to understand:
+- File/folder structure and naming conventions
+- How components are registered, invoked, and connected
+- Common patterns (argument parsing, error handling, output formatting, logging)
+- Shared utilities, base classes, or middleware used across the codebase
+- Database schemas, migration patterns, API contracts
+
+This prevents introducing inconsistencies or reinventing existing solutions.
+
+### 3. Verify
+
+Before writing any code, verify the work file's claims against the actual codebase:
+- Do referenced files, modules, and endpoints exist?
+- Do described patterns and architectures match reality?
+- Are documented APIs, schemas, and configs accurate?
+- Has anything changed since the work file was last updated?
+
+If anything is incorrect or outdated, note it and adapt your approach. Trust the
+code, not the docs.
+
+### 4. Execute
+
+Work through the tasks defined in the work file. Follow the mode-specific guidance
+below.
+
+**For implementation work:**
+- Work through sessions/tasks methodically, one at a time
+- Make small, deliberate, atomic changes
+- Validate each change before moving to the next
+- Handle error cases, edge cases, and logging properly
+- Follow existing patterns for argument parsing, output formatting, and error handling
+
+**For audit work:**
+- Analyze every relevant file thoroughly -- do not skip or skim
+- Document file paths, line counts, and specific findings
+- Identify concrete refactoring opportunities with rationale: architecture,
+  structure, code organization, and developer navigation improvements
+- Prioritize findings by impact and effort
+
+**For planning work:**
+- Analyze existing implementations to understand conventions before planning
+- If merging multiple draft plans, include only clear, objective improvements
+  from secondary sources
+- Structure with clear headings, bullet points, and code snippets where helpful
+- Aim for a document another senior engineer could implement without ambiguity
+- No wordiness, no redundancy
+
+**For review/validation work (partner engineer's output):**
+- Verify every claim in the partner's document against the actual codebase
+- Check for accuracy, completeness, and whether findings are up to date
+- Add missing findings, correct inaccuracies, remove stale entries
+- Preserve the partner's good work -- only modify what needs correction
+
+**For documentation/conversion work:**
+- Verify every detail against the actual codebase or source material
+- Do not trust existing docs -- they may be outdated or contain mistakes
+- Fact-check every word; no shortcuts, no assumptions, no fabrication
+- When converting formats (e.g., blueprints to pseudo-code), preserve all
+  functional logic faithfully
+
+### 5. Monitor resource consumption
+
+Keep a running awareness of resource usage:
+- **Tool executions**: Begin wrapping up when approaching 30
+- If the session feels overloaded, proceed to Step 6 rather than pushing further
+
+### 6. Update the work file and wrap up
+
+Before ending the session, update the work file with:
+- What was completed this session
+- What remains to be done
+- Current state of the implementation (what works, what is partial)
+- Any discoveries, decisions, or gotchas for the next session
+- Clear next steps so a fresh session can continue without re-investigation
+- If concise notes can improve the process moving forward, add them
+
+If the work file references a changelog or other tracking documents, update
+those too.
+
+## Output
+
+Report to the user:
+- What was accomplished in this session
+- How much of the work file's goals were completed
+- Any issues, warnings, or quality concerns discovered
+- Whether the session ended due to completion or session resource discipline
+- The work file has been updated for session continuity

--- a/skills/.experimental/apex-spec/references/qfrontdev.md
+++ b/skills/.experimental/apex-spec/references/qfrontdev.md
@@ -1,0 +1,158 @@
+# qfrontdev
+
+Run an autonomous frontend development session guided by a work file. Combines the
+mindset of a senior frontend engineer with a designer's eye -- obsessing over 1px
+alignment, easing curves, whitespace rhythm, and production-grade polish. The work
+file defines the goals (implement, audit, plan, fix, document, refactor) and serves
+as the running workspace for cross-session continuity.
+
+## Usage
+
+```
+qfrontdev <work-file>
+```
+
+- `<work-file>` -- Path to the markdown file that defines the session goals and
+  tracks progress (e.g., `docs/frontend/redesign-phase01.md`, `docs/frontend/audit.md`)
+
+The work file determines the mode of work. It might contain:
+- Implementation tasks to execute (session-by-session or phase-by-phase)
+- An audit scope to analyze
+- A plan to create or refine
+- A specific bug or UI issue to investigate and fix
+- Documentation to write or update
+
+## Rules
+
+1. **Senior frontend engineer with a designer's eye** -- Obsess over 1px alignment
+   issues, easing curves, and whitespace rhythm. Approach implementation like a
+   craftsperson: methodical, patient, and uncompromising on quality.
+2. **Work file is your hub** -- Read goals from the work file, write results and
+   progress back to it. The work file persists across sessions.
+3. **Work file is a guide, not gospel** -- You own the implementation. Verify its
+   details against the actual codebase and adapt as needed. Documentation can be
+   stale or ambiguous -- code is the only source of truth.
+4. **Work autonomously** -- Complete all tasks/sessions/phases in the work file
+   without stopping to ask permission. Work through each item sequentially.
+5. **Session resource discipline** -- Stop after approximately 30 tool executions
+   or when the session feels overloaded. Quality degrades in overloaded sessions.
+6. **No assumptions, no shortcuts, no lying** -- Never guess. Never skim when
+   details are needed. Pattern match precisely. Validate systematically. Look up
+   and verify any details you are not confident in. If something feels off, it
+   probably is -- investigate rather than hand-wave.
+7. **Trust code over docs** -- When documentation seems stale or ambiguous, verify
+   behavior in the actual codebase. Code is the single source of truth.
+8. **Measure twice, cut once** -- Fully understand before implementing. Read the
+   relevant files, understand the patterns, then make changes.
+9. **Read-only on spec system** -- Never modify state.json, session specs, or task
+   checklists.
+10. **ASCII only** -- All generated/modified files use characters 0-127 only.
+
+## Design North Star
+
+The UI should feel like it was crafted by a top-tier design agency -- every pixel
+intentional, every interaction delightful. Think **Linear**, **Vercel**, or
+**Stripe dashboard**-level polish. The kind of interface that makes users think
+"this company clearly invests in quality."
+
+This is not aspirational -- it is the minimum standard. Every component, every
+transition, every font choice should feel intentional.
+
+## Quality Gate (Apply to Every Change)
+
+Before considering any change complete, verify:
+
+- **Responsive** -- Works at all breakpoints (mobile, tablet, desktop, large screen)
+- **Accessible** -- Keyboard navigable, proper ARIA attributes, sufficient contrast,
+  focus states, reduced-motion support
+- **Consistent** -- Matches established patterns in the codebase; does not introduce
+  a new way of doing something that already has a convention
+- **Complete** -- Handles loading, empty, error, and edge-case states; no half-finished
+  UI paths
+- **Performant** -- No unnecessary re-renders, optimized assets, animations target
+  60fps; test with 6x CPU throttling mentally
+
+## Steps
+
+### 1. Orient
+
+Read the work file provided by the user. Identify:
+- The goal(s) of the session (implement, audit, plan, fix, document, refactor)
+- Any prior progress or context from previous sessions
+- The current phase/session to work on
+- Any notes, constraints, or implementation guidance
+
+If the work file references other documents (design guides, style guides, dashboard
+docs, changelogs), read those too for full context.
+
+### 2. Verify
+
+Before writing any code, verify the work file's claims against the actual codebase:
+- Do referenced files and components exist?
+- Do described patterns match reality?
+- Are documented APIs and props accurate?
+- Has anything changed since the work file was last updated?
+
+If anything is incorrect or outdated, note it and adapt your approach. Trust the
+code, not the docs.
+
+### 3. Execute
+
+Work through the tasks defined in the work file. Follow these principles:
+
+**For implementation work:**
+- Work through sessions/tasks methodically, one at a time
+- Make small, deliberate, atomic changes
+- Validate each change before moving to the next
+- Apply the Quality Gate to every change
+
+**For audit work:**
+- Analyze every relevant file thoroughly -- do not skip or skim
+- Document file paths, line counts, and specific findings
+- Identify concrete refactoring opportunities with rationale
+- Prioritize findings by impact
+
+**For planning work:**
+- Assess current state gaps and pain points
+- Propose direction with rationale
+- Break work into manageable sessions
+- Each session must leave the app in a working state
+- Include verification criteria for each session
+
+**For fix/debug work:**
+- Investigate root cause, not just symptoms
+- Consider whether the issue signals deeper architectural problems
+- Fix the underlying cause, not just the surface manifestation
+
+**For documentation work:**
+- Verify every detail against the actual codebase
+- Do not trust existing docs -- they may be outdated
+- Write for the next engineer who has never seen this code
+
+### 4. Monitor resource consumption
+
+Keep a running awareness of resource usage:
+- **Tool executions**: Begin wrapping up when approaching 30
+- If the session feels overloaded, proceed to Step 5 rather than pushing further
+
+### 5. Update the work file and wrap up
+
+Before ending the session, update the work file with:
+- What was completed this session
+- What remains to be done
+- Current state of the implementation (what works, what is partial)
+- Any discoveries, decisions, or gotchas for the next session
+- Clear next steps so a fresh session can continue without re-investigation
+- If relevant architectural or engineering changes were made, update any
+  referenced documentation files as well
+
+If the work file references a changelog, update it too.
+
+## Output
+
+Report to the user:
+- What was accomplished in this session
+- How much of the work file's goals were completed
+- Any issues, warnings, or quality concerns discovered
+- Whether the session ended due to completion or session resource discipline
+- The work file has been updated for session continuity

--- a/skills/.experimental/apex-spec/references/qimpl.md
+++ b/skills/.experimental/apex-spec/references/qimpl.md
@@ -1,0 +1,87 @@
+# qimpl
+
+Run an autonomous implementation session guided by a work file. The work file defines
+the goals and serves as the workspace for tracking progress. Designed for focused,
+high-quality implementation bursts that stay within session resource limits for optimal
+output quality.
+
+## Usage
+
+```
+qimpl <work-file>
+```
+
+- `<work-file>` -- Path to the markdown work file that defines the session goals
+  and serves as the running workspace (e.g., `work.md`, `docs/impl-plan.md`)
+
+## Rules
+
+1. **Senior engineer mindset** -- Approach implementation like a craftsperson who
+   obsesses over pristine code with zero errors, warnings, or issues. Be methodical,
+   patient, and uncompromising on quality.
+2. **Work file is your hub** -- Read goals from the work file, write results back to
+   it. The work file persists across sessions as the source of truth.
+3. **Work file is a guide, not gospel** -- You own the implementation. Verify its
+   details and adapt as needed to accomplish the goals.
+4. **Session resource discipline** -- Work autonomously but stop after approximately
+   30 tool executions or when the session feels overloaded. Quality degrades in
+   overloaded sessions.
+5. **No assumptions** -- Never guess. Pattern match precisely. Do not skim when
+   details are needed. Validate systematically. Look up and verify any details you
+   are not confident in.
+6. **No lying or "good enough"** -- Never misrepresent status. If something feels
+   off, it probably is. Investigate rather than hand-wave.
+7. **Read-only on spec system** -- Never modify state.json, session specs, or task
+   checklists.
+8. **ASCII only** -- All generated/modified files use characters 0-127 only.
+
+## Steps
+
+### 1. Load the work file
+
+Read the work file provided by the user. Identify:
+- The goal(s) of the session
+- Any prior progress or context from previous sessions
+- Any notes, constraints, or implementation guidance
+
+### 2. Assess and plan
+
+Review the current state of the codebase as it relates to the work file goals.
+Verify that the work file's details are accurate -- file paths exist, assumptions
+hold, referenced code matches expectations.
+
+If anything in the work file is incorrect or outdated, note it and adapt your
+approach accordingly.
+
+### 3. Implement
+
+Execute the work described in the work file. Follow these principles:
+- Work through items methodically, one at a time
+- Validate each change before moving to the next
+- If you encounter uncertainty about an API, library, or pattern, look it up
+  rather than guessing
+- Track your session resource consumption
+
+### 4. Monitor resource consumption
+
+Keep a running awareness of resource usage:
+- **Tool executions**: Begin wrapping up when approaching 30
+- If the session feels overloaded, proceed to Step 5 rather than pushing further
+
+### 5. Update the work file
+
+Before ending the session, update the work file with:
+- What was completed this session
+- What remains to be done
+- Current state of the implementation (what works, what is partial)
+- Any concise notes that would help the next session pick up efficiently
+  (gotchas discovered, decisions made, patterns established)
+- Clear next steps so a fresh session can continue without re-investigation
+
+## Output
+
+Report to the user:
+- What was accomplished in this session
+- How much of the work file's goals were completed
+- Whether the session ended due to completion or session resource discipline
+- The work file has been updated for session continuity

--- a/skills/.experimental/apex-spec/references/sculpt-ui.md
+++ b/skills/.experimental/apex-spec/references/sculpt-ui.md
@@ -1,0 +1,198 @@
+# sculpt-ui
+
+Guide the creation of distinctive, production-grade frontend interfaces with high design quality.
+Run this workflow step before building any frontend component, page, or application to establish
+a design brief, micro design system, and implementation strategy that avoids generic AI output.
+
+## Rules
+
+1. **Read-only on spec system** - Never modify state.json, session specs, or task checklists
+2. **Design brief first** - Always complete Phase 1 before writing code
+3. **ASCII only** - All generated files use characters 0-127, no emoji or smart quotes
+4. **Performance budget** - Target locked 60fps; test with 6x CPU throttling in DevTools
+5. **Accessibility baseline** - WCAG AA contrast minimum, semantic HTML, focus states, reduced-motion support
+
+## Steps
+
+### 1. Design Intelligence (ALWAYS do this first)
+
+Before writing a single line of code, build a **Design Brief** by thinking through these layers:
+
+#### The Human Layer
+- **Who is here?** Not "users" -- real people. A stressed founder checking metrics at midnight? A curious teenager exploring for the first time? A professional making a high-stakes decision? Their emotional state shapes everything.
+- **What should they FEEL?** Define 2-3 emotional targets. Examples: "calm authority + subtle delight," "raw energy + controlled chaos," "intimate warmth + precision." This emotional palette drives every decision downstream.
+- **What is the micro-narrative?** Every great interface has an arc: Arrival -> Orientation -> Engagement -> Action -> Resolution. Map the key moments. Think of the interface as a physical space the user navigates through -- architectural, intentional, almost editorial in its pacing -- not a flat page they scan.
+
+#### The Aesthetic Identity
+Do not pick from a list -- CONSTRUCT a unique identity by combining:
+- **A primary reference domain** (outside of web design): architecture, fashion editorial, vinyl record sleeves, scientific instruments, Japanese packaging, brutalist concrete, Art Nouveau ironwork, aerospace interfaces, museum exhibitions, vintage pharmacy labels, racing liveries, botanical illustrations...
+- **An era or movement**: Bauhaus, Memphis Group, Swiss International, Psychedelic 60s, Y2K, Acid Graphics, De Stijl, Constructivism, Streamline Moderne, Ukiyo-e...
+- **A material metaphor**: Does this interface feel like brushed steel? Handmade paper? Wet ink? Polished marble? Stretched canvas? Frosted glass? Worn leather?
+
+The intersection of these three inputs creates something that cannot be generic. A "Swiss International + aerospace instruments + brushed aluminum" interface is fundamentally different from "Memphis Group + Japanese packaging + wet ink."
+
+#### The Signature Moment
+Every interface needs ONE thing someone will screenshot or share. Define it explicitly:
+- A mesmerizing loading sequence?
+- A hover interaction that reveals hidden depth?
+- A scroll-triggered transformation that recontextualizes the page?
+- A typography treatment so beautiful it stops someone mid-scroll?
+- A data visualization that makes complexity feel elegant?
+
+This is your hero. Everything else supports it.
+
+### 2. Design System Foundation
+
+Build a micro design system BEFORE implementing components. This invisible architecture makes bold choices feel intentional rather than chaotic.
+
+#### Type Scale and Typography as Visual Object
+Define a modular type scale (e.g., 1.25 ratio, 1.414 ratio, or custom). Choose:
+- **Display font**: The personality carrier. Must be distinctive -- pull from Google Fonts deeper catalog, variable fonts, or characterful choices. NEVER default to overused favorites. Consider: Fraunces, Instrument Serif, Playfair Display, Space Mono, Anybody, Bricolage Grotesque, Syne, Crimson Pro, Outfit, Cormorant, Darker Grotesque, Climate Crisis, Unbounded... but also do not converge on these -- explore and vary every time.
+- **Body font**: Highly legible but with character. The quiet partner.
+- **Monospace** (if needed): For data, code, or utilitarian accents.
+
+**CRITICAL MINDSET SHIFT**: Typography is not just content delivery -- it is a visual and spatial element. Oversized text IS the layout. Words can be compositional anchors, kinetic objects, texture, negative space. Consider: text that acts as background at massive scale, headlines that ARE the hero instead of sitting next to one, letter-spacing and weight as scroll-driven variables, text as mask for imagery or color. The best interfaces make you notice the words as visual form before you read them as language.
+
+#### Color Architecture
+- **Dominant surface** (60%): The canvas. Sets the mood.
+- **Secondary surfaces** (25%): Depth, cards, sections. Relate to dominant.
+- **Accent** (10%): The punctuation. Sharp, intentional, memorable.
+- **Signal colors** (5%): Functional -- success, warning, error. Still on-brand.
+- Define as CSS custom properties with semantic names, not just color values.
+- Consider: Does the palette feel WARM or COOL? NATURAL or SYNTHETIC? LOUD or QUIET?
+
+**Accent restraint rule**: Limit accent color to ONE visible element at a time within any viewport. Accent gains its power from scarcity -- if everything is highlighted, nothing is. Multiple simultaneous accents create visual noise; a single accent creates a focal point.
+
+#### Spacing and Rhythm
+Use a consistent spacing scale (4px, 8px, 12px, 16px, 24px, 32px, 48px, 64px, 96px, 128px) as CSS variables. Generous whitespace is not emptiness -- it is breathing room that makes content sing. Cramped interfaces feel cheap; spacious ones feel confident.
+
+#### Elevation and Depth
+Define how depth works in your system: shadows, layers, blur, transparency, borders. Commit to a model -- flat with sharp borders? Deep with soft shadows? Layered with frosted glass? Flat with color-shift depth?
+
+### 3. Implementation Craft
+
+#### Layout as Composition
+Think like a graphic designer or architect, not a Bootstrap user:
+- **Break the grid intentionally**: Overlap elements. Use asymmetric columns. Let images bleed. Create diagonal flow with transforms.
+- **Negative space is a design element**: The emptiest areas of your layout should feel as intentional as the fullest.
+- **Visual hierarchy through scale contrast**: Make important things BIG. Make supporting things small. Avoid the mediocre middle where everything is roughly the same size.
+- **Consider the viewport as a canvas**: The fold, the edges, the scroll depth -- all are compositional tools.
+- **Asymmetry as intentional placement**: Elements should not be centered by default. Every element should feel PLACED with purpose -- pushed to a margin, offset from center, anchored to an edge. Symmetry is a choice, not a fallback. The asymmetry should create energy and direct the eye.
+- **Vary spatial rhythm dramatically**: Not every section should be the same height or density. Some sections should breathe with massive whitespace; others should be dense and information-rich. The variation itself creates pacing and narrative.
+
+#### Section Transitions as Choreography
+Sections should NOT end with hard cuts. Transitions between content areas happen through:
+- **Color shifts**: Background color evolving over scroll distance, not switching abruptly
+- **Element migration**: Objects from one section traveling into the next, creating continuity
+- **Overlap zones**: Content from adjacent sections sharing viewport space briefly during scroll
+- **Atmospheric changes**: Texture, grain, or depth shifting gradually to signal a new context
+
+This is what separates editorial-quality interfaces from template-assembled pages.
+
+#### Motion as Storytelling
+Motion should have PURPOSE, PHYSICS, and DISCIPLINE:
+
+**Entrance choreography**: Stagger reveals with `animation-delay` to create a narrative sequence. The eye should be guided, not overwhelmed. One well-orchestrated page entrance > 50 scattered animations.
+
+**Interaction feedback**: Hover states, click responses, focus rings -- these should feel PHYSICAL. Elements should have weight, resistance, elasticity.
+
+**Scroll-driven narrative**: Use `scroll-timeline`, `IntersectionObserver`, or scroll-triggered classes to create moments of transformation as the user moves through content. Scroll is a storytelling medium -- treat it as the user's way of pacing through a physical space.
+
+**Animation Discipline Rules** (these prevent motion from becoming noise):
+- **Maximum 3 elements animating simultaneously** in the same viewport region. More than this overwhelms the eye and tanks performance.
+- **Minimum 0.6s duration** for any scroll-triggered reveal. Anything faster reads as a glitch, not an animation.
+- **Never use linear easing.** Always use power, expo, or custom cubic-bezier curves. Linear motion looks mechanical and cheap.
+- **Easing philosophy**: Ease-out for entrances (arriving with energy, settling into place). Ease-in for exits (gathering energy, departing). Ease-in-out for state transitions. Custom cubic-beziers for personality.
+- **Entrance vectors matter**: Elements should NOT always enter from directly below their final position. Use diagonals, rotations, scale changes, and lateral movement. Predictable entrance directions are a hallmark of template animation.
+- **Decorative elements must respond to scroll or interaction.** Static decorative elements feel dead. If a geometric shape or line exists on the page, it should move, scale, rotate, or change opacity in response to something.
+
+Prefer CSS-only animation for HTML artifacts. Use Motion/Framer Motion for React when available. Use GSAP with ScrollTrigger for scroll-driven animation when the complexity warrants it.
+
+#### Advanced Techniques to Employ
+Push beyond basics. These create the "how did they do that" moments:
+- `clip-path` for non-rectangular reveals and morphing shapes
+- `mix-blend-mode` and `background-blend-mode` for depth and texture
+- CSS `mask-image` for gradient fades and pattern masks
+- `backdrop-filter` for frosted glass and environmental blur
+- SVG filters (`feTurbulence`, `feDisplacementMap`) for organic textures
+- `@property` for animatable custom properties (gradient animations, color transitions)
+- `container queries` for truly responsive component-level art direction
+- `scroll-snap` for controlled scroll experiences
+- Custom `cursor` styles that match the aesthetic
+- `text-shadow` and layered `box-shadow` for dimensional type and surfaces
+- CSS `conic-gradient` and `radial-gradient` for complex backgrounds
+- `@font-face` with `font-display: swap` and variable font axes
+- CSS Grid with `subgrid` for precise nested alignment
+- View Transitions API for page-level morphing (when supported)
+- SplitText-style character/word-level animation for typographic sequences
+
+#### Texture and Atmosphere
+Flat, solid-color backgrounds are a missed opportunity. Create atmosphere:
+- **Gradient meshes**: Multiple radial gradients layered for organic color fields
+- **Noise/grain**: Subtle SVG noise overlays add analog warmth (use SVG `feTurbulence`)
+- **Geometric patterns**: Repeating SVGs, CSS patterns, or generated backgrounds
+- **Photographic elements**: Blurred, color-shifted, or masked imagery as atmospheric layers
+- **Light effects**: Subtle glows, ambient reflections, or spotlight effects that respond to interaction
+
+### 4. Quality Standards
+
+#### Performance-Conscious Animation
+Beautiful AND fast -- these are not in tension when done right:
+- Prefer CSS over JS for visual effects wherever possible
+- Apply `will-change: transform` ONLY to elements currently animating -- add it before animation begins, remove it via `onComplete` callback. Permanent `will-change` on many elements consumes GPU memory for no benefit.
+- Use CSS containment (`contain: layout style paint`) on pinned or independently-scrolling sections to isolate rendering work
+- Batch identical animations (e.g., `ScrollTrigger.batch()` for card grids, logo strips)
+- Lazy-initialize animation controllers for content below the fold -- do not set up scroll listeners for elements the user may never reach
+- Target locked 60fps -- test with 6x CPU throttling in DevTools. If frames drop, reduce concurrent animations first, then simplify easing curves
+- Lazy-load heavy elements below the fold
+- Font loading optimization
+- Use modern image formats, appropriate sizes, `loading="lazy"`
+
+#### Accessibility as Creative Constraint
+Accessibility is not a checkbox -- it is a design discipline that produces BETTER work:
+- Color contrast ratios (WCAG AA minimum) force you to choose bolder, more intentional palettes
+- Focus states become another surface for creative expression -- make them beautiful, not just visible
+- Semantic HTML creates clean, maintainable structure
+- Reduced motion preferences (`prefers-reduced-motion`) should have their own elegant experience, not just "turn everything off" -- consider subtle opacity transitions or position shifts that respect the preference while maintaining design quality
+- Screen reader text and ARIA labels are invisible craft -- do them well
+
+#### Responsive as Adaptive Design
+Do not just shrink things. Redesign for each context:
+- Mobile should feel native to mobile -- thumb-friendly targets, swipe affordances, simplified hierarchy
+- Tablet gets its own composition -- not just "between phone and desktop"
+- Large screens are an opportunity for cinematic layouts, not just wider containers
+- Horizontal scroll sections should become vertical stacks on mobile with modified (not just disabled) animations
+- Touch targets: minimum 44x44px, with generous spacing between interactive elements
+
+### 5. Anti-Pattern Awareness
+
+Avoid these not because they are on a list, but because they signal LACK OF THOUGHT:
+- Same font appearing across multiple generations (if you notice yourself reaching for the same font, STOP and explore)
+- Card grids with identical border-radius and padding (cards are not the only container)
+- Purple/blue gradients as a default "modern" look
+- Centered-everything layouts with symmetric padding (asymmetry creates energy; centering should be a deliberate choice, not a default)
+- Icon libraries used without modification (customize, recolor, resize beyond defaults)
+- Drop shadows as the only depth mechanism
+- Hero sections that are just big text + button + gradient background
+- Animations with linear easing (always use power/expo curves)
+- Animations that complete instantly -- if it is worth animating, it is worth giving time to breathe
+- More than 3 elements animating simultaneously in the same viewport area
+- Elements always entering from directly below (use diagonals, rotations, scale)
+- Uniform section heights -- vary dramatically to create pacing
+- Hard cuts between sections instead of choreographed transitions
+- White/light gray backgrounds with blue accents (the unofficial colorway of AI demos)
+- Decorative elements that do not move or respond to anything -- dead ornaments
+- Sans-serif body text smaller than 18px on desktop
+- Stock photography or placeholder image boxes when CSS/SVG visuals would be more distinctive
+
+The test: If you removed the content and just looked at the structure and styling, could you tell this was designed for THIS specific context? If not, push further.
+
+## Output
+
+After running this workflow step, you will have:
+- A Design Brief documenting emotional targets, aesthetic identity, and signature moment
+- A micro design system (type scale, color architecture, spacing, depth model)
+- An implementation strategy with layout composition, motion choreography, and advanced techniques
+- Code that targets 60fps, WCAG AA accessibility, and responsive adaptive design
+
+The standard: Every interface should make someone pause and think, "this feels like it was designed by a human who cares deeply." Every pixel, every transition, every font choice should feel intentional.

--- a/skills/.experimental/apex-spec/references/up2imp.md
+++ b/skills/.experimental/apex-spec/references/up2imp.md
@@ -1,0 +1,100 @@
+# up2imp
+
+Audit a raw list of upstream changes against your hardened fork and rewrite it as a
+curated, optimally ordered implementation list containing only changes that objectively
+improve your codebase. Designed for teams maintaining modified forks that periodically
+cherry-pick upstream improvements.
+
+## Usage
+
+```
+up2imp <changes-file> [upstream-dir]
+```
+
+- `<changes-file>` -- Path to the markdown file containing raw upstream updates
+  since the last comparison (e.g., `upstream-changes.md`)
+- `[upstream-dir]` -- Path to the full upstream codebase copy for reference
+  (defaults to `.001_ORIGINAL/`)
+
+## Rules
+
+1. **Senior engineer mindset** -- Approach this like a craftsperson who obsesses over
+   pristine code with zero errors, warnings, or issues. Be methodical, patient, and
+   uncompromising on quality.
+2. **Objective improvements only** -- Every retained item must demonstrably make the
+   codebase more correct, faster, safer, more stable, or more maintainable.
+3. **Respect the fork's direction** -- This is a hardened, stripped-down,
+   security-focused fork that has diverged intentionally. Never include changes that
+   conflict with those decisions.
+4. **Preserve implementation detail** -- Each retained item must have enough context
+   (affected files, upstream references, rationale) for an engineer to implement it
+   efficiently.
+5. **Optimal order** -- Sort the final list in the order items should be implemented,
+   accounting for dependencies, risk, and logical grouping.
+6. **Read-only on spec system** -- Never modify state.json, session specs, or task
+   checklists.
+7. **ASCII only** -- Output file uses characters 0-127 only.
+
+## Steps
+
+### 1. Load context
+
+Read the changes file provided by the user. This contains the raw list of upstream
+updates since the last comparison.
+
+Read the upstream codebase directory (default `.001_ORIGINAL/`) to understand the
+full context of each change when needed.
+
+Read the current project codebase to understand the fork's architecture, security
+modifications, and which components exist or have been replaced.
+
+### 2. Categorize each upstream change
+
+For every item in the changes file, classify it into one of these categories:
+
+**INCLUDE -- objectively improves the fork:**
+- Bug fixes -- correctness issues, edge cases, error handling
+- Performance improvements -- measurable efficiency gains
+- Security patches -- vulnerability fixes, hardening measures
+- Stability improvements -- crash fixes, race conditions, resource leaks
+- Meaningful refactors -- code that is demonstrably cleaner, more maintainable,
+  or reduces technical debt
+
+**EXCLUDE -- does not belong in the fork:**
+- Feature additions the fork has intentionally stripped out
+- Changes to components/modules the fork does not use or has replaced
+- Cosmetic/stylistic changes (formatting, comment rewording, variable renames
+  with no clarity gain)
+- Changes that conflict with the fork's security modifications or architectural
+  decisions
+- Dependency bumps with no functional impact on the fork
+
+### 3. Determine implementation order
+
+Sort the included items by optimal implementation sequence:
+- Dependencies first (if change B relies on change A, A comes first)
+- Security patches and bug fixes before refactors
+- Lower-risk changes before higher-risk ones
+- Logically related changes grouped together
+
+### 4. Rewrite the changes file
+
+Overwrite the original changes file with the curated list. The output contains
+ONLY the actionable improvements -- no excluded items, no commentary about what
+was removed.
+
+For each retained item, ensure it includes:
+- Clear description of what the change does and why it matters
+- Which files in the fork are affected
+- References to upstream (commit hashes, file paths, PR numbers if available)
+- Any implementation notes or caveats specific to the fork
+
+## Output
+
+The changes file is rewritten in place as the filtered, optimally ordered
+implementation list. Report:
+- Total items reviewed
+- Items retained (with breakdown by category: bug fix, performance, security,
+  stability, refactor)
+- Items excluded (with brief summary of why, grouped by exclusion reason)
+- The final ordered list is ready for sequential implementation

--- a/skills/.experimental/apex-spec/references/updateprd.md
+++ b/skills/.experimental/apex-spec/references/updateprd.md
@@ -1,0 +1,222 @@
+# updateprd
+
+After successful validation, mark the session complete, update all tracking documents, increment the project version, and commit to the repository.
+
+## Rules
+
+1. **Validation must have PASSED** - if `validation.md` shows FAIL, stop and instruct user to fix issues first
+2. **ASCII-only characters** and Unix LF line endings in all output
+3. **No co-authors or attributions** in commit messages
+4. **Increment patch version** by default (X.Y.Z -> X.Y.Z+1), preserve pre-release suffixes
+
+## Steps
+
+### 1. Verify Validation Passed
+
+Read `.spec_system/specs/[current-session]/validation.md`:
+- Confirm overall result is PASS
+- If FAIL, instruct user to fix issues first
+
+Also read `.spec_system/specs/[current-session]/spec.md` to extract the `Package:` field (if present). This determines the package context for state updates below.
+
+### 2. Update State
+
+Update `.spec_system/state.json`:
+
+**Single-repo** (or `monorepo: false/null`):
+```json
+{
+  "completed_sessions": [
+    "...existing...",
+    "phaseNN-sessionNN-name"
+  ],
+  "current_session": null,
+  "next_session_history": [
+    {
+      "date": "YYYY-MM-DD",
+      "session": "phaseNN-sessionNN-name",
+      "status": "completed"
+    }
+  ],
+  "phases": {
+    "N": {
+      "status": "in_progress",
+      "session_count": N
+    }
+  }
+}
+```
+
+**Monorepo** (`monorepo: true`): Use object form for `completed_sessions` and include `package` in history:
+```json
+{
+  "completed_sessions": [
+    "...existing...",
+    { "id": "phaseNN-sessionNN-name", "package": "apps/web" }
+  ],
+  "current_session": null,
+  "next_session_history": [
+    {
+      "date": "YYYY-MM-DD",
+      "session": "phaseNN-sessionNN-name",
+      "package": "apps/web",
+      "status": "completed"
+    }
+  ]
+}
+```
+
+- The `package` value comes from the session's spec.md `Package:` field (read in Step 1)
+- Use `null` for the package field in cross-cutting sessions
+- Phase completion: all sessions in the phase must be done, regardless of which packages they target
+```
+
+### 3. Update Phase PRD
+
+Update `.spec_system/PRD/phase_NN/PRD_phase_NN.md`:
+- Mark session as Complete in Progress Tracker
+- Add completion date
+- Update progress percentage
+
+### 4. Create Implementation Summary
+
+Create `.spec_system/specs/[session]/IMPLEMENTATION_SUMMARY.md`:
+
+```markdown
+# Implementation Summary
+
+**Session ID**: `phaseNN-sessionNN-name`
+[MONOREPO ONLY - include when monorepo: true]
+**Package**: [package-path]
+[END MONOREPO ONLY]
+**Completed**: [DATE]
+**Duration**: [X] hours
+
+---
+
+## Overview
+
+[Brief summary of what was accomplished]
+
+---
+
+## Deliverables
+
+### Files Created
+| File | Purpose | Lines |
+|------|---------|-------|
+| `path/file1` | [purpose] | ~N |
+| `path/file2` | [purpose] | ~N |
+
+### Files Modified
+| File | Changes |
+|------|---------|
+| `path/file` | [changes] |
+
+---
+
+## Technical Decisions
+
+1. **[Decision]**: [Rationale]
+2. **[Decision]**: [Rationale]
+
+---
+
+## Test Results
+
+| Metric | Value |
+|--------|-------|
+| Tests | N |
+| Passed | N |
+| Coverage | X% |
+
+---
+
+## Lessons Learned
+
+1. [Lesson]
+2. [Lesson]
+
+---
+
+## Future Considerations
+
+Items for future sessions:
+1. [Item]
+2. [Item]
+
+---
+
+## Session Statistics
+
+- **Tasks**: N completed
+- **Files Created**: N
+- **Files Modified**: N
+- **Tests Added**: N
+- **Blockers**: N resolved
+```
+
+### 5. Check Phase Completion
+
+If this was the last session in the phase:
+- Update phase status to "complete" in state.json
+- Archive phase: move `.spec_system/PRD/phase_NN/` to `.spec_system/archive/phases/phase_NN/`
+- Update master `.spec_system/PRD/PRD.md`
+
+### 6. Increment Project Version
+
+Increment the project's patch version in standard version files. Check for these files in order and update the first one found:
+
+| File | Version Location | Example |
+|------|------------------|---------|
+| `package.json` | `"version": "X.Y.Z"` | `1.2.3` -> `1.2.4` |
+| `pyproject.toml` | `version = "X.Y.Z"` | `1.2.3` -> `1.2.4` |
+| `setup.py` | `version="X.Y.Z"` | `1.2.3` -> `1.2.4` |
+| `Cargo.toml` | `version = "X.Y.Z"` | `1.2.3` -> `1.2.4` |
+| `version.txt` | Plain version string | `1.2.3` -> `1.2.4` |
+| `VERSION` | Plain version string | `1.2.3` -> `1.2.4` |
+
+**Version increment rules:**
+- Increment the **patch** version by default (X.Y.Z -> X.Y.Z+1)
+- If version has pre-release suffix (e.g., `-alpha`, `-beta`), preserve it
+- If no version file found, skip this step and note it in the report
+- **Monorepo**: Check the package directory first for a version file (e.g., `apps/web/package.json`), then fall back to the repo root version file. Increment whichever is found first. If both exist, increment the package version file only -- root version is managed separately.
+
+**Also update version in documentation** if the project follows the monorepo documentation standard (see documents):
+- `README.md` - if it contains a version badge or version line
+- Any other files that reference the project version
+
+### 7. Commit and Push to Repo
+
+Commit and push ALL non-gitignored repo changes.  DO NOT add ANY attributions or co-authors!
+
+Commit message format:
+```
+Complete phaseNN-sessionNN-name: [brief description]
+
+- [key deliverable 1]
+- [key deliverable 2]
+- Version: X.Y.Z -> X.Y.Z+1
+```
+
+**Monorepo**: Include the package path in the commit message when applicable:
+```
+Complete phaseNN-sessionNN-name (apps/web): [brief description]
+
+- [key deliverable 1]
+- [key deliverable 2]
+- Version (apps/web): X.Y.Z -> X.Y.Z+1
+```
+
+### 8. Report Completion
+
+Tell the user:
+- Session marked complete
+- Updated files list
+- Version change (old -> new)
+- Phase progress
+- Next recommended action
+
+## Output
+
+Report: session marked complete, updated files, version change, phase progress, and next action (plansession if phase continues, audit if phase complete).

--- a/skills/.experimental/apex-spec/references/utilities.md
+++ b/skills/.experimental/apex-spec/references/utilities.md
@@ -1,0 +1,238 @@
+# Utility Commands
+
+Standalone helpers that operate **outside the session workflow**.
+These can be run at any time -- they do not read or modify session state (`state.json`), specs, or task checklists.
+
+## When to Use
+
+Use utility commands for ad-hoc operations that support your workflow but are not part of the plan-implement-validate cycle. They are safe to run at any point -- mid-session, between sessions, or before initialization.
+
+## Command Reference
+
+| Command | Purpose |
+|---------|---------|
+| `sculpt-ui` | Guide AI-led creation of distinctive, production-grade frontend interfaces |
+| `copush` | Pull, version-bump, commit all changes, and push to origin |
+| `dockcleanbuild` | Clean Docker environment and rebuild all images and containers from scratch |
+| `dockbuild` | Quick Docker Compose build and start with full output |
+| `up2imp` | Audit upstream changes and curate an optimally ordered implementation list |
+| `pullndoc` | Git pull an upstream repo and document every imported change |
+| `qimpl` | Context-aware autonomous implementation session driven by a work file |
+| `qfrontdev` | Autonomous frontend implementation session with designer-level quality standards |
+| `qbackenddev` | Autonomous backend/infrastructure development session driven by a work file |
+
+## Adding a New Utility Command
+
+### 1. Create the reference file
+
+Create `references/<name>.md` with this structure (no frontmatter):
+
+```markdown
+# <name>
+
+<Purpose paragraph>
+
+## Rules
+
+- <constraints and guardrails>
+
+## Steps
+
+1. <step>
+2. <step>
+...
+```
+
+Keep utility commands focused -- they should do one thing well and require minimal context.
+
+### 2. Document it here
+
+Add a row to the Command Reference table above, then add a section below with:
+
+```markdown
+## <name>
+
+**Purpose**: What it does in one sentence.
+
+**Usage**:
+
+<name> [arguments if any]
+
+**Behavior**: What happens when you run it.
+```
+
+### 3. Update README.md
+
+Add the command to the Utility Commands table in README.md.
+
+---
+
+## Conventions
+
+- Utility commands **must not** modify `state.json`, session specs, or task checklists
+- Utility commands **may** read `.spec_system/` files for context
+- Utility commands **may** modify project source files, configs, or non-session spec system files
+- Frontmatter must include `category: utility`
+- Command names should be short, verb-first when possible (e.g., `check-ascii`, `reset-hooks`)
+
+---
+
+## copush
+
+**Purpose**: Pull latest from origin, increment the project version, commit all non-gitignored changes, and push.
+
+**Usage**:
+```
+copush
+```
+
+**Behavior**: Pulls from origin (never upstream) and halts if the merge is not clean.
+Increments the patch version in all project version files (README.md, plugin.json, etc.),
+preserving any pre-release tag. Stages and commits ALL non-gitignored changes -- including
+work outside the current session -- with no co-author or attribution lines. Pushes to origin
+and halts if rejected. Reports every step's outcome.
+
+---
+
+## dockcleanbuild
+
+**Purpose**: Full Docker cleanup and from-scratch rebuild cycle, preserving volumes/data.
+
+**Usage**:
+```
+dockcleanbuild
+```
+
+**Behavior**: Clears Docker build cache and stale images, then stops and removes the
+project's containers (preserving volumes). Builds the project source if applicable, then
+rebuilds all Docker images with `--no-cache` -- primary Dockerfile first, then any
+secondary Dockerfiles (Dockerfile.local, etc.). Brings containers back up and runs a
+final cleanup of dangling images. All docker commands use `sudo`. Reports ALL output
+including warnings, errors, deprecation notices, and update notices regardless of severity.
+
+---
+
+## dockbuild
+
+**Purpose**: Quick Docker Compose build-and-start with full output reporting.
+
+**Usage**:
+```
+dockbuild
+```
+
+**Behavior**: Runs `sudo docker compose up -d --build 2>&1 | tee dev/stderr` to build
+and start containers with full output capture. Verifies container status afterwards.
+Reports every warning, error, deprecation notice, update notice, and informational
+message found in the output, no matter how minor.
+
+---
+
+## up2imp
+
+**Purpose**: Audit a raw upstream changes list and rewrite it as a curated, optimally ordered implementation list for a hardened fork.
+
+**Usage**:
+```
+up2imp <changes-file> [upstream-dir]
+```
+
+**Behavior**: Reads the specified changes file (raw upstream updates since last comparison)
+and the upstream codebase directory (defaults to `.001_ORIGINAL/`). Classifies each change
+as include or exclude based on whether it objectively improves the fork (bug fixes,
+performance, security, stability, meaningful refactors). Excludes stripped features,
+unused components, cosmetic changes, and anything conflicting with the fork's direction.
+Rewrites the changes file in place with only actionable items in optimal implementation
+order, preserving enough detail for efficient engineering.
+
+---
+
+## qimpl
+
+**Purpose**: Run an autonomous, context-window-disciplined implementation session guided by a work file.
+
+**Usage**:
+```
+qimpl <work-file>
+```
+
+**Behavior**: Reads the work file for session goals and prior context, verifies details
+against the actual codebase, then implements methodically with senior-engineer rigor.
+Stops after approximately 30 tool executions or when the session feels overloaded to
+maintain output quality. Updates the work file on exit with progress, remaining work,
+and notes for session continuity. Never assumes or guesses -- looks up uncertain details.
+
+---
+
+## qbackenddev
+
+**Purpose**: Run an autonomous backend, infrastructure, or general engineering session guided by a work file.
+
+**Usage**:
+```
+qbackenddev <work-file>
+```
+
+**Behavior**: Reads the work file for session goals (implement, audit, plan, refactor,
+document, convert, or review partner work) covering backend code, infrastructure, DevOps,
+CLI commands, APIs, and databases. Analyzes existing codebase patterns before making
+changes. Verifies all work file details against actual code. Works autonomously through
+all tasks without asking permission. Supports merging multiple draft plans, validating a
+partner engineer's audit, and converting between formats. Stops after approximately 30
+tool executions or when the session feels overloaded and updates the work file for
+session continuity.
+
+---
+
+## qfrontdev
+
+**Purpose**: Run an autonomous frontend development session with senior-engineer rigor and designer-level quality standards, guided by a work file.
+
+**Usage**:
+```
+qfrontdev <work-file>
+```
+
+**Behavior**: Reads the work file for session goals (implement, audit, plan, fix, document,
+or refactor) with a designer's eye for quality. Verifies all referenced details against
+the actual codebase before writing code. Works autonomously through all tasks in the work
+file, applying a quality gate (responsive, accessible, consistent, complete, performant)
+to every change. Targets Linear/Vercel/Stripe-level polish as the minimum standard.
+Stops after approximately 30 tool executions or when the session feels overloaded and
+updates the work file for session continuity.
+
+---
+
+## pullndoc
+
+**Purpose**: Pull an upstream/original repo and generate a comprehensive changelog documenting every imported change.
+
+**Usage**:
+```
+pullndoc <upstream-dir>
+```
+
+**Behavior**: Snapshots the current HEAD of the upstream directory, runs `git pull`, then
+analyzes every commit and file diff between the old and new HEAD. Generates a markdown file
+at `<upstream-dir>/docs/upstream-pull-<YYYY-MM-DD>.md` with a full summary, commit log,
+per-file change descriptions (with intent, not just line counts), and a breaking changes
+section. Never omits any changed file. Stops early if already up to date.
+
+---
+
+## sculpt-ui
+
+**Purpose**: Guide AI-led creation of distinctive, production-grade frontend interfaces with high design quality.
+
+**Usage**:
+```
+sculpt-ui
+```
+
+**Behavior**: Walks through a four-phase design process before and during frontend implementation.
+Phase 1 builds a Design Brief (emotional targets, aesthetic identity, signature moment).
+Phase 2 establishes a micro design system (type scale, color architecture, spacing, depth).
+Phase 3 covers implementation craft (layout composition, section transitions, motion choreography, advanced CSS/SVG techniques).
+Phase 4 enforces quality standards (60fps performance, WCAG AA accessibility, responsive adaptive design).
+Also includes an anti-pattern checklist to avoid generic AI output.
+Read-only on the spec system -- never modifies state.json, specs, or task checklists.

--- a/skills/.experimental/apex-spec/references/validate.md
+++ b/skills/.experimental/apex-spec/references/validate.md
@@ -1,0 +1,498 @@
+# validate
+
+Verify that all session requirements are met before marking the session complete.
+
+## Rules
+
+1. **PASS requires ALL of**: 100% tasks complete, all deliverables exist, all files ASCII-encoded with LF endings, all tests passing, all success criteria met, no security or GDPR violations, no critical behavioral quality violations (when BQC applies)
+2. **Any single failure = overall FAIL** - no partial passes
+3. **Script first** - run `analyze-project.sh --json` before any analysis
+4. Conventions compliance is a spot-check, not exhaustive - flag obvious violations only
+
+### No Deferral Policy
+
+- If a validation check fails and YOU can fix it (encoding issues, missing directories, failing tests with obvious fixes), FIX IT and re-validate
+- The ONLY valid reason to report a FAIL back to the user is when the fix requires their input, credentials, or decisions only a human can make
+- "The environment isn't set up" is NOT a valid FAIL -- setting it up IS the task
+- If you report a FAIL for something you could have fixed, that is a **critical failure**
+
+## Steps
+
+### 1. Get Deterministic Project State (REQUIRED FIRST STEP)
+
+Run the analysis script to get reliable state facts. Local scripts (`.spec_system/scripts/`) take precedence over plugin scripts if they exist:
+
+```bash
+# Check for local scripts first, fall back to plugin
+if [ -d ".spec_system/scripts" ]; then
+  bash .spec_system/scripts/analyze-project.sh --json
+else
+  bash scripts/analyze-project.sh --json
+fi
+```
+
+This returns structured JSON including:
+- `current_session` - The session to validate
+- `current_session_dir_exists` - Whether specs directory exists
+- `current_session_files` - Files already in the session directory
+- `monorepo` - true/false/null from state.json
+- `packages` - Array of registered packages (empty if not monorepo)
+- `active_package` - Resolved package context (null if not applicable)
+
+**IMPORTANT**: Use the `current_session` value from this output. If `current_session` is `null`, run plansession yourself to set one up. Only ask the user if plansession itself requires user input.
+
+### 1a. Determine Package Context (Monorepo Only)
+
+**Skip this step if** `monorepo` is not `true` in the JSON output.
+
+Resolve the active package for this session:
+
+1. **spec.md header**: Read the `Package:` field from the session's spec.md (set during plansession)
+2. **active_package from script**: If spec.md has no Package field, use `active_package` from the JSON output
+
+Store the resolved package path for use in Steps 3-5. A `null` package means this is a cross-cutting session.
+
+### 2. Read Session Files
+
+Using the `current_session` value from the script output, read all session documents:
+- `.spec_system/specs/[current-session]/spec.md` - Requirements
+- `.spec_system/specs/[current-session]/tasks.md` - Task checklist
+- `.spec_system/specs/[current-session]/implementation-notes.md` - Progress log
+- `.spec_system/specs/[current-session]/security-compliance.md` - Prior security report (if exists from previous validation run)
+- `.spec_system/CONVENTIONS.md` - Project coding conventions (if exists)
+
+**CONVENTIONS.md** is used in the Quality Gates check (section 3.E) to verify code follows project conventions for naming, structure, error handling, testing, etc.
+
+### 3. Run Validation Checks
+
+#### A. Task Completion
+Verify all tasks in tasks.md are marked `[x]`:
+- Count total tasks
+- Count completed tasks
+- List any incomplete tasks
+
+#### B. Deliverables Check
+From spec.md deliverables section:
+- Verify each file exists
+- Check file is non-empty
+- Note any missing files
+- **Monorepo**: File paths should be repo-root-relative (e.g., `apps/web/src/auth.ts`). Verify files are within the declared package scope (from Step 1a). Flag any deliverables outside the package boundary.
+
+#### C. ASCII Encoding Check
+For each deliverable file:
+```bash
+# Check encoding
+file [filename]  # Should show: ASCII text
+
+# Find non-ASCII characters
+LC_ALL=C grep '[^[:print:][:space:]]' [filename]
+
+# Check for CRLF line endings
+grep -l $'\r' [filename]
+```
+- Report any non-ASCII characters found
+- Report any CRLF line endings
+
+#### D. Test Verification
+Run the project's test suite:
+- Record total tests
+- Record passed/failed
+- Calculate coverage if available
+- Note any failures
+- **Monorepo**: When a package is resolved (Step 1a), run tests scoped to that package first (e.g., `cd apps/web && npm test`, or using workspace commands like `pnpm --filter web test`). Also run repo-root tests if they exist, since cross-package regressions matter.
+
+**CRITICAL -- NO "PRE-EXISTING" EXCUSE**: If ANY test fails, you MUST:
+1. Investigate the root cause -- determine whether the session's changes caused or contributed to the failure
+2. NEVER dismiss a failure as "pre-existing" or "environment issue" -- if tests passed before this session and fail now, THIS SESSION BROKE THEM
+3. FIX the failure before continuing validation. If you changed a Docker image, a dependency, a config file, or any shared code, failures in existing tests are YOUR responsibility
+4. Only after all tests pass (0 failures) may you mark Test Verification as PASS
+5. If a failure is genuinely unrelated (e.g., flaky network test), you must PROVE it by showing the test also fails on the pre-session commit -- do not assume
+
+#### E. Success Criteria
+From spec.md success criteria:
+- Check each functional requirement
+- Verify testing requirements met
+- Confirm quality gates passed
+
+#### F. Conventions Compliance (if CONVENTIONS.md exists)
+Spot-check deliverables against project conventions:
+- **Naming**: Functions, variables, files follow naming conventions
+- **Structure**: Files are organized according to file structure conventions
+- **Error Handling**: Follows the project's error handling approach
+- **Comments**: Explain "why" not "what", no commented-out code
+- **Testing**: Tests follow project testing philosophy
+- **Database** (if Database Layer conventions exist): Migration naming follows convention, model/table naming matches convention, required columns present on new tables, indexes on foreign keys
+
+Note: This is a spot-check, not exhaustive. Flag obvious violations only.
+
+#### G. Security & GDPR Compliance
+
+Review **only files created or modified in this session** (use deliverables from spec.md and git diff against the pre-session commit). Skip files not touched by this session.
+
+**Security (OWASP Top 10 spot-check):**
+- **Injection**: SQL, command, LDAP injection vectors -- unsanitized user input in queries or shell calls
+- **Broken Auth**: Hardcoded credentials, API keys, tokens, or secrets in source code
+- **Sensitive Data Exposure**: Unencrypted PII in logs, error messages, or responses; secrets in plaintext config
+- **Insecure Dependencies**: Known-vulnerable packages added in this session (`npm audit`, `pip audit`, `cargo audit` as applicable)
+- **Misconfiguration**: Debug modes enabled, overly permissive CORS, missing security headers
+- **Database Security** (if Database Layer conventions exist): Hardcoded connection strings (must use env vars), raw SQL with string concatenation (must use parameterized queries), missing down/rollback migrations, unencrypted sensitive columns (passwords, tokens, PII), unlimited connection pools, shared credentials between test and production
+
+**GDPR Compliance:**
+- **Data Collection**: Any new collection of personal data (names, emails, IPs, device IDs) must have a documented purpose and legal basis
+- **Consent**: If collecting user data, verify consent mechanism exists before data is stored
+- **Data Minimization**: Only the minimum necessary personal data is collected -- flag any over-collection
+- **Right to Erasure**: If storing personal data, verify a deletion path exists or is documented as a future requirement
+- **Data Logging**: Personal data must not appear in application logs -- check log statements for PII leakage
+- **Third-Party Sharing**: If sending data to external services, verify the transfer is documented
+
+**Scope rules:**
+- This is a targeted review of session deliverables, not a full codebase audit
+- Flag **clear violations** only -- do not speculate about edge cases
+- If the session added no user-facing data handling, mark GDPR as N/A with a brief justification
+- Hardcoded secrets and injection vulnerabilities are always FAIL regardless of scope
+- **Monorepo**: Scope the review to files within the declared package boundary (from Step 1a). Cross-cutting sessions review all modified files.
+
+#### H. Behavioral Quality Spot-Check
+
+Determine whether a BQC applies: does this session produce application code?
+
+**If no application code**: Mark as N/A and skip to Step 4.
+
+**If application code**: Select up to 5 deliverable files most likely to contain behavioral issues (files with side effects, mutations, external calls, user interaction, or data fetching). Spot-check against these priorities:
+
+| Priority | What to check | FAIL if... |
+|----------|---------------|------------|
+| 1 | Trust boundary enforcement | External input processed without validation, or access granted without authorization check |
+| 2 | Resource cleanup | Scoped lifecycle acquires resources (timers, subscriptions, connections) without releasing on exit |
+| 3 | Mutation safety | State-mutating actions triggerable multiple times while in-flight, or write path lacks idempotency protection |
+| 4 | Failure path completeness | Operation can fail but has no explicit error/failure handling visible to caller |
+| 5 | Contract alignment | Interface between components has shape mismatch, missing enum case, or schema drift |
+
+**Scoring**:
+- 0 violations: PASS
+- 1-2 low-severity (e.g., missing retry backoff on non-critical read path): WARN -- log but do not block
+- Any high-severity in top priorities: FAIL -- fix before passing
+
+### 4. Generate Security & Compliance Report
+
+Create `security-compliance.md` in the session directory (`.spec_system/specs/[current-session]/security-compliance.md`):
+
+```markdown
+# Security & Compliance Report
+
+**Session ID**: `phaseNN-sessionNN-name`
+[MONOREPO ONLY - include when monorepo: true]
+**Package**: [package-path]
+[END MONOREPO ONLY]
+**Reviewed**: [YYYY-MM-DD]
+**Result**: PASS / FAIL / N/A
+
+---
+
+## Scope
+
+**Files reviewed** (session deliverables only):
+- `path/file1` - [brief description]
+- `path/file2` - [brief description]
+
+**Review method**: Static analysis of session deliverables + dependency audit (if applicable)
+
+---
+
+## Security Assessment
+
+### Overall: PASS / FAIL
+
+| Category | Status | Severity | Details |
+|----------|--------|----------|---------|
+| Injection (SQLi, CMDi, LDAPi) | PASS/FAIL | -- / Critical / High | [details] |
+| Hardcoded Secrets | PASS/FAIL | -- / Critical | [details] |
+| Sensitive Data Exposure | PASS/FAIL | -- / High / Medium | [details] |
+| Insecure Dependencies | PASS/FAIL | -- / High / Medium | [details] |
+| Security Misconfiguration | PASS/FAIL | -- / Medium | [details] |
+
+### Findings
+
+#### [Finding Title] (if any)
+- **Severity**: Critical / High / Medium / Low
+- **File**: `path/file:line`
+- **Description**: [what the issue is]
+- **Remediation**: [how to fix it]
+- **Status**: Open / Remediated
+
+[Repeat for each finding, or "No security findings."]
+
+---
+
+## GDPR Compliance Assessment
+
+### Overall: PASS / FAIL / N/A
+
+*N/A if session introduced no personal data handling.*
+
+| Category | Status | Details |
+|----------|--------|---------|
+| Data Collection & Purpose | PASS/FAIL/N/A | [details] |
+| Consent Mechanism | PASS/FAIL/N/A | [details] |
+| Data Minimization | PASS/FAIL/N/A | [details] |
+| Right to Erasure | PASS/FAIL/N/A | [details] |
+| PII in Logs | PASS/FAIL/N/A | [details] |
+| Third-Party Data Transfers | PASS/FAIL/N/A | [details] |
+
+### Personal Data Inventory (if applicable)
+
+| Data Element | Source | Storage | Purpose | Retention | Deletion Path |
+|-------------|--------|---------|---------|-----------|---------------|
+| [e.g., email] | [user input] | [database table] | [authentication] | [until account deletion] | [DELETE /api/user] |
+
+[Or "No personal data collected or processed in this session."]
+
+### Findings
+
+#### [Finding Title] (if any)
+- **Category**: [GDPR category]
+- **File**: `path/file:line`
+- **Description**: [what the issue is]
+- **Remediation**: [how to fix it]
+- **Status**: Open / Remediated
+
+[Repeat for each finding, or "No GDPR findings."]
+
+---
+
+## Recommendations
+
+[Actionable items for future sessions, or "None -- session is compliant."]
+
+---
+
+## Sign-Off
+
+- **Result**: PASS / FAIL / N/A
+- **Reviewed by**: AI validation (validate)
+- **Date**: [YYYY-MM-DD]
+```
+
+### 5. Generate Validation Report
+
+Create `validation.md` in the session directory:
+
+```markdown
+# Validation Report
+
+**Session ID**: `phaseNN-sessionNN-name`
+[MONOREPO ONLY - include when monorepo: true]
+**Package**: [package-path]
+[END MONOREPO ONLY]
+**Validated**: [YYYY-MM-DD]
+**Result**: PASS / FAIL
+
+---
+
+## Validation Summary
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Tasks Complete | PASS/FAIL | X/Y tasks |
+| Files Exist | PASS/FAIL | X/Y files |
+| ASCII Encoding | PASS/FAIL | [issues] |
+| Tests Passing | PASS/FAIL | X/Y tests |
+| Quality Gates | PASS/FAIL | [issues] |
+| Conventions | PASS/SKIP | [issues or "No CONVENTIONS.md"] |
+| Security & GDPR | PASS/FAIL/N/A | [issues] |
+| Behavioral Quality | PASS/WARN/FAIL/N/A | [issues or "N/A -- no application code"] |
+
+**Overall**: PASS / FAIL
+
+---
+
+## 1. Task Completion
+
+### Status: PASS/FAIL
+
+| Category | Required | Completed | Status |
+|----------|----------|-----------|--------|
+| Setup | N | N | PASS |
+| Foundation | N | N | PASS |
+| Implementation | N | N | PASS |
+| Testing | N | N | PASS |
+
+### Incomplete Tasks
+[List any incomplete tasks or "None"]
+
+---
+
+## 2. Deliverables Verification
+
+### Status: PASS/FAIL
+
+#### Files Created
+| File | Found | Status |
+|------|-------|--------|
+| `path/file1` | Yes | PASS |
+| `path/file2` | Yes | PASS |
+
+### Missing Deliverables
+[List any missing or "None"]
+
+---
+
+## 3. ASCII Encoding Check
+
+### Status: PASS/FAIL
+
+| File | Encoding | Line Endings | Status |
+|------|----------|--------------|--------|
+| `path/file1` | ASCII | LF | PASS |
+
+### Encoding Issues
+[List issues or "None"]
+
+---
+
+## 4. Test Results
+
+### Status: PASS/FAIL
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | N |
+| Passed | N |
+| Failed | 0 |
+| Coverage | X% |
+
+### Failed Tests
+[List failures or "None"]
+
+---
+
+## 5. Success Criteria
+
+From spec.md:
+
+### Functional Requirements
+- [x] [Requirement 1]
+- [x] [Requirement 2]
+
+### Testing Requirements
+- [x] Unit tests written and passing
+- [x] Manual testing completed
+
+### Quality Gates
+- [x] All files ASCII-encoded
+- [x] Unix LF line endings
+- [x] Code follows project conventions
+
+---
+
+## 6. Conventions Compliance
+
+### Status: PASS/SKIP
+
+*Skipped if no `.spec_system/CONVENTIONS.md` exists.*
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Naming | PASS/FAIL | [issues] |
+| File Structure | PASS/FAIL | [issues] |
+| Error Handling | PASS/FAIL | [issues] |
+| Comments | PASS/FAIL | [issues] |
+| Testing | PASS/FAIL | [issues] |
+
+### Convention Violations
+[List violations or "None" or "Skipped - no CONVENTIONS.md"]
+
+---
+
+## 7. Security & GDPR Compliance
+
+### Status: PASS/FAIL/N/A
+
+**Full report**: See `security-compliance.md` in this session directory.
+
+#### Summary
+| Area | Status | Findings |
+|------|--------|----------|
+| Security | PASS/FAIL | [count] issues |
+| GDPR | PASS/FAIL/N/A | [count] issues |
+
+### Critical Violations (if any)
+[List critical/high severity items or "None"]
+
+---
+
+## 8. Behavioral Quality Spot-Check
+
+### Status: PASS/WARN/FAIL/N/A
+
+*N/A if session produced no application code.*
+
+**Checklist applied**: [Yes / N/A]
+**Files spot-checked**: [list of up to 5 files]
+
+| Category | Status | File | Details |
+|----------|--------|------|---------|
+| Trust boundaries | PASS/FAIL | `path` | [details or "--"] |
+| Resource cleanup | PASS/FAIL | `path` | [details or "--"] |
+| Mutation safety | PASS/FAIL | `path` | [details or "--"] |
+| Failure paths | PASS/FAIL | `path` | [details or "--"] |
+| Contract alignment | PASS/FAIL | `path` | [details or "--"] |
+
+### Violations Found
+[List with file:line, category, severity, or "None"]
+
+### Fixes Applied During Validation
+[List fixes, or "None"]
+
+## Validation Result
+
+### PASS / FAIL
+
+[Summary of validation outcome]
+
+### Required Actions (if FAIL)
+[List what needs to be fixed]
+
+## Next Steps
+
+[If PASS]: Run updateprd to mark session complete.
+[If FAIL]: Address required actions and run validate again.
+```
+
+### 6. Update State
+
+Update `.spec_system/state.json` based on validation result:
+
+**If PASS:**
+```json
+{
+  "current_session": "phaseNN-sessionNN-name",
+  "next_session_history": [
+    {
+      "date": "YYYY-MM-DD",
+      "session": "phaseNN-sessionNN-name",
+      "status": "validated"
+    }
+  ]
+}
+```
+
+**If FAIL:**
+```json
+{
+  "next_session_history": [
+    {
+      "date": "YYYY-MM-DD",
+      "session": "phaseNN-sessionNN-name",
+      "status": "validation_failed"
+    }
+  ]
+}
+```
+
+- Update `next_session_history` entry status to `validated` or `validation_failed`
+- **Monorepo only**: Include the `package` field in the history entry when a package was resolved in Step 1a (matching the pattern from plansession Step 6). Omit the `package` field for single-repo projects or cross-cutting sessions.
+
+## Output
+
+Report PASS/FAIL with a summary of each check. If PASS, prompt updateprd. If FAIL, list issues with suggested fixes and prompt re-run of validate.

--- a/skills/.experimental/apex-spec/references/walkthrough.md
+++ b/skills/.experimental/apex-spec/references/walkthrough.md
@@ -1,0 +1,479 @@
+# Apex Spec System Walkthrough
+
+A real-world walkthrough based on an actual project: **NJ Title Intelligence Platform**.
+
+> This walkthrough uses artifacts from a production project that processed 4M+ parcels across 16 phases and 79+ sessions over 3 weeks.
+
+---
+
+## The Project
+
+**NJ Title Intelligence Platform** - A property intelligence system for NJ title insurance that unifies parcel, lien, environmental, and corporate data using free public data sources.
+
+| Metric | Value |
+|--------|-------|
+| Total Phases | 16 |
+| Completed Sessions | 79+ |
+| Records Processed | 4M+ parcels, 105M+ historical records |
+| Development Time | ~3 weeks |
+| Tech Stack | Python/Litestar, PostgreSQL/PostGIS, React/Next.js |
+
+---
+
+## Stage 1: Initialization
+
+### Step 1: initspec
+
+```
+User: initspec
+```
+
+Claude creates the spec system structure:
+
+```
+title_clerk/
+|-- .spec_system/
+|   |-- state.json              # Tracks progress
+|   |-- CONSIDERATIONS.md       # Lessons learned
+|   |-- SECURITY-COMPLIANCE.md  # Security posture & GDPR compliance
+|   |-- CONVENTIONS.md          # Coding standards
+|   \-- PRD/
+|       \-- PRD.md              # Empty template
+```
+
+### Step 2: createprd
+
+```
+User: createprd "A property intelligence platform for NJ title insurance
+      that maximizes FREE public data, covering 21 NJ counties, 564
+      municipalities, and ~4M parcels with $0 data acquisition cost."
+```
+
+Claude generates a comprehensive PRD with phase breakdown:
+
+```markdown
+# NJ Title Intelligence Platform - PRD
+
+## Phase Map
+| Phase | Name | Sessions |
+|-------|------|----------|
+| 01 | Infrastructure & Project Setup | 7 |
+| 02 | MOD-IV Data Pipeline | 6 |
+| 03 | Core Parcel API | 4 |
+| 04 | Federal Lien Integration | 5 |
+| 05 | Frontend Application (Foundation) | 6 |
+| 06 | Environmental Risk | 5 |
+| ... | ... | ... |
+| 16 | Frontend: Corporate & Admin Features | 5 |
+```
+
+### Step 3: phasebuild
+
+```
+User: phasebuild
+```
+
+Creates Phase 01 structure with session stubs:
+
+```
+.spec_system/PRD/phase_01/
+|-- README.md
+|-- session_01_project_structure_python_setup.md
+|-- session_02_docker_compose_postgresql.md
+|-- session_03_database_extensions_init.md
+|-- session_04_litestar_application_skeleton.md
+|-- session_05_alembic_migrations_framework.md
+|-- session_06_redis_celery_configuration.md
+\-- session_07_development_tooling_documentation.md
+```
+
+---
+
+## Stage 2: Session Workflow
+
+This is where the real work happens. Repeat for each session until the phase is complete.
+
+### Step 4: plansession
+
+```
+User: plansession
+```
+
+Claude analyzes project state, recommends the next session, creates the specification, and generates the task checklist -- all in one step:
+
+```markdown
+# Recommendation
+
+**Recommended**: phase09-session01-rutgers-modiv-analysis
+
+## Why This Session
+- Phase 09 is next in sequence
+- Session 01 establishes historical data foundation
+- Prerequisites met: Phase 02 bulk loader patterns available
+```
+
+Creates the spec and tasks in the session directory:
+
+```
+.spec_system/specs/phase09-session01-rutgers-modiv-analysis/
+|-- spec.md
+|-- tasks.md
+\-- (security-compliance.md, validation.md created by validate)
+```
+
+**Actual spec.md excerpt:**
+
+```markdown
+# Session Specification
+
+**Session ID**: phase09-session01-rutgers-modiv-analysis
+**Phase**: 09 - Historical Data + Workflow
+**Created**: 2025-12-21
+
+## 1. Session Overview
+
+This session establishes the foundation for loading 105M+ historical
+parcel records from Rutgers University's MOD-IV data archive (1989-present).
+
+## 4. Scope
+
+### In Scope (MVP)
+- Analyze Rutgers MOD-IV data portal structure
+- Document available data files by year and county
+- Design parcel_history table with 44+ core fields
+- Define partition boundaries: 1989-1999, 2000-2009, 2010-2019, 2020+
+```
+
+**Actual tasks.md excerpt:**
+
+```markdown
+# Task Checklist
+
+**Session ID**: phase09-session01-rutgers-modiv-analysis
+**Total Tasks**: 24
+**Estimated Duration**: 2-3 hours
+
+## Setup (3 tasks)
+
+- [ ] T001 [S0901] Create `docs/historical-data/` directory structure
+- [ ] T002 [S0901] Verify access to Rutgers MOD-IV portal
+- [ ] T003 [S0901] Review existing Parcel model schema for reference
+
+## Portal Analysis (5 tasks)
+
+- [ ] T004 [S0901] Document portal navigation structure
+- [ ] T005 [S0901] Identify all available tax years (1989-2024)
+- [ ] T006 [S0901] Document available file formats per year
+- [ ] T007 [S0901] [P] Analyze county-level data organization
+- [ ] T008 [S0901] [P] Document download mechanisms and rate limits
+```
+
+### Step 5: implement
+
+```
+User: implement
+```
+
+Claude works through tasks one by one:
+
+- Reads spec.md and tasks.md for context
+- Implements each task sequentially
+- Marks tasks `[x]` as completed
+- Logs progress in implementation-notes.md
+- Handles blockers with documentation
+
+**Progress tracking in real-time:**
+
+```markdown
+## Implementation Progress
+
+### T001 - Create directory structure
+Status: Complete
+Created: docs/historical-data/
+
+### T002 - Verify portal access
+Status: Complete
+Portal accessible at https://modiv.rutgers.edu/
+Identified: 21 counties, years 1989-2024
+
+### T003 - Review Parcel model
+Status: Complete
+Reference: 44 fields in current schema
+```
+
+### Step 6: validate
+
+```
+User: validate
+```
+
+Claude verifies session completeness:
+
+**Actual validation.md:**
+
+```markdown
+# Validation Report
+
+**Session ID**: phase09-session01-rutgers-modiv-analysis
+**Validated**: 2025-12-21
+**Result**: PASS
+
+## Validation Summary
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Tasks Complete | PASS | 24/24 tasks |
+| Files Exist | PASS | 7/7 files |
+| ASCII Encoding | PASS | All ASCII |
+| Line Endings | PASS | All LF |
+| Quality Gates | PASS | No issues |
+| Security & GDPR | PASS | No findings |
+
+**Overall**: PASS
+
+## 1. Task Completion
+
+| Category | Required | Completed | Status |
+|----------|----------|-----------|--------|
+| Setup | 3 | 3 | PASS |
+| Portal Analysis | 5 | 5 | PASS |
+| Field Analysis | 5 | 5 | PASS |
+| Schema Design | 5 | 5 | PASS |
+| Documentation | 4 | 4 | PASS |
+| Validation | 2 | 2 | PASS |
+| **Total** | **24** | **24** | **PASS** |
+
+## 2. Deliverables Verification
+
+| File | Found | Lines | Status |
+|------|-------|-------|--------|
+| docs/historical-data/rutgers-portal-analysis.md | Yes | 237 | PASS |
+| docs/historical-data/field-mapping.md | Yes | 302 | PASS |
+| docs/historical-data/partition-design.md | Yes | 189 | PASS |
+```
+
+### Step 7: updateprd
+
+```
+User: updateprd
+```
+
+Claude marks session complete and commits:
+
+- Adds session to `completed_sessions` in state.json
+- Updates phase README with completion status
+- **Commits and pushes** (your recovery safety net!)
+- Clears `current_session`
+- Reports next steps
+
+```
+Session phase09-session01-rutgers-modiv-analysis marked COMPLETE.
+
+Phase 09 Progress: 1/8 sessions complete (12.5%)
+
+Next: Run plansession for session 02 recommendation.
+```
+
+### Repeat Until Phase Complete
+
+Continue the cycle:
+```
+plansession -> implement -> validate -> updateprd
+```
+
+Until all sessions in the phase are done.
+
+---
+
+## Stage 3: Phase Transition
+
+After completing all sessions in a phase, run the phase transition commands.
+
+### audit
+
+```
+User: audit
+```
+
+Adds local dev tooling one bundle at a time:
+1. Formatting (Prettier, Ruff)
+2. Linting (ESLint, Ruff)
+3. Type Safety (TypeScript, mypy)
+4. Testing (Jest, pytest + coverage)
+5. Observability (structlog, pino, tracing, slog)
+6. Git Hooks (husky, pre-commit)
+
+Run multiple times until all bundles are configured.
+
+### pipeline
+
+```
+User: pipeline
+```
+
+Adds CI/CD workflows one bundle at a time:
+1. Code Quality (lint + format + type check)
+2. Build & Test (build + unit tests + coverage)
+3. Security (secrets scanning + CodeQL)
+4. Integration (E2E tests)
+5. Operations (Dependabot, release tagging)
+
+### infra
+
+```
+User: infra
+```
+
+Adds production infrastructure one bundle at a time:
+1. Health (health endpoint + probes)
+2. Security (WAF rules + rate limiting)
+3. Backup (DB backup + retention)
+4. Deploy (CD webhook from main)
+
+### carryforward
+
+```
+User: carryforward
+```
+
+Captures lessons learned in CONSIDERATIONS.md and updates SECURITY-COMPLIANCE.md:
+
+**Actual excerpt from title_clerk:**
+
+```markdown
+## Lessons Learned
+
+### What Worked
+
+- [P01] **PostGIS + Apache AGE + pgvector stack**: Single PostgreSQL
+  instance with extensions handles spatial, graph, and vector needs.
+
+- [P02] **Idempotent bulk loader pattern**: Loading 4M+ parcels with
+  UPSERT ensures reruns are safe. Always build data pipelines rerunnable.
+
+- [P04] **CourtListener hybrid approach**: Bulk S3 dumps for initial
+  seeding (unlimited), REST API for real-time (rate-limited).
+
+- [P07] **PyMuPDF before Tesseract**: Always try native PDF text
+  extraction first. OCR is 6x slower and should be fallback only.
+
+- [P08] **5s+ delays for NJ Courts**: Respecting rate limits prevents
+  WAF blocks. Aggressive scraping causes IP bans - patience wins.
+
+### What To Avoid
+
+- [P08] **Playwright scraper fragility**: NJ Courts scraper depends on
+  DOM selectors that may break with site updates.
+```
+
+### documents
+
+```
+User: documents
+```
+
+Audits and updates documentation:
+- README.md
+- CONTRIBUTING.md
+- docs/ARCHITECTURE.md
+- API documentation
+- Per-package READMEs
+
+### Manual Testing
+
+**Highly recommended** - Test the phase's features manually before proceeding.
+
+### phasebuild (Next Phase)
+
+```
+User: phasebuild
+```
+
+Creates structure for the next phase, then return to Stage 2.
+
+---
+
+## Real Project Timeline
+
+The title_clerk project progressed through 16 phases:
+
+| Date | Sessions Completed | Phases |
+|------|-------------------|--------|
+| Dec 8 | 6 | Phase 01 started |
+| Dec 9 | 13 | Phases 01-02 complete |
+| Dec 10 | 4 | Phase 03 complete |
+| Dec 11 | 11 | Phases 04-05 complete |
+| Dec 12-13 | 11 | Phases 06-07 complete |
+| Dec 21-22 | 14 | Phases 08-09 complete |
+| Dec 22-23 | 8 | Phase 10 complete |
+| Dec 24 | 6 | Phase 11 complete |
+| Dec 25 | 7 | Phase 12 complete |
+| Dec 28 | 7 | Phase 13 complete, 14 in progress |
+
+**79+ sessions completed in ~3 weeks** with consistent structure and documentation.
+
+---
+
+## Key Takeaways
+
+1. **Sessions are atomic** - Each session has clear scope (12-25 tasks, 2-4 hours)
+
+2. **State is tracked** - state.json knows exactly where you are
+
+3. **Git is your safety net** - Every updateprd commits and pushes
+
+4. **Lessons accumulate** - CONSIDERATIONS.md grows with institutional memory; SECURITY-COMPLIANCE.md tracks cumulative security posture
+
+5. **Phase transitions matter** - audit, pipeline, infra ensure production readiness
+
+6. **Trust the system** - Follow the workflow, resist scope creep
+
+---
+
+## Monorepo Walkthrough (Summary)
+
+Apex Spec supports monorepo projects with per-package session scoping. Here is a condensed example using an **Acme SaaS Platform** (pnpm + Turborepo) with `apps/web`, `apps/api`, and `packages/shared`.
+
+### Key Differences from Single-Repo
+
+| Aspect | Single-Repo | Monorepo |
+|--------|------------|----------|
+| Session scoping | Whole project | Per-package (e.g., `apps/web`) |
+| state.json | `monorepo: false` | `monorepo: true` + `packages` array |
+| Session stubs | No Package annotation | `Package: apps/web` in header |
+| completed_sessions | String IDs | Object with `id` + `package` |
+| Prerequisites | Project-level | Package-level (`check-prereqs.sh --package apps/web`) |
+| Audit/pipeline | Single config | Per-package based on stack |
+
+### Monorepo Workflow
+
+1. **initspec** detects monorepo structure (workspace manager, packages) and populates state.json
+2. **createprd** adds a Package Map section to the PRD; CONVENTIONS.md gains a Workspace Structure table
+3. **phasebuild** annotates session stubs with `Package:` lines
+4. **plansession** resolves package context from stub annotations and scopes tasks to the package directory
+5. **implement** validates files stay within the declared package boundary
+6. **validate** runs package-scoped tests first, then repo-root tests
+7. **updateprd** records package in completed_sessions and history entries
+
+### Key Monorepo Takeaways
+
+1. **One .spec_system/ at the root** -- not per-package
+2. **Sessions interleave** across packages within a phase
+3. **Phase completion is global** -- all sessions must complete regardless of package
+4. **Cross-cutting sessions are normal** -- use them for workspace config, CI/CD, shared infra
+5. **Package context is automatic** -- flows from stub annotations through spec.md to implementation
+
+---
+
+## Quick Reference
+
+```
+Stage 1: INITIALIZATION (once)
+initspec -> createprd -> createuxprd (optional) -> phasebuild
+
+Stage 2: SESSION WORKFLOW (repeat per session)
+plansession -> implement -> validate -> updateprd
+
+Stage 3: PHASE TRANSITION (after all phase sessions complete)
+audit -> pipeline -> infra -> carryforward -> documents -> manual testing -> phasebuild
+```

--- a/skills/.experimental/apex-spec/references/workflow-overview.md
+++ b/skills/.experimental/apex-spec/references/workflow-overview.md
@@ -1,0 +1,120 @@
+# Workflow Overview
+
+Quick-reference for the Apex Spec System's 13-command workflow.
+
+## Core Philosophy
+
+**1 session = 1 spec = 2-4 hours (12-25 tasks)**
+
+A collection of sessions is a phase. A collection of phases is a mature
+technical PRD.
+
+## Session Scope Rules
+
+| Limit | Value |
+|-------|-------|
+| Maximum tasks | 25 |
+| Maximum duration | 4 hours |
+| Ideal task count | 12-25 (sweet spot: 20) |
+| Objectives | Single clear objective |
+
+## The 3 Stages
+
+### Stage 1: Initialization (One-Time Setup)
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| 1 | initspec | Set up .spec_system/ in your project |
+| 2 | createprd | Generate PRD from requirements doc (optional) |
+| 3 | createuxprd | Generate UX PRD from design docs (optional) |
+| 4 | phasebuild | Create first phase structure with session stubs |
+
+### Stage 2: Session Workflow (Repeat Until Phase Complete)
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| 1 | plansession | Analyze project state, create spec + task checklist |
+| 2 | implement | AI-led task-by-task implementation |
+| 3 | validate | Verify session completeness and quality gates |
+| 4 | updateprd | Mark session complete, sync PRD and state |
+
+Repeat this cycle for each session in the phase.
+
+### Stage 3: Phase Transition (After All Phase Sessions Complete)
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| 1 | audit | Set up local dev tooling (formatter, linter, types, tests) |
+| 2 | pipeline | Configure CI/CD workflows (quality, build, security) |
+| 3 | infra | Set up production infrastructure (health, security, deploy) |
+| 4 | carryforward | Capture lessons learned (optional but recommended) |
+| 5 | documents | Audit and update project documentation |
+| - | (manual) | Manual testing and LLM audit (highly recommended) |
+| 6 | phasebuild | Create next phase structure, return to Stage 2 |
+
+## Workflow Diagram
+
+```
+STAGE 1: INIT           STAGE 2: SESSIONS        STAGE 3: TRANSITION
+
+initspec                plansession ----+         audit
+    |                       |           |             |
+    v                       v           |             v
+createprd (opt)         implement       |         pipeline
+    |                       |           |             |
+    v                       v           |             v
+createuxprd (opt)       validate        |         infra
+    |                       |           |             |
+    v                       v           |             v
+phasebuild              updateprd ------+         carryforward
+                                                      |
+                                                      v
+                                                  documents
+                                                      |
+                                                      v
+                                                  phasebuild --> Stage 2
+```
+
+## Utility Commands (Safe at Any Time)
+
+These 9 commands run outside the session workflow:
+
+| Command | Purpose |
+|---------|---------|
+| copush | Pull, version-bump, commit all changes, push to origin |
+| sculpt-ui | Guide AI-led creation of distinctive frontend interfaces |
+| dockbuild | Quick Docker Compose build and start |
+| dockcleanbuild | Clean Docker environment and rebuild from scratch |
+| up2imp | Audit upstream changes and curate implementation list |
+| qimpl | Context-aware autonomous implementation session |
+| qfrontdev | Autonomous frontend implementation session |
+| qbackenddev | Autonomous backend/infrastructure development session |
+| pullndoc | Git pull upstream repo and document imported changes |
+
+## Command Quick Reference
+
+| Command | Input | Output |
+|---------|-------|--------|
+| initspec | Project info | .spec_system/ structure |
+| createprd | Requirements doc | PRD/PRD.md |
+| createuxprd | Design docs | PRD/PRD_UX.md |
+| plansession | state.json, PRD | spec.md + tasks.md |
+| implement | spec.md, tasks.md | implementation-notes.md |
+| validate | All session files | validation.md |
+| updateprd | validation.md | Updated state.json |
+| audit | CONVENTIONS.md | Updated dev tools |
+| pipeline | CONVENTIONS.md | Workflow files |
+| infra | CONVENTIONS.md | Config files |
+| documents | state.json, PRD | Updated docs |
+| carryforward | Phase artifacts | CONSIDERATIONS.md |
+| phasebuild | PRD | PRD/phase_NN/ |
+
+## Task Format
+
+```
+- [ ] TNNN [SNNMM] [P] Action verb + what + where (`path/to/file`)
+```
+
+- `TNNN`: Sequential task ID (T001, T002, ...)
+- `[SNNMM]`: Session reference (S0103 = Phase 01, Session 03)
+- `[P]`: Optional parallelization marker

--- a/skills/.experimental/apex-spec/scripts/analyze-project.sh
+++ b/skills/.experimental/apex-spec/scripts/analyze-project.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# =============================================================================
+# analyze-project.sh - Analyze project state for session recommendations
+# =============================================================================
+# Usage:
+#   ./analyze-project.sh           # Human-readable output
+#   ./analyze-project.sh --json    # JSON output for Claude integration
+# =============================================================================
+# CREDIT NOTE: The 1st version of this file was taken directly from Github's Spec Kit
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# =============================================================================
+# OUTPUT MODE
+# =============================================================================
+
+OUTPUT_MODE="human"
+PACKAGE_FILTER=""
+
+# =============================================================================
+# JSON OUTPUT FUNCTIONS
+# =============================================================================
+
+output_json() {
+    check_jq || exit 1
+
+    local project_name current_phase current_session completed_count
+    project_name=$(get_project_name)
+    current_phase=$(get_current_phase)
+    current_session=$(get_current_session)
+    completed_count=$(get_completed_sessions_count)
+
+    # Monorepo state
+    local monorepo_flag packages_json active_package monorepo_detection
+    monorepo_flag=$(get_monorepo_flag)
+    packages_json=$(get_packages)
+    active_package=$(resolve_package_context "$PACKAGE_FILTER")
+
+    # Auto-detect monorepo when state is unknown (null)
+    if [[ "$monorepo_flag" == "null" ]]; then
+        monorepo_detection=$(detect_monorepo)
+    else
+        monorepo_detection="null"
+    fi
+
+    # Build phases array
+    local phases_json="[]"
+    local phases
+    phases=$(json_get "$STATE_FILE" '.phases | keys[]' 2>/dev/null || echo "")
+
+    for phase in $phases; do
+        local name status count
+        name=$(get_phase_name "$phase")
+        status=$(get_phase_status "$phase")
+        count=$(get_phase_session_count "$phase")
+
+        phases_json=$(echo "$phases_json" | jq \
+            --arg num "$phase" \
+            --arg name "$name" \
+            --arg status "$status" \
+            --argjson count "$count" \
+            '. += [{"number": ($num | tonumber), "name": $name, "status": $status, "session_count": $count}]')
+    done
+
+    # Build completed sessions array
+    local completed_json="[]"
+    while IFS= read -r session; do
+        [[ -n "$session" ]] && completed_json=$(echo "$completed_json" | jq --arg s "$session" '. += [$s]')
+    done < <(get_completed_sessions)
+
+    # Build candidate sessions array
+    local candidates_json="[]"
+    local prd_dir
+    prd_dir="${SPEC_SYSTEM_DIR}/PRD/phase_$(printf '%02d' "$current_phase")"
+
+    if [[ -d "$prd_dir" ]]; then
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            local filename
+            filename=$(basename "$file" .md)
+
+            # Extract session number from filename (session_NN_name)
+            if [[ "$filename" =~ ^session_([0-9]+)_(.+)$ ]]; then
+                local session_num_raw="${BASH_REMATCH[1]}"
+                local session_num
+                session_num=$((10#$session_num_raw))
+                local session_name="${BASH_REMATCH[2]}"
+                local is_completed="false"
+
+                if is_session_number_completed "$session_num" "$current_phase"; then
+                    is_completed="true"
+                fi
+
+                # Parse Package: annotation from first 10 lines of stub
+                local pkg_annotation=""
+                pkg_annotation=$(head -10 "$file" | sed -n 's/^[*]*Package[*]*:[[:space:]]*\(.*\)/\1/p' | head -1)
+                pkg_annotation=$(trim "$pkg_annotation")
+
+                candidates_json=$(echo "$candidates_json" | jq \
+                    --arg file "$filename" \
+                    --arg path "$file" \
+                    --argjson num "$session_num" \
+                    --arg name "$session_name" \
+                    --argjson completed "$is_completed" \
+                    --arg pkg "$pkg_annotation" \
+                    '. += [{"file": $file, "path": $path, "session_number": $num, "name": $name, "completed": $completed, "package": (if $pkg == "" then null else $pkg end)}]')
+            fi
+        done < <(find "$prd_dir" -name "session_*.md" -type f 2>/dev/null | sort)
+    fi
+
+    # Filter candidates by package if --package was specified
+    if [[ -n "$PACKAGE_FILTER" ]]; then
+        candidates_json=$(echo "$candidates_json" | jq --arg pkg "$PACKAGE_FILTER" \
+            '[.[] | select(.package == $pkg or .package == null)]')
+    fi
+
+    # Get current session directory status
+    local session_dir_exists="false"
+    local session_files="[]"
+    if [[ "$current_session" != "null" && -n "$current_session" ]]; then
+        local session_dir
+        session_dir=$(get_session_dir "$current_session")
+        if [[ -d "$session_dir" ]]; then
+            session_dir_exists="true"
+            while IFS= read -r f; do
+                [[ -n "$f" ]] && session_files=$(echo "$session_files" | jq --arg f "$(basename "$f")" '. += [$f]')
+            done < <(find "$session_dir" -type f -name "*.md" 2>/dev/null | sort)
+        fi
+    fi
+
+    # Convert monorepo_flag string to proper JSON value
+    local monorepo_json
+    case "$monorepo_flag" in
+        true) monorepo_json="true" ;;
+        false) monorepo_json="false" ;;
+        *) monorepo_json="null" ;;
+    esac
+
+    # Build final JSON output
+    jq -n \
+        --arg project "$project_name" \
+        --arg state_file "$STATE_FILE" \
+        --argjson current_phase "$current_phase" \
+        --arg current_session "$current_session" \
+        --argjson session_dir_exists "$session_dir_exists" \
+        --argjson session_files "$session_files" \
+        --argjson completed_count "$completed_count" \
+        --argjson phases "$phases_json" \
+        --argjson completed_sessions "$completed_json" \
+        --argjson candidates "$candidates_json" \
+        --argjson monorepo "$monorepo_json" \
+        --argjson packages "$packages_json" \
+        --argjson active_package "$active_package" \
+        --argjson monorepo_detection "$monorepo_detection" \
+        --arg generated_at "$(get_datetime)" \
+        '{
+            "project": $project,
+            "state_file": $state_file,
+            "generated_at": $generated_at,
+            "current_phase": $current_phase,
+            "current_session": (if $current_session == "null" then null else $current_session end),
+            "current_session_dir_exists": $session_dir_exists,
+            "current_session_files": $session_files,
+            "completed_sessions_count": $completed_count,
+            "monorepo": $monorepo,
+            "packages": $packages,
+            "active_package": $active_package,
+            "monorepo_detection": $monorepo_detection,
+            "phases": $phases,
+            "completed_sessions": $completed_sessions,
+            "candidate_sessions": $candidates
+        }'
+}
+
+# =============================================================================
+# HUMAN-READABLE OUTPUT FUNCTIONS
+# =============================================================================
+
+analyze_phases() {
+    log_info "Analyzing phases..."
+
+    local current_phase
+    current_phase=$(get_current_phase)
+
+    echo "Current Phase: $current_phase"
+    echo ""
+    echo "Phase Status:"
+    echo "-------------"
+
+    # Get all phase numbers from state
+    local phases
+    phases=$(json_get "$STATE_FILE" '.phases | keys[]' 2>/dev/null || echo "")
+
+    for phase in $phases; do
+        local name status count
+        name=$(get_phase_name "$phase")
+        status=$(get_phase_status "$phase")
+        count=$(get_phase_session_count "$phase")
+        printf "  Phase %02d: %-25s [%s] (%d sessions)\n" "$phase" "$name" "$status" "$count"
+    done
+}
+
+analyze_sessions() {
+    log_info "Analyzing completed sessions..."
+
+    local count
+    count=$(get_completed_sessions_count)
+
+    echo ""
+    echo "Completed Sessions: $count"
+    echo "-------------------"
+
+    get_completed_sessions | while read -r session; do
+        [[ -n "$session" ]] && echo "  - $session"
+    done
+}
+
+analyze_current() {
+    log_info "Analyzing current state..."
+
+    local current
+    current=$(get_current_session)
+
+    echo ""
+    echo "Current Session: ${current:-"(none)"}"
+
+    if [[ "$current" != "null" && -n "$current" ]]; then
+        local session_dir
+        session_dir=$(get_session_dir "$current")
+
+        echo "Session Directory: $session_dir"
+
+        if [[ -d "$session_dir" ]]; then
+            echo "Files:"
+            find "$session_dir" -maxdepth 1 -type f -printf '  %f\n' 2>/dev/null | sort
+        else
+            echo "  (directory not created yet)"
+        fi
+    fi
+}
+
+analyze_next_candidates() {
+    log_info "Finding next session candidates..."
+
+    local current_phase
+    current_phase=$(get_current_phase)
+
+    local prd_dir
+    prd_dir="${SPEC_SYSTEM_DIR}/PRD/phase_$(printf '%02d' "$current_phase")"
+
+    echo ""
+    echo "Next Session Candidates (Phase $current_phase):"
+    echo "----------------------------------------------"
+
+    if [[ -d "$prd_dir" ]]; then
+        # List session files that aren't completed
+        while IFS= read -r file; do
+            local filename
+            filename=$(basename "$file" .md)
+
+            # Extract session number from filename (session_NN_name)
+            if [[ "$filename" =~ ^session_([0-9]+)_ ]]; then
+                local session_num_raw="${BASH_REMATCH[1]}"
+                local session_num
+                session_num=$((10#$session_num_raw))
+
+                if ! is_session_number_completed "$session_num" "$current_phase"; then
+                    echo "  - $filename (not completed)"
+                else
+                    echo "  - $filename (completed)"
+                fi
+            fi
+        done < <(find "$prd_dir" -name "session_*.md" -type f | sort)
+    else
+        echo "  (no phase directory found: $prd_dir)"
+    fi
+}
+
+show_summary() {
+    echo ""
+    echo "=============================================="
+    echo "PROJECT ANALYSIS SUMMARY"
+    echo "=============================================="
+
+    local project_name
+    project_name=$(get_project_name)
+
+    echo "Project: $project_name"
+    echo "State File: $STATE_FILE"
+
+    # Show monorepo status if applicable
+    local monorepo_flag
+    monorepo_flag=$(get_monorepo_flag)
+    if [[ "$monorepo_flag" == "true" ]]; then
+        echo "Monorepo: Yes"
+        local packages
+        packages=$(get_packages)
+        local pkg_count
+        pkg_count=$(echo "$packages" | jq 'length')
+        echo "Packages: $pkg_count"
+        echo "$packages" | jq -r '.[] | "  - \(.name) (\(.path))"' 2>/dev/null
+    elif [[ "$monorepo_flag" == "null" ]]; then
+        echo "Monorepo: Unknown (not yet determined)"
+    fi
+    echo ""
+
+    analyze_phases
+    analyze_sessions
+    analyze_current
+    analyze_next_candidates
+
+    echo ""
+    echo "=============================================="
+}
+
+# =============================================================================
+# USAGE
+# =============================================================================
+
+show_usage() {
+    cat <<'EOF'
+Usage: analyze-project.sh [OPTIONS]
+
+Analyze project state for session recommendations.
+
+OPTIONS:
+  --json              Output analysis as JSON (for Claude integration)
+  --package PATH      Filter candidates by package path (monorepo only)
+  --help              Show this help message
+
+OUTPUT MODES:
+  Default (no flags): Human-readable summary with colors
+  --json: Structured JSON for programmatic use
+
+JSON OUTPUT STRUCTURE:
+  {
+    "project": "project-name",
+    "state_file": ".spec_system/state.json",
+    "generated_at": "2024-01-15 10:30:00",
+    "current_phase": 1,
+    "current_session": "phase01-session02-feature" | null,
+    "current_session_dir_exists": true | false,
+    "current_session_files": ["spec.md", "tasks.md"],
+    "completed_sessions_count": 5,
+    "monorepo": true | false | null,
+    "packages": [{"name": "web", "path": "apps/web", "stack_hint": "TypeScript"}],
+    "active_package": {"name": "web", "path": "apps/web", ...} | null,
+    "monorepo_detection": {"detected": true, "indicator": "...", "packages": [...]} | null,
+    "phases": [
+      {"number": 0, "name": "Foundation", "status": "completed", "session_count": 3}
+    ],
+    "completed_sessions": ["phase00-session01-setup", ...],
+    "candidate_sessions": [
+      {"file": "session_01_auth", "path": "...", "session_number": 1, "name": "auth", "completed": false, "package": "apps/web" | null}
+    ]
+  }
+
+MONOREPO FIELDS:
+  monorepo             true/false/null from state.json
+  packages             Array of registered packages (empty if not monorepo)
+  active_package       Resolved package context from --package flag or CWD
+  monorepo_detection   Auto-detection result (only when monorepo is null)
+  candidate.package    Package annotation parsed from session stub header
+
+EXAMPLES:
+  ./analyze-project.sh                          # View human-readable summary
+  ./analyze-project.sh --json                   # Get JSON for Claude
+  ./analyze-project.sh --json | jq              # Pretty-print JSON
+  ./analyze-project.sh --json --package apps/web  # Filter by package
+EOF
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json)
+                OUTPUT_MODE="json"
+                shift
+                ;;
+            --package)
+                if [[ -z "${2:-}" ]]; then
+                    log_error "--package requires a PATH argument"
+                    exit 1
+                fi
+                PACKAGE_FILTER="$2"
+                shift 2
+                ;;
+            --help | -h)
+                show_usage
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    check_spec_system || exit 1
+
+    if [[ "$OUTPUT_MODE" == "json" ]]; then
+        output_json
+    else
+        show_summary
+    fi
+}
+
+# Run if executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi
+
+# CREDIT NOTE: The 1st version of this file was taken directly from Github's Spec Kit

--- a/skills/.experimental/apex-spec/scripts/check-prereqs.sh
+++ b/skills/.experimental/apex-spec/scripts/check-prereqs.sh
@@ -1,0 +1,896 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-prereqs.sh - Validate session prerequisites
+# =============================================================================
+# Usage:
+#   ./check-prereqs.sh --env                    # Check environment only
+#   ./check-prereqs.sh --tools "node,npm"       # Check specific tools
+#   ./check-prereqs.sh --json --env             # JSON output for Claude
+# =============================================================================
+# NOTE: The 1st version of this file was taken directly from Github's Spec Kit
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# =============================================================================
+# OUTPUT MODE
+# =============================================================================
+
+OUTPUT_MODE="human"
+JSON_RESULT=""
+PACKAGE_FILTER=""
+
+# =============================================================================
+# JSON BUILDING HELPERS
+# =============================================================================
+
+init_json() {
+    JSON_RESULT=$(jq -n --arg generated_at "$(get_datetime)" '{
+        "generated_at": $generated_at,
+        "overall": "pass",
+        "environment": {},
+        "package": {},
+        "workspace": {},
+        "tools": {},
+        "sessions": {},
+        "files": {},
+        "database": {},
+        "issues": []
+    }')
+}
+
+add_json_issue() {
+    local type="$1"
+    local name="$2"
+    local message="$3"
+    JSON_RESULT=$(echo "$JSON_RESULT" | jq \
+        --arg type "$type" \
+        --arg name "$name" \
+        --arg msg "$message" \
+        '.issues += [{"type": $type, "name": $name, "message": $msg}]')
+    JSON_RESULT=$(echo "$JSON_RESULT" | jq '.overall = "fail"')
+}
+
+set_check_result() {
+    local category="$1"
+    local name="$2"
+    local status="$3"
+    local extra="${4:-}"
+
+    if [[ -n "$extra" ]]; then
+        JSON_RESULT=$(echo "$JSON_RESULT" | jq \
+            --arg cat "$category" \
+            --arg name "$name" \
+            --arg status "$status" \
+            --arg extra "$extra" \
+            '.[$cat][$name] = {"status": $status, "info": $extra}')
+    else
+        JSON_RESULT=$(echo "$JSON_RESULT" | jq \
+            --arg cat "$category" \
+            --arg name "$name" \
+            --arg status "$status" \
+            '.[$cat][$name] = {"status": $status}')
+    fi
+}
+
+# =============================================================================
+# SMALL STRING/LIST HELPERS
+# =============================================================================
+
+trim() {
+    local s="${1:-}"
+    # Remove leading whitespace
+    s="${s#"${s%%[![:space:]]*}"}"
+    # Remove trailing whitespace
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+# Print a comma-separated list as trimmed, non-empty, newline-delimited items.
+# This avoids word-splitting issues and preserves spaces inside individual items.
+split_csv() {
+    local input="${1:-}"
+    local item=""
+    local -a parts=()
+
+    input="$(trim "$input")"
+    [[ -z "$input" ]] && return 0
+
+    local IFS=','
+    read -r -a parts <<<"$input" || true
+
+    for item in "${parts[@]}"; do
+        item="$(trim "$item")"
+        [[ -z "$item" ]] && continue
+        printf '%s\n' "$item"
+    done
+}
+
+# =============================================================================
+# CHECK FUNCTIONS
+# =============================================================================
+
+check_required_sessions() {
+    local prereqs="${1:-}"
+
+    if [[ "$OUTPUT_MODE" == "human" ]]; then
+        log_info "Checking required sessions..."
+    fi
+
+    if [[ -z "$(trim "$prereqs")" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_info "No prerequisite sessions specified"
+        fi
+        return 0
+    fi
+
+    local failed=0
+
+    local prereq=""
+    while IFS= read -r prereq; do
+        [[ -z "$prereq" ]] && continue
+
+        if is_session_completed "$prereq"; then
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_success "Prerequisite met: $prereq"
+            else
+                set_check_result "sessions" "$prereq" "pass" "completed"
+            fi
+        else
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_error "Prerequisite NOT met: $prereq"
+            else
+                set_check_result "sessions" "$prereq" "fail" "not completed"
+                add_json_issue "session" "$prereq" "prerequisite session not completed"
+            fi
+            ((failed++)) || true
+        fi
+    done < <(split_csv "$prereqs")
+
+    return $failed
+}
+
+check_required_tools() {
+    local tools="${1:-}"
+
+    if [[ "$OUTPUT_MODE" == "human" ]]; then
+        log_info "Checking required tools..."
+    fi
+
+    if [[ -z "$(trim "$tools")" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_info "No specific tools required"
+        fi
+        return 0
+    fi
+
+    local failed=0
+
+    local tool=""
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+
+        if command -v "$tool" &>/dev/null; then
+            local version=""
+            # Try to get version for common tools
+            case "$tool" in
+                node) version=$(node --version 2>&1 | head -1 || echo "unknown") ;;
+                npm) version=$(npm --version 2>&1 | head -1 || echo "unknown") ;;
+                python | python3) version=$("$tool" --version 2>&1 | head -1 || echo "unknown") ;;
+                docker) version=$(docker --version 2>&1 | head -1 || echo "unknown") ;;
+                git) version=$(git --version 2>&1 | head -1 || echo "unknown") ;;
+                go) version=$(go version 2>&1 | head -1 || echo "unknown") ;;
+                cargo) version=$(cargo --version 2>&1 | head -1 || echo "unknown") ;;
+                *) version=$("$tool" --version 2>&1 | head -1 || echo "available") ;;
+            esac
+            [[ -z "$version" ]] && version="available"
+
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_success "Tool available: $tool ($version)"
+            else
+                set_check_result "tools" "$tool" "pass" "$version"
+            fi
+        else
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_error "Tool NOT available: $tool"
+            else
+                set_check_result "tools" "$tool" "fail" "not installed"
+                add_json_issue "tool" "$tool" "required tool not installed"
+            fi
+            ((failed++)) || true
+        fi
+    done < <(split_csv "$tools")
+
+    return $failed
+}
+
+check_required_files() {
+    local files="${1:-}"
+
+    if [[ "$OUTPUT_MODE" == "human" ]]; then
+        log_info "Checking required files..."
+    fi
+
+    if [[ -z "$(trim "$files")" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_info "No specific files required"
+        fi
+        return 0
+    fi
+
+    local failed=0
+
+    local file=""
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+
+        if [[ -f "$file" ]]; then
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_success "File exists: $file"
+            else
+                set_check_result "files" "$file" "pass" "exists"
+            fi
+        else
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_error "File NOT found: $file"
+            else
+                set_check_result "files" "$file" "fail" "not found"
+                add_json_issue "file" "$file" "required file not found"
+            fi
+            ((failed++)) || true
+        fi
+    done < <(split_csv "$files")
+
+    return $failed
+}
+
+check_database() {
+    # Only runs when database signals are detected
+    local has_db=false
+
+    # Check for common DB signals
+    local db_signals=(
+        "docker-compose.yml" "docker-compose.yaml" "compose.yml" "compose.yaml"
+        "prisma/schema.prisma" "drizzle.config.ts" "drizzle.config.js"
+        "alembic.ini" "knexfile.js" "knexfile.ts"
+        "diesel.toml" "sqlc.yaml" "sqlc.yml"
+    )
+
+    for signal in "${db_signals[@]}"; do
+        if [[ -f "$signal" ]]; then
+            has_db=true
+            break
+        fi
+    done
+
+    # Check .env for DATABASE_URL
+    if [[ -f ".env" ]] && grep -q "DATABASE_URL\|DB_HOST\|DB_PORT" .env 2>/dev/null; then
+        has_db=true
+    fi
+
+    [[ "$has_db" == false ]] && return 0
+
+    # Detect DB type
+    local db_type="unknown"
+    if [[ -f ".env" ]]; then
+        if grep -q "postgresql://" .env 2>/dev/null; then
+            db_type="PostgreSQL"
+        elif grep -q "mysql://" .env 2>/dev/null; then
+            db_type="MySQL"
+        elif grep -q "mongodb://" .env 2>/dev/null; then
+            db_type="MongoDB"
+        fi
+    fi
+    set_check_result "database" "type" "pass" "$db_type"
+
+    # Detect migration tool
+    local migration_tool="none"
+    if [[ -f "prisma/schema.prisma" ]]; then
+        migration_tool="prisma"
+    elif [[ -f "drizzle.config.ts" || -f "drizzle.config.js" ]]; then
+        migration_tool="drizzle"
+    elif [[ -f "alembic.ini" ]]; then
+        migration_tool="alembic"
+    elif [[ -f "knexfile.js" || -f "knexfile.ts" ]]; then
+        migration_tool="knex"
+    elif [[ -f "diesel.toml" ]]; then
+        migration_tool="diesel"
+    elif [[ -f "sqlc.yaml" || -f "sqlc.yml" ]]; then
+        migration_tool="sqlc"
+    fi
+
+    if [[ "$migration_tool" != "none" ]]; then
+        set_check_result "database" "migration_tool" "pass" "$migration_tool"
+    else
+        set_check_result "database" "migration_tool" "warn" "no migration tool detected"
+    fi
+
+    # Check if migration tool CLI is available
+    if [[ "$migration_tool" != "none" && "$migration_tool" != "sqlc" ]]; then
+        local tool_cmd=""
+        case "$migration_tool" in
+            prisma) tool_cmd="npx prisma" ;;
+            drizzle) tool_cmd="npx drizzle-kit" ;;
+            alembic) tool_cmd="alembic" ;;
+            knex) tool_cmd="npx knex" ;;
+            diesel) tool_cmd="diesel" ;;
+        esac
+        if [[ -n "$tool_cmd" ]] && command -v "$(echo "$tool_cmd" | awk '{print $1}')" &>/dev/null; then
+            set_check_result "database" "tool_available" "pass" "$tool_cmd"
+        else
+            set_check_result "database" "tool_available" "warn" "$tool_cmd not in PATH"
+        fi
+    fi
+
+    # Check for seed script
+    local seed_found=false
+    local seed_files=("scripts/seed.ts" "scripts/seed.js" "scripts/seed.py" "prisma/seed.ts" "prisma/seed.js" "cmd/seed/main.go")
+    for sf in "${seed_files[@]}"; do
+        if [[ -f "$sf" ]]; then
+            set_check_result "database" "seed_script" "pass" "$sf"
+            seed_found=true
+            break
+        fi
+    done
+    if [[ "$seed_found" == false ]]; then
+        set_check_result "database" "seed_script" "warn" "no seed script found"
+    fi
+}
+
+check_environment() {
+    if [[ "$OUTPUT_MODE" == "human" ]]; then
+        log_info "Checking environment..."
+    fi
+
+    local failed=0
+    local has_jq=false
+    if command -v jq &>/dev/null; then
+        has_jq=true
+    fi
+
+    # Check spec system
+    if [[ -d "$SPEC_SYSTEM_DIR" && -f "$STATE_FILE" ]]; then
+        if [[ "$has_jq" == true ]]; then
+            if validate_json "$STATE_FILE" 2>/dev/null; then
+                if [[ "$OUTPUT_MODE" == "human" ]]; then
+                    log_success "Spec system: OK"
+                else
+                    set_check_result "environment" "spec_system" "pass" "$SPEC_SYSTEM_DIR"
+                fi
+            else
+                if [[ "$OUTPUT_MODE" == "human" ]]; then
+                    log_error "Spec system: Invalid state.json"
+                else
+                    set_check_result "environment" "spec_system" "fail" "invalid state.json"
+                    add_json_issue "environment" "spec_system" "state.json is not valid JSON"
+                fi
+                ((failed++)) || true
+            fi
+        else
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_error "Spec system: Found but jq missing (cannot validate state.json)"
+            else
+                set_check_result "environment" "spec_system" "fail" "jq not installed (cannot validate state.json)"
+                add_json_issue "environment" "spec_system" "jq is required to validate state.json"
+            fi
+            ((failed++)) || true
+        fi
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_error "Spec system: NOT found"
+        else
+            set_check_result "environment" "spec_system" "fail" "not found"
+            add_json_issue "environment" "spec_system" ".spec_system directory or state.json not found"
+        fi
+        ((failed++)) || true
+    fi
+
+    # Check jq
+    if [[ "$has_jq" == true ]]; then
+        local jq_version
+        jq_version=$(jq --version 2>/dev/null || echo "unknown")
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_success "jq: OK ($jq_version)"
+        else
+            set_check_result "environment" "jq" "pass" "$jq_version"
+        fi
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_error "jq: NOT installed (required for scripts)"
+        else
+            set_check_result "environment" "jq" "fail" "not installed"
+            add_json_issue "environment" "jq" "jq is required but not installed"
+        fi
+        ((failed++)) || true
+    fi
+
+    # Check git (optional but noted)
+    if command -v git &>/dev/null; then
+        local git_version
+        git_version=$(git --version 2>/dev/null | head -1 || echo "unknown")
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_success "git: OK ($git_version)"
+        else
+            set_check_result "environment" "git" "pass" "$git_version"
+        fi
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_info "git: NOT installed (optional)"
+        else
+            set_check_result "environment" "git" "skip" "not installed (optional)"
+        fi
+    fi
+
+    return $failed
+}
+
+# =============================================================================
+# MONOREPO: PACKAGE & WORKSPACE CHECKS
+# =============================================================================
+
+# Verify a specific package exists in state.json and on disk.
+# Requires: PACKAGE_FILTER set, jq available, state.json valid.
+check_package() {
+    local pkg_path="$1"
+
+    if [[ "$OUTPUT_MODE" == "human" ]]; then
+        log_info "Checking package: $pkg_path ..."
+    fi
+
+    local failed=0
+
+    # Check package exists in state.json packages array
+    local pkg_entry=""
+    pkg_entry=$(get_package_by_path "$pkg_path" 2>/dev/null) || true
+
+    if [[ -z "$pkg_entry" || "$pkg_entry" == "null" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_error "Package not registered in state.json: $pkg_path"
+        else
+            set_check_result "package" "registered" "fail" "$pkg_path not in state.json packages"
+            add_json_issue "package" "$pkg_path" "package not registered in state.json"
+        fi
+        ((failed++)) || true
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_success "Package registered: $pkg_path"
+        else
+            set_check_result "package" "registered" "pass" "$pkg_path"
+        fi
+    fi
+
+    # Check package directory exists on disk
+    if [[ -d "$pkg_path" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_success "Package directory exists: $pkg_path"
+        else
+            set_check_result "package" "directory" "pass" "$pkg_path"
+        fi
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_error "Package directory NOT found: $pkg_path"
+        else
+            set_check_result "package" "directory" "fail" "$pkg_path not found"
+            add_json_issue "package" "$pkg_path" "package directory does not exist"
+        fi
+        ((failed++)) || true
+    fi
+
+    # Check for a package manifest (package.json, Cargo.toml, etc.)
+    if [[ -d "$pkg_path" ]]; then
+        local has_manifest=false
+        for manifest in package.json Cargo.toml go.mod pyproject.toml setup.py; do
+            if [[ -f "$pkg_path/$manifest" ]]; then
+                has_manifest=true
+                if [[ "$OUTPUT_MODE" == "human" ]]; then
+                    log_success "Package manifest: $pkg_path/$manifest"
+                else
+                    set_check_result "package" "manifest" "pass" "$manifest"
+                fi
+                break
+            fi
+        done
+        if [[ "$has_manifest" == false ]]; then
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_info "No package manifest found in $pkg_path (optional)"
+            else
+                set_check_result "package" "manifest" "skip" "no manifest found (optional)"
+            fi
+        fi
+    fi
+
+    # Include package stack hint from state.json if available
+    if [[ -n "$pkg_entry" && "$pkg_entry" != "null" ]]; then
+        local stack=""
+        stack=$(echo "$pkg_entry" | jq -r '.stack // empty' 2>/dev/null) || true
+        if [[ -n "$stack" ]]; then
+            if [[ "$OUTPUT_MODE" == "human" ]]; then
+                log_info "Package stack: $stack"
+            else
+                set_check_result "package" "stack" "pass" "$stack"
+            fi
+        fi
+    fi
+
+    return $failed
+}
+
+# Verify monorepo workspace tooling when monorepo: true.
+# Checks for workspace manager, config, and optional task runner.
+check_workspace_tools() {
+    if [[ "$OUTPUT_MODE" == "human" ]]; then
+        log_info "Checking workspace tools..."
+    fi
+
+    local monorepo_flag=""
+    monorepo_flag=$(get_monorepo_flag 2>/dev/null) || true
+
+    if [[ "$monorepo_flag" != "true" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_info "Not a monorepo -- skipping workspace tool checks"
+        else
+            set_check_result "workspace" "status" "skip" "not a monorepo"
+        fi
+        return 0
+    fi
+
+    local failed=0
+
+    # Detect workspace manager
+    local manager=""
+    local manager_version=""
+    if [[ -f "pnpm-workspace.yaml" ]]; then
+        manager="pnpm"
+        manager_version=$(pnpm --version 2>/dev/null || echo "not installed")
+    elif [[ -f "package.json" ]] && jq -e '.workspaces' package.json &>/dev/null; then
+        # npm or yarn workspaces
+        if command -v yarn &>/dev/null; then
+            manager="yarn"
+            manager_version=$(yarn --version 2>/dev/null || echo "unknown")
+        else
+            manager="npm"
+            manager_version=$(npm --version 2>/dev/null || echo "unknown")
+        fi
+    elif [[ -f "Cargo.toml" ]] && grep -q '^\[workspace\]' Cargo.toml 2>/dev/null; then
+        manager="cargo"
+        manager_version=$(cargo --version 2>/dev/null | head -1 || echo "unknown")
+    elif [[ -f "go.work" ]]; then
+        manager="go"
+        manager_version=$(go version 2>/dev/null | head -1 || echo "unknown")
+    elif [[ -f "lerna.json" ]]; then
+        manager="lerna"
+        manager_version=$(npx lerna --version 2>/dev/null || echo "unknown")
+    fi
+
+    if [[ -n "$manager" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_success "Workspace manager: $manager ($manager_version)"
+        else
+            set_check_result "workspace" "manager" "pass" "$manager $manager_version"
+        fi
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_error "No workspace manager detected (monorepo: true in state.json)"
+        else
+            set_check_result "workspace" "manager" "fail" "no workspace config found"
+            add_json_issue "workspace" "manager" "monorepo is true but no workspace manager detected"
+        fi
+        ((failed++)) || true
+    fi
+
+    # Check for task runner (turbo, nx -- optional but noted)
+    local runner=""
+    local runner_version=""
+    if [[ -f "turbo.json" ]]; then
+        runner="turbo"
+        runner_version=$(npx turbo --version 2>/dev/null || echo "config found")
+    elif [[ -f "nx.json" ]]; then
+        runner="nx"
+        runner_version=$(npx nx --version 2>/dev/null || echo "config found")
+    fi
+
+    if [[ -n "$runner" ]]; then
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_success "Task runner: $runner ($runner_version)"
+        else
+            set_check_result "workspace" "runner" "pass" "$runner $runner_version"
+        fi
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            log_info "No task runner detected (turbo/nx -- optional)"
+        else
+            set_check_result "workspace" "runner" "skip" "none detected (optional)"
+        fi
+    fi
+
+    return $failed
+}
+
+# =============================================================================
+# USAGE
+# =============================================================================
+
+show_usage() {
+    cat <<'EOF'
+Usage: check-prereqs.sh [OPTIONS]
+
+Check prerequisites for a session.
+
+OPTIONS:
+  -t, --tools LIST     Comma-separated list of required tools
+  -f, --files LIST     Comma-separated list of required files
+  -p, --prereqs LIST   Comma-separated list of prerequisite sessions
+  -e, --env            Check environment only
+  --package PATH       Check package-specific prerequisites (monorepo)
+  --json               Output results as JSON (for Claude integration)
+  -h, --help           Show this help message
+
+OUTPUT MODES:
+  Default (no --json): Human-readable output with colors
+  --json: Structured JSON for programmatic use
+
+MONOREPO SUPPORT:
+  When --package is specified:
+  - Verifies the package is registered in state.json
+  - Checks the package directory exists on disk
+  - Checks for a package manifest (package.json, Cargo.toml, etc.)
+  - Reports the package stack from state.json
+
+  When monorepo: true in state.json (automatic with --env):
+  - Detects workspace manager (pnpm, npm/yarn, cargo, go, lerna)
+  - Detects task runner (turbo, nx) if present
+
+JSON OUTPUT STRUCTURE:
+  {
+    "generated_at": "2024-01-15 10:30:00",
+    "overall": "pass" | "fail",
+    "environment": {
+      "spec_system": {"status": "pass", "info": ".spec_system"},
+      "jq": {"status": "pass", "info": "jq-1.7"}
+    },
+    "package": {
+      "registered": {"status": "pass", "info": "apps/web"},
+      "directory": {"status": "pass", "info": "apps/web"},
+      "manifest": {"status": "pass", "info": "package.json"},
+      "stack": {"status": "pass", "info": "TypeScript + React"}
+    },
+    "workspace": {
+      "manager": {"status": "pass", "info": "pnpm 8.15.0"},
+      "runner": {"status": "pass", "info": "turbo 1.12.0"}
+    },
+    "tools": {
+      "node": {"status": "pass", "info": "v20.10.0"},
+      "docker": {"status": "fail", "info": "not installed"}
+    },
+    "sessions": {
+      "phase00-session01": {"status": "pass", "info": "completed"}
+    },
+    "files": {
+      "package.json": {"status": "pass", "info": "exists"}
+    },
+    "issues": [
+      {"type": "tool", "name": "docker", "message": "required tool not installed"}
+    ]
+  }
+
+    "database": {
+      "type": {"status": "pass", "info": "PostgreSQL"},
+      "migration_tool": {"status": "pass", "info": "prisma"},
+      "tool_available": {"status": "pass", "info": "npx prisma"},
+      "seed_script": {"status": "warn", "info": "no seed script found"}
+    },
+
+  Notes:
+  - "package" section only present when --package is used
+  - "workspace" section only present when monorepo: true in state.json
+  - "database" section only present when DB signals detected in project
+  - Both "package" and "workspace" sections empty ({}) when not applicable
+
+EXAMPLES:
+  ./check-prereqs.sh --env                              # Check environment
+  ./check-prereqs.sh --tools "node,npm,docker"          # Check tools
+  ./check-prereqs.sh --json --env                       # JSON output
+  ./check-prereqs.sh --json --env --tools "node,npm"
+  ./check-prereqs.sh --json --env --package apps/web    # Monorepo package check
+EOF
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+    local tools=""
+    local files=""
+    local prereqs=""
+    local env_only=false
+    local run_any=false
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json)
+                OUTPUT_MODE="json"
+                check_jq || exit 1
+                init_json
+                shift
+                ;;
+            --tools=*)
+                tools="${1#*=}"
+                run_any=true
+                shift
+                ;;
+            -t | --tools)
+                if [[ $# -lt 2 ]]; then
+                    log_error "Missing value for $1"
+                    show_usage
+                    exit 1
+                fi
+                tools="$2"
+                run_any=true
+                shift 2
+                ;;
+            --files=*)
+                files="${1#*=}"
+                run_any=true
+                shift
+                ;;
+            -f | --files)
+                if [[ $# -lt 2 ]]; then
+                    log_error "Missing value for $1"
+                    show_usage
+                    exit 1
+                fi
+                files="$2"
+                run_any=true
+                shift 2
+                ;;
+            --prereqs=*)
+                prereqs="${1#*=}"
+                run_any=true
+                shift
+                ;;
+            -p | --prereqs)
+                if [[ $# -lt 2 ]]; then
+                    log_error "Missing value for $1"
+                    show_usage
+                    exit 1
+                fi
+                prereqs="$2"
+                run_any=true
+                shift 2
+                ;;
+            -e | --env)
+                env_only=true
+                run_any=true
+                shift
+                ;;
+            --package)
+                if [[ -z "${2:-}" ]]; then
+                    log_error "--package requires a PATH argument"
+                    exit 1
+                fi
+                PACKAGE_FILTER="$2"
+                run_any=true
+                shift 2
+                ;;
+            -h | --help)
+                show_usage
+                exit 0
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    # Default to env check if nothing specified
+    if [[ "$run_any" == false ]]; then
+        env_only=true
+    fi
+
+    if [[ "$OUTPUT_MODE" != "json" ]]; then
+        echo "=============================================="
+        echo "PREREQUISITE CHECK"
+        echo "=============================================="
+        echo ""
+    fi
+
+    local total_failed=0
+    local rc=0
+
+    # Always check environment first
+    rc=0
+    check_environment || rc=$?
+    total_failed=$((total_failed + rc))
+
+    # Check workspace tools when monorepo (automatic with --env)
+    if [[ "$env_only" == true || -n "$PACKAGE_FILTER" ]]; then
+        rc=0
+        check_workspace_tools || rc=$?
+        total_failed=$((total_failed + rc))
+    fi
+
+    # Check database (automatic with --env, only when DB signals detected)
+    if [[ "$env_only" == true && "$OUTPUT_MODE" == "json" ]]; then
+        check_database
+    fi
+
+    # Check package if --package was specified
+    if [[ -n "$PACKAGE_FILTER" ]]; then
+        [[ "$OUTPUT_MODE" == "human" ]] && echo ""
+        rc=0
+        check_package "$PACKAGE_FILTER" || rc=$?
+        total_failed=$((total_failed + rc))
+    fi
+
+    if [[ "$env_only" == true && -z "$tools" && -z "$files" && -z "$prereqs" && -z "$PACKAGE_FILTER" ]]; then
+        # Just environment check (and workspace/package if applicable)
+        :
+    else
+        if [[ "$OUTPUT_MODE" == "human" ]]; then
+            echo ""
+        fi
+
+        # Check session prerequisites
+        if [[ -n "$(trim "$prereqs")" ]]; then
+            rc=0
+            check_required_sessions "$prereqs" || rc=$?
+            total_failed=$((total_failed + rc))
+            [[ "$OUTPUT_MODE" == "human" ]] && echo ""
+        fi
+
+        # Check tools
+        if [[ -n "$(trim "$tools")" ]]; then
+            rc=0
+            check_required_tools "$tools" || rc=$?
+            total_failed=$((total_failed + rc))
+            [[ "$OUTPUT_MODE" == "human" ]] && echo ""
+        fi
+
+        # Check files
+        if [[ -n "$(trim "$files")" ]]; then
+            rc=0
+            check_required_files "$files" || rc=$?
+            total_failed=$((total_failed + rc))
+            [[ "$OUTPUT_MODE" == "human" ]] && echo ""
+        fi
+    fi
+
+    # Output results
+    if [[ "$OUTPUT_MODE" == "json" ]]; then
+        echo "$JSON_RESULT" | jq .
+    else
+        echo "=============================================="
+        if [[ $total_failed -eq 0 ]]; then
+            log_success "All prerequisites met!"
+        else
+            log_error "Some prerequisites not met ($total_failed issues)"
+        fi
+    fi
+
+    # Exit with appropriate code
+    if [[ "$OUTPUT_MODE" == "json" ]]; then
+        local overall
+        overall=$(echo "$JSON_RESULT" | jq -r '.overall')
+        [[ "$overall" == "pass" ]] && exit 0 || exit 1
+    else
+        [[ $total_failed -eq 0 ]] && exit 0 || exit 1
+    fi
+}
+
+# Run if executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi
+
+# CREDIT NOTE: The 1st version of this file was taken directly from Github's Spec Kit

--- a/skills/.experimental/apex-spec/scripts/common.sh
+++ b/skills/.experimental/apex-spec/scripts/common.sh
@@ -1,0 +1,897 @@
+#!/usr/bin/env bash
+# =============================================================================
+# common.sh - Shared utilities for the Apex Spec System
+# =============================================================================
+# Source this file in other scripts: source "$(dirname "$0")/common.sh"
+# =============================================================================
+# CREDIT NOTE: The 1st version of this file was taken directly from Github's Spec Kit
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SPEC_SYSTEM_DIR="${SPEC_SYSTEM_DIR:-.spec_system}"
+STATE_FILE="${SPEC_SYSTEM_DIR}/state.json"
+SPECS_DIR="${SPECS_DIR:-${SPEC_SYSTEM_DIR}/specs}"
+
+# =============================================================================
+# COLORS AND LOGGING
+# =============================================================================
+
+# Colors (only if terminal supports it)
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    CYAN='\033[0;36m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    CYAN=''
+    NC=''
+fi
+
+log_info() {
+    # Use printf for portability and to avoid echo option edge-cases (e.g. "-n").
+    printf '%b\n' "${BLUE}[INFO]${NC} $*"
+}
+
+log_success() {
+    printf '%b\n' "${GREEN}[SUCCESS]${NC} $*"
+}
+
+log_warning() {
+    printf '%b\n' "${YELLOW}[WARNING]${NC} $*"
+}
+
+log_error() {
+    printf '%b\n' "${RED}[ERROR]${NC} $*" >&2
+}
+
+log_debug() {
+    if [[ "${DEBUG:-0}" == "1" ]]; then
+        printf '%b\n' "${CYAN}[DEBUG]${NC} $*"
+    fi
+}
+
+# =============================================================================
+# STRING HELPERS
+# =============================================================================
+
+trim() {
+    local s="${1:-}"
+    # Remove leading whitespace
+    s="${s#"${s%%[![:space:]]*}"}"
+    # Remove trailing whitespace
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+# =============================================================================
+# JSON OPERATIONS (requires jq)
+# =============================================================================
+
+check_jq() {
+    if ! command -v jq &>/dev/null; then
+        log_error "jq is required but not installed. Install with: apt install jq"
+        return 1
+    fi
+}
+
+json_get() {
+    local file="$1"
+    local path="$2"
+
+    check_jq || return 1
+
+    if [[ ! -f "$file" ]]; then
+        log_error "File not found: $file"
+        return 1
+    fi
+
+    jq -r "$path" -- "$file"
+}
+
+json_set() {
+    local file="$1"
+    local path="$2"
+    local value="$3"
+
+    check_jq || return 1
+
+    if [[ ! -f "$file" ]]; then
+        log_error "File not found: $file"
+        return 1
+    fi
+
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    if jq "$path = $value" -- "$file" >"$tmp_file"; then
+        if mv -- "$tmp_file" "$file"; then
+            return 0
+        fi
+        local rc=$?
+        rm -f -- "$tmp_file"
+        return $rc
+    fi
+
+    local rc=$?
+    rm -f -- "$tmp_file"
+    return $rc
+}
+
+json_append_array() {
+    local file="$1"
+    local path="$2"
+    local value="$3"
+
+    check_jq || return 1
+
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    if jq "$path += [$value]" -- "$file" >"$tmp_file"; then
+        if mv -- "$tmp_file" "$file"; then
+            return 0
+        fi
+        local rc=$?
+        rm -f -- "$tmp_file"
+        return $rc
+    fi
+
+    local rc=$?
+    rm -f -- "$tmp_file"
+    return $rc
+}
+
+validate_json() {
+    local file="$1"
+
+    check_jq || return 1
+
+    if jq empty -- "$file" 2>/dev/null; then
+        return 0
+    else
+        log_error "Invalid JSON in $file"
+        return 1
+    fi
+}
+
+# =============================================================================
+# SESSION ID PARSING
+# =============================================================================
+# Session ID format: phaseNN-sessionNN[x]-name
+# Examples:
+#   phase00-session01-project-setup
+#   phase01-session08b-refinements
+
+is_valid_identifier() {
+    local name="${1:-}"
+    # Valid bash identifier: [a-zA-Z_][a-zA-Z0-9_]*
+    # Use glob matching (not regex) to avoid clobbering BASH_REMATCH.
+    [[ -n "$name" ]] || return 1
+    [[ "$name" == [a-zA-Z_]* ]] || return 1
+    [[ "$name" != *[!a-zA-Z0-9_]* ]] || return 1
+    return 0
+}
+
+parse_session_id() {
+    local session_id="$1"
+    local phase_var="${2:-}"
+    local session_var="${3:-}"
+    local suffix_var="${4:-}"
+    local name_var="${5:-}"
+
+    # Regex: phase([0-9]{2})-session([0-9]{2})([a-z])?-(.+)
+    if [[ "$session_id" =~ ^phase([0-9]{2})-session([0-9]{2})([a-z])?-(.+)$ ]]; then
+        # Capture values immediately so helper calls below can't clobber BASH_REMATCH.
+        local phase_val="${BASH_REMATCH[1]}"
+        local session_val="${BASH_REMATCH[2]}"
+        local suffix_val="${BASH_REMATCH[3]}"
+        local name_val="${BASH_REMATCH[4]}"
+
+        if [[ -n "$phase_var" ]]; then
+            is_valid_identifier "$phase_var" || {
+                log_error "Invalid variable name: $phase_var"
+                return 1
+            }
+            printf -v "$phase_var" '%s' "$phase_val"
+        fi
+        if [[ -n "$session_var" ]]; then
+            is_valid_identifier "$session_var" || {
+                log_error "Invalid variable name: $session_var"
+                return 1
+            }
+            printf -v "$session_var" '%s' "$session_val"
+        fi
+        if [[ -n "$suffix_var" ]]; then
+            is_valid_identifier "$suffix_var" || {
+                log_error "Invalid variable name: $suffix_var"
+                return 1
+            }
+            printf -v "$suffix_var" '%s' "$suffix_val"
+        fi
+        if [[ -n "$name_var" ]]; then
+            is_valid_identifier "$name_var" || {
+                log_error "Invalid variable name: $name_var"
+                return 1
+            }
+            printf -v "$name_var" '%s' "$name_val"
+        fi
+        return 0
+    else
+        log_error "Invalid session ID format: $session_id"
+        return 1
+    fi
+}
+
+get_phase_from_session_id() {
+    local session_id="$1"
+    local phase
+    parse_session_id "$session_id" phase && echo "$phase"
+}
+
+get_session_number_from_id() {
+    local session_id="$1"
+    local session
+    parse_session_id "$session_id" "" session && echo "$session"
+}
+
+get_session_suffix_from_id() {
+    local session_id="$1"
+    local suffix
+    parse_session_id "$session_id" "" "" suffix && echo "$suffix"
+}
+
+get_session_name_from_id() {
+    local session_id="$1"
+    local name
+    parse_session_id "$session_id" "" "" "" name && echo "$name"
+}
+
+build_session_id() {
+    local phase="$1"
+    local session="$2"
+    local name="$3"
+    local suffix="${4:-}"
+
+    # Zero-pad phase and session
+    printf "phase%02d-session%02d%s-%s" "$phase" "$session" "$suffix" "$name"
+}
+
+# Build session reference (e.g., S0103 for Phase 01, Session 03)
+build_session_ref() {
+    local phase="$1"
+    local session="$2"
+
+    printf "S%02d%02d" "$phase" "$session"
+}
+
+# =============================================================================
+# STATE QUERIES
+# =============================================================================
+
+get_current_phase() {
+    json_get "$STATE_FILE" '.current_phase'
+}
+
+get_current_session() {
+    json_get "$STATE_FILE" '.current_session'
+}
+
+get_project_name() {
+    json_get "$STATE_FILE" '.project_name'
+}
+
+get_completed_sessions() {
+    # Handle both string entries ("phase00-session01-name") and
+    # object entries ({"id": "phase00-session01-name", "package": "apps/web"}).
+    # Always returns normalized session IDs, one per line.
+    check_jq || return 1
+    jq -r '.completed_sessions[] |
+        if type == "object" then .id else . end' -- "$STATE_FILE" 2>/dev/null || true
+}
+
+get_completed_sessions_count() {
+    json_get "$STATE_FILE" '.completed_sessions | length'
+}
+
+is_session_completed() {
+    local session_id="$1"
+    local completed
+    completed=$(get_completed_sessions)
+
+    if grep -Fxq -- "$session_id" <<<"$completed"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Check if session number is completed (handles suffixes like session08b)
+is_session_number_completed() {
+    local session_num="$1"
+    local phase="${2:-$(get_current_phase)}"
+    local completed
+    completed=$(get_completed_sessions)
+
+    # Match any session with this number (with or without suffix)
+    local pattern
+    pattern=$(printf "phase%02d-session%02d" "$phase" "$session_num")
+
+    if grep -q "^${pattern}" <<<"$completed"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+get_phase_status() {
+    local phase="$1"
+    json_get "$STATE_FILE" ".phases[\"$phase\"].status"
+}
+
+get_phase_name() {
+    local phase="$1"
+    json_get "$STATE_FILE" ".phases[\"$phase\"].name"
+}
+
+get_phase_session_count() {
+    local phase="$1"
+    json_get "$STATE_FILE" ".phases[\"$phase\"].session_count"
+}
+
+# =============================================================================
+# STATE UPDATES
+# =============================================================================
+
+set_current_session() {
+    local session_id="$1"
+    json_set "$STATE_FILE" '.current_session' "\"$session_id\""
+}
+
+clear_current_session() {
+    json_set "$STATE_FILE" '.current_session' 'null'
+}
+
+add_completed_session() {
+    local session_id="$1"
+    local package_path="${2:-}"
+
+    local monorepo_flag
+    monorepo_flag=$(get_monorepo_flag)
+
+    if [[ "$monorepo_flag" == "true" ]]; then
+        # Object form: { "id": "...", "package": "..." | null }
+        local entry
+        if [[ -n "$package_path" && "$package_path" != "null" ]]; then
+            entry=$(jq -n --arg id "$session_id" --arg pkg "$package_path" \
+                '{"id": $id, "package": $pkg}')
+        else
+            entry=$(jq -n --arg id "$session_id" '{"id": $id, "package": null}')
+        fi
+        json_append_array "$STATE_FILE" '.completed_sessions' "$entry"
+    else
+        # String form (classic single-repo behavior)
+        json_append_array "$STATE_FILE" '.completed_sessions' "\"$session_id\""
+    fi
+}
+
+set_phase_status() {
+    local phase="$1"
+    local status="$2"
+    json_set "$STATE_FILE" ".phases[\"$phase\"].status" "\"$status\""
+}
+
+# =============================================================================
+# MONOREPO STATE QUERIES
+# =============================================================================
+
+# Returns "true", "false", or "null" (unknown/absent).
+get_monorepo_flag() {
+    check_jq || return 1
+    local val
+    val=$(jq -r 'if .monorepo == true then "true"
+                 elif .monorepo == false then "false"
+                 else "null" end' -- "$STATE_FILE" 2>/dev/null)
+    echo "${val:-null}"
+}
+
+# Returns the packages array as compact JSON. Empty array if absent.
+get_packages() {
+    check_jq || return 1
+    jq -c '.packages // []' -- "$STATE_FILE" 2>/dev/null || echo "[]"
+}
+
+# Given a package name, return its path (e.g., "apps/web").
+get_package_path() {
+    local name="$1"
+    check_jq || return 1
+    jq -r --arg name "$name" \
+        '(.packages // []) | map(select(.name == $name)) | .[0].path // empty' \
+        -- "$STATE_FILE" 2>/dev/null
+}
+
+# Given a relative path, return the full package JSON object.
+get_package_by_path() {
+    local path="$1"
+    check_jq || return 1
+    jq -c --arg path "$path" \
+        '(.packages // []) | map(select(.path == $path)) | .[0] // empty' \
+        -- "$STATE_FILE" 2>/dev/null
+}
+
+# Return completed session IDs for a specific package (or cross-cutting if empty/null).
+get_sessions_for_package() {
+    local package_path="${1:-}"
+    check_jq || return 1
+
+    if [[ -z "$package_path" || "$package_path" == "null" ]]; then
+        # Cross-cutting sessions: objects with null package, or plain strings
+        jq -r '.completed_sessions[] |
+            if type == "object" then
+                (if .package == null then .id else empty end)
+            else . end' -- "$STATE_FILE" 2>/dev/null || true
+    else
+        # Sessions scoped to a specific package
+        jq -r --arg pkg "$package_path" '.completed_sessions[] |
+            if type == "object" then
+                (if .package == $pkg then .id else empty end)
+            else empty end' -- "$STATE_FILE" 2>/dev/null || true
+    fi
+}
+
+# =============================================================================
+# MONOREPO DETECTION
+# =============================================================================
+
+# Check if the project is a monorepo by looking for workspace indicators.
+# Returns JSON: { "detected": bool, "indicator": string|null, "packages": [...] }
+detect_monorepo() {
+    check_jq || return 1
+
+    local detected="false"
+    local indicator=""
+
+    # Check workspace indicators in priority order
+    if [[ -f "pnpm-workspace.yaml" ]]; then
+        detected="true"
+        indicator="pnpm-workspace.yaml"
+    elif [[ -f "package.json" ]] && jq -e '.workspaces' -- "package.json" &>/dev/null; then
+        detected="true"
+        indicator="package.json workspaces"
+    elif [[ -f "turbo.json" ]]; then
+        detected="true"
+        indicator="turbo.json"
+    elif [[ -f "nx.json" ]]; then
+        detected="true"
+        indicator="nx.json"
+    elif [[ -f "Cargo.toml" ]] && grep -q '^\[workspace\]' "Cargo.toml" 2>/dev/null; then
+        detected="true"
+        indicator="Cargo.toml workspace"
+    elif [[ -f "go.work" ]]; then
+        detected="true"
+        indicator="go.work"
+    elif [[ -f "lerna.json" ]]; then
+        detected="true"
+        indicator="lerna.json"
+    fi
+
+    if [[ "$detected" == "true" ]]; then
+        local pkgs
+        pkgs=$(detect_packages)
+        jq -n --arg indicator "$indicator" --argjson packages "$pkgs" \
+            '{"detected": true, "indicator": $indicator, "packages": $packages}'
+    else
+        jq -n '{"detected": false, "indicator": null, "packages": []}'
+    fi
+}
+
+# Enumerate packages in a monorepo.
+# Returns JSON array of { name, path, stack_hint }.
+detect_packages() {
+    check_jq || return 1
+
+    local packages="[]"
+    local -a pkg_globs=()
+    local require_manifest=false
+
+    # Extract workspace globs from config files
+    if [[ -f "pnpm-workspace.yaml" ]]; then
+        while IFS= read -r g; do
+            [[ -n "$g" ]] && pkg_globs+=("$g")
+        done < <(_extract_pnpm_globs)
+    elif [[ -f "package.json" ]] && jq -e '.workspaces' -- "package.json" &>/dev/null; then
+        while IFS= read -r g; do
+            [[ -n "$g" ]] && pkg_globs+=("$g")
+        done < <(_extract_npm_globs)
+    elif [[ -f "Cargo.toml" ]] && grep -q '^\[workspace\]' "Cargo.toml" 2>/dev/null; then
+        while IFS= read -r g; do
+            [[ -n "$g" ]] && pkg_globs+=("$g")
+        done < <(_extract_cargo_members)
+    elif [[ -f "go.work" ]]; then
+        while IFS= read -r g; do
+            [[ -n "$g" ]] && pkg_globs+=("$g")
+        done < <(_extract_go_dirs)
+    fi
+
+    # Fallback: scan common monorepo directories (require manifest evidence)
+    if [[ ${#pkg_globs[@]} -eq 0 ]]; then
+        pkg_globs=("apps/*" "packages/*" "libs/*" "services/*" "modules/*")
+        require_manifest=true
+    fi
+
+    # Expand globs and build package list
+    local prev_nullglob
+    prev_nullglob=$(shopt -p nullglob 2>/dev/null || echo "shopt -u nullglob")
+    shopt -s nullglob
+
+    for glob in "${pkg_globs[@]}"; do
+        for dir in $glob; do
+            [[ -d "$dir" ]] || continue
+            if [[ "$require_manifest" == true ]]; then
+                _has_package_manifest "$dir" || continue
+            fi
+
+            local name
+            name=$(basename "$dir")
+            local stack
+            stack=$(_detect_stack_hint "$dir")
+
+            packages=$(echo "$packages" | jq \
+                --arg name "$name" \
+                --arg path "$dir" \
+                --arg stack "$stack" \
+                '. += [{"name": $name, "path": $path, "stack_hint": $stack}]')
+        done
+    done
+
+    eval "$prev_nullglob"
+    echo "$packages"
+}
+
+# Resolve which package is active based on explicit flag or CWD inference.
+# Returns: compact JSON package object, or "null".
+resolve_package_context() {
+    local explicit_package="${1:-}"
+    check_jq || return 1
+
+    local monorepo_flag
+    monorepo_flag=$(get_monorepo_flag)
+
+    # Not a monorepo -- no package context
+    if [[ "$monorepo_flag" != "true" ]]; then
+        echo "null"
+        return 0
+    fi
+
+    # Priority 1: Explicit --package argument
+    if [[ -n "$explicit_package" && "$explicit_package" != "null" ]]; then
+        local pkg
+        pkg=$(get_package_by_path "$explicit_package")
+        if [[ -n "$pkg" ]]; then
+            echo "$pkg"
+        else
+            # Path not in packages array; return minimal info
+            jq -n --arg path "$explicit_package" \
+                '{"name": ($path | split("/") | last), "path": $path,
+                  "type": "unknown", "stack": "unknown"}'
+        fi
+        return 0
+    fi
+
+    # Priority 2: CWD inference
+    local cwd repo_root rel_cwd
+    cwd=$(pwd)
+    repo_root=$(cd "$(dirname "$STATE_FILE")/.." 2>/dev/null && pwd)
+    rel_cwd="${cwd#"${repo_root}"/}"
+
+    # CWD is repo root (prefix not stripped) -- ambiguous
+    if [[ "$rel_cwd" == "$cwd" || -z "$rel_cwd" ]]; then
+        echo "null"
+        return 0
+    fi
+
+    # Find the longest matching package path
+    local packages_json
+    packages_json=$(get_packages)
+    echo "$packages_json" | jq -c --arg cwd "$rel_cwd" \
+        '[.[] | select(($cwd == .path) or ($cwd | startswith(.path + "/")))]
+         | sort_by(.path | length) | reverse | .[0] // null'
+}
+
+# --- Internal helpers for monorepo detection ---
+
+_has_package_manifest() {
+    local dir="$1"
+    [[ -f "$dir/package.json" ]] \
+        || [[ -f "$dir/Cargo.toml" ]] \
+        || [[ -f "$dir/go.mod" ]] \
+        || [[ -f "$dir/pyproject.toml" ]] \
+        || [[ -f "$dir/setup.py" ]]
+}
+
+_detect_stack_hint() {
+    local dir="$1"
+    if [[ -f "$dir/tsconfig.json" ]] || compgen -G "$dir/tsconfig.*.json" >/dev/null 2>&1; then
+        echo "TypeScript"
+    elif [[ -f "$dir/package.json" ]]; then
+        echo "JavaScript"
+    elif [[ -f "$dir/Cargo.toml" ]]; then
+        echo "Rust"
+    elif [[ -f "$dir/go.mod" ]]; then
+        echo "Go"
+    elif [[ -f "$dir/pyproject.toml" ]] || [[ -f "$dir/setup.py" ]] || [[ -f "$dir/requirements.txt" ]]; then
+        echo "Python"
+    elif [[ -f "$dir/Gemfile" ]]; then
+        echo "Ruby"
+    elif [[ -f "$dir/pom.xml" ]] || [[ -f "$dir/build.gradle" ]] || [[ -f "$dir/build.gradle.kts" ]]; then
+        echo "Java"
+    else
+        echo "unknown"
+    fi
+}
+
+# Parse package globs from pnpm-workspace.yaml
+_extract_pnpm_globs() {
+    local in_packages=false
+    while IFS= read -r line; do
+        local trimmed
+        trimmed=$(trim "$line")
+        if [[ "$trimmed" == "packages:" ]]; then
+            in_packages=true
+            continue
+        fi
+        if [[ "$in_packages" == true ]]; then
+            # End of list: non-list, non-empty line
+            if [[ -n "$trimmed" && "$trimmed" != -* ]]; then
+                break
+            fi
+            if [[ "$trimmed" == "- "* ]]; then
+                local val="${trimmed#- }"
+                val=$(trim "$val")
+                # Remove surrounding quotes
+                val="${val%\"}"
+                val="${val#\"}"
+                val="${val%\'}"
+                val="${val#\'}"
+                [[ -n "$val" ]] && printf '%s\n' "$val"
+            fi
+        fi
+    done <"pnpm-workspace.yaml"
+}
+
+# Parse workspace globs from package.json (npm/yarn format)
+_extract_npm_globs() {
+    jq -r '.workspaces |
+        if type == "array" then .[]
+        elif type == "object" then (.packages // [])[]
+        else empty end' -- "package.json" 2>/dev/null
+}
+
+# Parse workspace members from Cargo.toml
+_extract_cargo_members() {
+    sed -n '/^\[workspace\]/,/^\[/{
+        /members/,/\]/{
+            s/.*"\([^"]*\)".*/\1/p
+        }
+    }' "Cargo.toml" 2>/dev/null
+}
+
+# Parse use directives from go.work
+_extract_go_dirs() {
+    local in_use=false
+    while IFS= read -r line; do
+        local trimmed
+        trimmed=$(trim "$line")
+        if [[ "$trimmed" == "use ("* ]]; then
+            in_use=true
+            continue
+        fi
+        if [[ "$in_use" == true ]]; then
+            [[ "$trimmed" == ")" ]] && {
+                in_use=false
+                continue
+            }
+            trimmed="${trimmed#./}"
+            [[ -n "$trimmed" ]] && printf '%s\n' "$trimmed"
+        elif [[ "$trimmed" == use\ ./* ]]; then
+            local dir="${trimmed#use ./}"
+            dir=$(trim "$dir")
+            [[ -n "$dir" ]] && printf '%s\n' "$dir"
+        fi
+    done <"go.work" 2>/dev/null
+}
+
+# =============================================================================
+# FILE VALIDATION
+# =============================================================================
+
+validate_ascii() {
+    local file="$1"
+
+    if [[ ! -f "$file" ]]; then
+        log_error "File not found: $file"
+        return 1
+    fi
+
+    # Check for non-ASCII characters (bytes > 127) using POSIX-compatible grep
+    # LC_ALL=C ensures byte-by-byte comparison; [^[:print:][:space:]] catches
+    # non-printable/non-whitespace chars including non-ASCII
+    if LC_ALL=C grep -q '[^[:print:][:space:]]' -- "$file" 2>/dev/null; then
+        log_error "Non-ASCII characters found in: $file"
+        return 1
+    fi
+
+    # Check for CRLF line endings (carriage return)
+    if grep -q "$(printf '\r')" -- "$file" 2>/dev/null; then
+        log_error "CRLF line endings found in: $file"
+        return 1
+    fi
+
+    return 0
+}
+
+find_non_ascii() {
+    local file="$1"
+
+    if [[ ! -f "$file" ]]; then
+        log_error "File not found: $file"
+        return 1
+    fi
+
+    # Show non-ASCII characters with line numbers using POSIX-compatible grep
+    LC_ALL=C grep -n '[^[:print:][:space:]]' -- "$file" 2>/dev/null || true
+}
+
+validate_all_files() {
+    local dir="${1:-.}"
+    local errors=0
+
+    while IFS= read -r -d '' file; do
+        if ! validate_ascii "$file"; then
+            ((errors++)) || true
+        fi
+    done < <(find "$dir" -type f \( -name "*.md" -o -name "*.py" -o -name "*.js" -o -name "*.ts" -o -name "*.json" -o -name "*.sh" \) -print0)
+
+    if [[ $errors -gt 0 ]]; then
+        log_error "Found $errors files with encoding issues"
+        return 1
+    fi
+
+    log_success "All files pass ASCII validation"
+    return 0
+}
+
+# =============================================================================
+# DIRECTORY OPERATIONS
+# =============================================================================
+
+ensure_dir() {
+    local dir="$1"
+    if [[ ! -d "$dir" ]]; then
+        mkdir -p -- "$dir"
+        log_info "Created directory: $dir"
+    fi
+}
+
+get_session_dir() {
+    local session_id="$1"
+    echo "${SPECS_DIR}/${session_id}"
+}
+
+session_dir_exists() {
+    local session_id="$1"
+    [[ -d "$(get_session_dir "$session_id")" ]]
+}
+
+# =============================================================================
+# DATE/TIME UTILITIES
+# =============================================================================
+
+get_date() {
+    date '+%Y-%m-%d'
+}
+
+get_datetime() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+get_timestamp() {
+    date '+%Y%m%d_%H%M%S'
+}
+
+# =============================================================================
+# INITIALIZATION CHECK
+# =============================================================================
+
+check_spec_system() {
+    if [[ ! -d "$SPEC_SYSTEM_DIR" ]]; then
+        log_error "Spec system not found. Expected: $SPEC_SYSTEM_DIR/"
+        return 1
+    fi
+
+    if [[ ! -f "$STATE_FILE" ]]; then
+        log_error "State file not found: $STATE_FILE"
+        return 1
+    fi
+
+    if ! validate_json "$STATE_FILE"; then
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# HELP
+# =============================================================================
+
+show_common_help() {
+    cat <<'EOF'
+Apex Spec System - Common Utilities
+
+Functions available after sourcing common.sh:
+
+LOGGING:
+  log_info <msg>      - Blue info message
+  log_success <msg>   - Green success message
+  log_warning <msg>   - Yellow warning message
+  log_error <msg>     - Red error message
+
+JSON (requires jq):
+  json_get <file> <path>           - Read JSON value
+  json_set <file> <path> <value>   - Write JSON value
+  validate_json <file>             - Validate JSON syntax
+
+SESSION ID:
+  parse_session_id <id> [vars...]  - Parse session ID components
+  get_phase_from_session_id <id>   - Extract phase number
+  build_session_id <p> <s> <name>  - Construct session ID
+  build_session_ref <p> <s>        - Build ref like S0103
+
+STATE:
+  get_current_phase                - Current phase number
+  get_current_session              - Current session ID
+  get_completed_sessions           - List completed sessions
+  is_session_completed <id>        - Check if completed
+  set_current_session <id>         - Update current session
+  add_completed_session <id> [pkg] - Mark session complete
+
+MONOREPO:
+  get_monorepo_flag                - "true", "false", or "null"
+  get_packages                     - JSON array of packages
+  get_package_path <name>          - Package path by name
+  get_package_by_path <path>       - Package object by path
+  get_sessions_for_package [path]  - Sessions for a package
+  detect_monorepo                  - Detect monorepo (JSON)
+  detect_packages                  - Enumerate packages (JSON)
+  resolve_package_context [path]   - Active package (JSON)
+
+VALIDATION:
+  validate_ascii <file>            - Check ASCII encoding
+  find_non_ascii <file>            - List non-ASCII chars
+  check_spec_system                - Verify setup
+
+UTILITIES:
+  get_date                         - YYYY-MM-DD
+  get_datetime                     - YYYY-MM-DD HH:MM:SS
+  ensure_dir <dir>                 - Create if not exists
+  get_session_dir <id>             - Get specs/session path
+EOF
+}
+
+# Show help if script run directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    show_common_help
+fi
+
+# CREDIT NOTE: The 1st version of this file was taken directly from Github's Spec Kit


### PR DESCRIPTION
## Summary

Add the **Apex Spec System** skill to the `.experimental` catalog tier.

Apex Spec is a specification-driven workflow system for AI-assisted development that breaks large projects into manageable 2-4 hour sessions with 12-25 tasks each. It provides a 22-command workflow covering initialization, implementation, validation, and phase transitions.

## Contents

| Path | Description |
|------|-------------|
| `skills/.experimental/apex-spec/SKILL.md` | Root orchestrator with YAML frontmatter |
| `skills/.experimental/apex-spec/references/` | 26 command reference files |
| `skills/.experimental/apex-spec/scripts/` | 3 bash utilities (analyze-project.sh, check-prereqs.sh, common.sh) |
| `skills/.experimental/apex-spec/agents/openai.yaml` | Codex CLI metadata |
| `skills/.experimental/apex-spec/LICENSE.txt` | MIT License |
| `skills/.experimental/apex-spec/README.md` | Skill description and installation |

## Installation (after merge)

```
$skill-installer install the apex-spec skill from the .experimental folder
```

## Verification

1. Clone this branch
2. Copy `skills/.experimental/apex-spec/` to `~/.agents/skills/apex-spec/`
3. Verify `ls ~/.agents/skills/apex-spec/SKILL.md` exists
4. In any project: `$apex-spec initspec` should initialize the spec system

## Source Repository

https://github.com/aiwithapex/apex-spec-system-open (v2.0.8-codex)

## Requirements

- bash, git, jq (standard CLI tools, no additional dependencies)

## Notes

- This creates the `skills/.experimental/` directory (first experimental skill submission)
- All files are ASCII-only with Unix LF line endings
- No external dependencies beyond bash, git, jq, and standard coreutils
- License: MIT