### PR TITLE
Removed reference to ".experimental" directory in skills repo

### DIFF
--- a/skills/.system/skill-installer/SKILL.md
+++ b/skills/.system/skill-installer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # Skill Installer
 
-Helps install skills. By default these are from https://github.com/openai/skills/tree/main/skills/.curated, but users can also provide other locations. Experimental skills live in https://github.com/openai/skills/tree/main/skills/.experimental and can be installed the same way.
+Helps install skills. By default these are from https://github.com/openai/skills/tree/main/skills/.curated, but users can also provide other locations.
 
 Use the helper scripts based on the task:
 - List skills when the user asks what is available, or if the user uses this skill without specifying what to do. Default listing is `.curated`, but you can pass `--path skills/.experimental` when they ask about experimental skills.


### PR DESCRIPTION
This directory no longer exists. Link results in 404.

This addresses https://github.com/openai/codex/issues/11068