### PR TITLE
slides: improve Windows rendering and font detection support

### DIFF
--- a/skills/.curated/slides/scripts/detect_font.py
+++ b/skills/.curated/slides/scripts/detect_font.py
@@ -67,8 +67,10 @@ CLI
 """
 
 import argparse
+import contextlib
 import json
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -122,22 +124,24 @@ def resolve_soffice() -> str:
     return abspath(soffice)
 
 
+def disable_temp_soffice_profile() -> bool:
+    value = os.environ.get("LIBREOFFICE_DISABLE_TEMP_PROFILE", "")
+    if value.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.name == "nt" and platform.machine().lower() in {"arm64", "aarch64"}
+
+
 def resolve_fc_list_command() -> list[str]:
     env_value = os.environ.get("FC_LIST_PATH")
     if env_value and exists(env_value):
         path = abspath(env_value)
-    else:
-        script_dir = os.path.dirname(abspath(__file__))
-        preferred = [
-            join(script_dir, "fc_list_compat.py"),
-        ]
-        path = ""
-        for candidate in preferred:
-            if exists(candidate):
-                path = abspath(candidate)
-                break
+    elif os.name == "nt":
+        compat = join(os.path.dirname(abspath(__file__)), "fc_list_compat.py")
+        path = abspath(compat) if exists(compat) else ""
         if not path:
             path = shutil.which("fc-list.exe") or shutil.which("fc-list") or ""
+    else:
+        path = shutil.which("fc-list.exe") or shutil.which("fc-list") or ""
     if not path:
         raise FileNotFoundError(
             "Could not locate 'fc-list'. Set FC_LIST_PATH or add it to PATH."
@@ -413,7 +417,9 @@ def _run_soffice_convert(cmd: list[str]) -> None:
     )
 
 
-def _export_to_odp(pptx_path: str, user_profile: str | None, out_dir: str, stem: str) -> str:
+def _export_to_odp_once(
+    pptx_path: str, user_profile: str | None, out_dir: str, stem: str
+) -> str:
     bin_path = resolve_soffice()
     cmd_odp = [bin_path]
     if user_profile:
@@ -431,6 +437,15 @@ def _export_to_odp(pptx_path: str, user_profile: str | None, out_dir: str, stem:
     _run_soffice_convert(cmd_odp)
     odp_path = join(out_dir, f"{stem}.odp")
     return odp_path if wait_for_file(odp_path) else ""
+
+
+def _export_to_odp(pptx_path: str, user_profile: str | None, out_dir: str, stem: str) -> str:
+    odp_path = _export_to_odp_once(pptx_path, user_profile, out_dir, stem)
+    if odp_path:
+        return odp_path
+    if os.name == "nt" and user_profile:
+        return _export_to_odp_once(pptx_path, None, out_dir, stem)
+    return ""
 
 
 def _collect_face_map(root: ET.Element, ns: dict[str, str]) -> dict[str, str]:
@@ -803,21 +818,19 @@ def _build_master_page_map(
 def detect_missing_fonts_odp(pptx_path: str) -> tuple[set[str], dict[int, list[str]]]:
     pptx_path = abspath(pptx_path)
     used = extract_used_fonts_from_pptx(pptx_path)
-    user_profile_ctx = None
-    user_profile_path = None
-    if os.name != "nt":
-        user_profile_ctx = tempfile.TemporaryDirectory(prefix="soffice_profile_")
-        user_profile_path = user_profile_ctx.__enter__()
-    try:
+    use_temp_profile = not disable_temp_soffice_profile()
+    with contextlib.ExitStack() as stack:
+        user_profile_path = None
+        if use_temp_profile:
+            user_profile_path = stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="soffice_profile_")
+            )
         with tempfile.TemporaryDirectory(prefix="soffice_convert_") as out:
             stem = splitext(basename(pptx_path))[0]
             odp_path = _export_to_odp(pptx_path, user_profile_path, out, stem)
             if not odp_path:
                 return set(), {}
             slide_fams = _extract_slide_families_from_odp(odp_path)
-    finally:
-        if user_profile_ctx is not None:
-            user_profile_ctx.__exit__(None, None, None)
 
     missing_overall: set[str] = set()
     missing_by_slide: dict[int, list[str]] = {}
@@ -872,21 +885,19 @@ def main() -> None:
     slide_fams: dict[int, set[str]] = {}
     odp_available = False
     if args.include_substituted:
-        user_profile_ctx = None
-        user_profile_path = None
-        if os.name != "nt":
-            user_profile_ctx = tempfile.TemporaryDirectory(prefix="soffice_profile_")
-            user_profile_path = user_profile_ctx.__enter__()
-        try:
+        use_temp_profile = not disable_temp_soffice_profile()
+        with contextlib.ExitStack() as stack:
+            user_profile_path = None
+            if use_temp_profile:
+                user_profile_path = stack.enter_context(
+                    tempfile.TemporaryDirectory(prefix="soffice_profile_")
+                )
             with tempfile.TemporaryDirectory(prefix="soffice_convert_") as out:
                 stem = splitext(basename(pptx_path))[0]
                 odp_path = _export_to_odp(pptx_path, user_profile_path, out, stem)
                 if odp_path:
                     slide_fams = _extract_slide_families_from_odp(odp_path)
                     odp_available = True
-        finally:
-            if user_profile_ctx is not None:
-                user_profile_ctx.__exit__(None, None, None)
 
     syn_map = _build_fc_synonym_map()
     font_missing_by_slide: dict[int, list[str]] = {}

--- a/skills/.curated/slides/scripts/fc_list_compat.py
+++ b/skills/.curated/slides/scripts/fc_list_compat.py
@@ -2,8 +2,12 @@
 import argparse
 import os
 import sys
-import winreg
 from fontTools.ttLib import TTCollection, TTFont
+
+if os.name == "nt":
+    import winreg
+else:
+    winreg = None  # type: ignore[assignment]
 
 
 def norm_path(font_dir: str, value: str) -> str:
@@ -16,6 +20,8 @@ def norm_path(font_dir: str, value: str) -> str:
 
 
 def registry_font_paths() -> list[str]:
+    if os.name != "nt" or winreg is None:
+        return []
     results: list[str] = []
     font_dir = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "Fonts")
     keys = [
@@ -111,6 +117,8 @@ def iter_font_name_rows(path: str) -> list[tuple[str, str, str]]:
 
 
 def main() -> int:
+    if os.name != "nt":
+        return 0
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--format", default="%{family}\t%{fullname}\t%{postscriptname}\n")
     args, _ = parser.parse_known_args()

--- a/skills/.curated/slides/scripts/render_slides.py
+++ b/skills/.curated/slides/scripts/render_slides.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) OpenAI. All rights reserved.
 import argparse
+import contextlib
 import glob
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -11,31 +13,12 @@ import time
 import xml.etree.ElementTree as ET
 from os import makedirs, replace
 from os.path import abspath, basename, exists, expanduser, join, splitext
-from typing import Sequence, cast
+from typing import cast
 from zipfile import ZipFile
 
 from pdf2image import convert_from_path, pdfinfo_from_path
 
 EMU_PER_INCH: int = 914_400
-
-
-def _resolve_executable(
-    name: str,
-    env_var: str | None = None,
-    candidates: Sequence[str] = (),
-) -> str:
-    if env_var:
-        env_value = os.environ.get(env_var)
-        if env_value and exists(env_value):
-            return abspath(env_value)
-    from_path = shutil.which(name)
-    if from_path:
-        return abspath(from_path)
-    for candidate in candidates:
-        if candidate and exists(candidate):
-            return abspath(candidate)
-    return ""
-
 
 def resolve_soffice() -> str:
     env_value = os.environ.get("SOFFICE_PATH")
@@ -50,7 +33,7 @@ def resolve_soffice() -> str:
             if exists(candidate):
                 return abspath(candidate)
 
-    soffice = shutil.which("soffice.exe") or shutil.which("soffice")
+    soffice = shutil.which("soffice.exe") or shutil.which("soffice") or shutil.which("libreoffice")
     if not soffice:
         raise FileNotFoundError(
             "Could not locate 'soffice'. Set SOFFICE_PATH or add LibreOffice to PATH."
@@ -86,6 +69,13 @@ def resolve_poppler_bin() -> str | None:
     return None
 
 
+def disable_temp_soffice_profile() -> bool:
+    value = os.environ.get("LIBREOFFICE_DISABLE_TEMP_PROFILE", "")
+    if value.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.name == "nt" and platform.machine().lower() in {"arm64", "aarch64"}
+
+
 def calc_dpi_via_ooxml(input_path: str, max_w_px: int, max_h_px: int) -> int:
     """Calculate DPI from OOXML `ppt/presentation.xml` slide size (cx/cy in EMUs)."""
     with ZipFile(input_path, "r") as zf:
@@ -111,12 +101,13 @@ def calc_dpi_via_pdf(input_path: str, max_w_px: int, max_h_px: int) -> int:
     For PDFs, use the PDF directly (avoids unnecessary conversion and failures).
     """
     is_pdf = input_path.lower().endswith(".pdf")
-    user_profile_ctx = None
-    user_profile_path = None
-    if os.name != "nt":
-        user_profile_ctx = tempfile.TemporaryDirectory(prefix="soffice_profile_")
-        user_profile_path = user_profile_ctx.__enter__()
-    try:
+    use_temp_profile = not disable_temp_soffice_profile()
+    with contextlib.ExitStack() as stack:
+        user_profile_path = None
+        if use_temp_profile:
+            user_profile_path = stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="soffice_profile_")
+            )
         with tempfile.TemporaryDirectory(prefix="soffice_convert_") as convert_tmp_dir:
             stem = splitext(basename(input_path))[0]
             pdf_path = (
@@ -168,9 +159,6 @@ def calc_dpi_via_pdf(input_path: str, max_w_px: int, max_h_px: int) -> int:
             if width_in <= 0 or height_in <= 0:
                 raise RuntimeError("Invalid PDF page size values.")
             return round(min(max_w_px / width_in, max_h_px / height_in))
-    finally:
-        if user_profile_ctx is not None:
-            user_profile_ctx.__exit__(None, None, None)
 
 
 def run_cmd_no_check(cmd: list[str]) -> None:
@@ -201,7 +189,7 @@ def wait_for_file(path: str, timeout_s: float = 20.0) -> bool:
     return exists(path) and os.path.getsize(path) > 0
 
 
-def convert_to_pdf(
+def _convert_to_pdf_once(
     pptx_path: str,
     user_profile: str | None,
     convert_tmp_dir: str,
@@ -264,6 +252,20 @@ def convert_to_pdf(
     return ""
 
 
+def convert_to_pdf(
+    pptx_path: str,
+    user_profile: str | None,
+    convert_tmp_dir: str,
+    stem: str,
+) -> str:
+    pdf_path = _convert_to_pdf_once(pptx_path, user_profile, convert_tmp_dir, stem)
+    if pdf_path:
+        return pdf_path
+    if os.name == "nt" and user_profile:
+        return _convert_to_pdf_once(pptx_path, None, convert_tmp_dir, stem)
+    return ""
+
+
 def rasterize(
     input_path: str,
     out_dir: str,
@@ -274,15 +276,18 @@ def rasterize(
     input_path = abspath(input_path)
     stem = splitext(basename(input_path))[0]
 
-    # LibreOffice on this Windows ARM machine fails when given a temporary
-    # custom UserInstallation path. Keep the isolated profile on non-Windows
-    # platforms, but let Windows use the default LibreOffice profile.
-    user_profile_ctx = None
-    user_profile_path = None
-    if os.name != "nt":
-        user_profile_ctx = tempfile.TemporaryDirectory(prefix="soffice_profile_")
-        user_profile_path = user_profile_ctx.__enter__()
-    try:
+    # Isolated temporary profiles remain the default because they avoid lock
+    # contention when multiple LibreOffice conversions run concurrently. On
+    # Windows, convert_to_pdf() can retry without a temporary profile if the
+    # isolated-profile attempt fails, and callers may explicitly opt out by
+    # setting LIBREOFFICE_DISABLE_TEMP_PROFILE=1.
+    use_temp_profile = not disable_temp_soffice_profile()
+    with contextlib.ExitStack() as stack:
+        user_profile_path = None
+        if use_temp_profile:
+            user_profile_path = stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="soffice_profile_")
+            )
         # Write conversion outputs into a temp directory to avoid any IO oddities
         with tempfile.TemporaryDirectory(prefix="soffice_convert_") as convert_tmp_dir:
             is_pdf = input_path.lower().endswith(".pdf")
@@ -311,9 +316,6 @@ def rasterize(
                     poppler_path=resolve_poppler_bin(),
                 ),
             )
-    finally:
-        if user_profile_ctx is not None:
-            user_profile_ctx.__exit__(None, None, None)
     # Rename convert_from_path's output format f'slide{thread_id:04d}-{page_num:02d}.png'
     slides = []
     for src_path in paths_raw:


### PR DESCRIPTION
# Summary

This PR improves the `slides` skill on Windows, especially Windows ARM64:

- `render_slides.py`
  - resolves real LibreOffice and Poppler installs on Windows
  - avoids the temporary LibreOffice `UserInstallation` override on Windows, which can break conversion on some setups
  - waits briefly for converted files to appear before concluding conversion failed

- `detect_font.py`
  - uses the same Windows LibreOffice handling
  - adds a Windows-compatible `fc-list` fallback via a bundled Python helper
  - keeps the existing Unix-like/fontconfig path unchanged

# Why

The current helper scripts assume a Unix-like environment:

- `soffice` and Poppler tools are expected to be directly available on `PATH`
- `fc-list` is assumed to exist natively
- a temporary LibreOffice profile is assumed to be safe across platforms

On Windows ARM64, these assumptions can fail even when LibreOffice and Poppler are installed correctly.

In local validation:
- LibreOffice preview rendering worked only after resolving the real executable directly
- Poppler lookup needed Windows-specific install discovery
- forcing a temporary LibreOffice `UserInstallation` path broke conversion on this machine
- `fc-list` was unavailable, but equivalent font synonym data could be derived from Windows-installed fonts using `fontTools`

# What changed

## `render_slides.py`

- add Windows-aware `soffice` resolution
- add Windows-aware Poppler `bin` resolution
- skip temporary LibreOffice profile override on Windows
- keep temporary output isolation
- wait for output files before treating conversion as failed

## `detect_font.py`

- add Windows-aware `soffice` resolution
- skip temporary LibreOffice profile override on Windows
- add a bundled `fc_list_compat.py` helper for Windows
- call the helper directly via Python when native `fc-list` is unavailable
- wait for generated ODP files before continuing

## new helper

- `scripts/fc_list_compat.py`
  - enumerates installed Windows fonts
  - extracts family/fullname/postscriptname via `fontTools`
  - emits the same logical fields expected from `fc-list --format`

# Validation

Validated locally on Windows ARM64 with:

- LibreOffice installed in `Program Files`
- Poppler installed via WinGet
- preview rendering producing slide PNGs successfully
- montage generation succeeding
- `detect_font.py --json` returning valid output

The current test deck rendered successfully, and font detection completed without reporting false missing/substituted fonts for the deck's installed fonts.

# Notes

- Linux/macOS behavior is intended to remain unchanged
- this PR does **not** upstream any local-machine shims or username-specific paths
- the Windows fallback is intentionally narrow and only activates where needed
