### PR TITLE
[codex] Add anti-vibecoding experimental skill

### DIFF
--- a/skills/.experimental/anti-vibecoding/LICENSE.txt
+++ b/skills/.experimental/anti-vibecoding/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.experimental/anti-vibecoding/SKILL.md
+++ b/skills/.experimental/anti-vibecoding/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: anti-vibecoding
+description: Clarification-first guardrail for coding tasks that prevents premature execution and forces requirement hardening before implementation. Use when users ask to avoid vibecoding, request strict clarifying questions, tune pre-execution tool-call aggressiveness, route work to the relevant current codebase using project memories, enforce naming and architecture decisions, and get milestone coaching reports with mistakes, knowledge gaps, and learning actions.
+---
+
+# Anti Vibecoding
+
+## Overview
+
+Enforce a clarification-first workflow before implementation. Route tasks to the correct project using memory signals, ask targeted questions in rounds grounded in the current codebase, gate execution until readiness is green, trace tool usage verbosely, and emit milestone coaching reports.
+
+## Required Operating Contract
+
+1. Start in clarification mode, not implementation mode.
+2. Route the task to a relevant project before deep clarification.
+3. Search for existing agent or project memories before asking codebase questions.
+4. If memory is missing or weak, create a small startup project memory in-session and use it as provisional routing context.
+5. Block mutating implementation actions until readiness gate is green.
+6. Allow only read-only discovery before green, and only within configured pre-green tool budget.
+7. Ask for both micro naming and macro naming decisions.
+8. Explain every tool use with a short rationale and confidence impact.
+9. Emit a milestone coaching report at each major milestone.
+
+## Parse Runtime Configuration
+
+Extract optional config from user text. Apply defaults when omitted.
+
+```text
+mode=<strict|balanced|light|auto>
+aggressiveness=<1-5>
+pre_green_tool_budget=<int>
+milestone_reporting=<on|off>
+memory_strategy=<discover-first|always-bootstrap|hybrid>
+project_hint=<path|name>
+```
+
+Default values:
+
+- `mode=auto`
+- `aggressiveness=3`
+- `milestone_reporting=on`
+- `memory_strategy=hybrid`
+- `pre_green_tool_budget` derives from `mode` unless explicitly overridden
+
+Mode mapping:
+
+- `strict`: budget `0`
+- `balanced`: budget `3`
+- `light`: budget `8`
+- `auto`: choose with `references/gating_rubric.md`
+
+`aggressiveness` meaning:
+
+- `1`: ask only blocking questions
+- `2`: ask blocking plus one quality pass
+- `3`: ask balanced depth across all dimensions
+- `4`: ask deeper edge-case and failure-mode questions
+- `5`: ask exhaustive requirement and architecture pressure-test questions
+
+`memory_strategy` meaning:
+
+- `discover-first`: only use discovered memories; do not bootstrap unless user allows assumptions
+- `always-bootstrap`: always create a startup memory first, then refine with discovered context
+- `hybrid`: discover first, bootstrap only when memory is absent or low confidence
+
+## Clarification Workflow
+
+Follow this workflow in order for each task chunk.
+
+### Phase A: Intake, Memory Discovery, and Project Routing
+
+1. Restate user objective in one concise sentence.
+2. Discover candidate projects and repositories from user prompt, workspace context, and `project_hint`.
+3. Run memory discovery using `references/memory_routing.md`.
+4. If memory is absent or insufficient, generate a small startup project memory block and mark confidence as inferred.
+5. Select the routed target project and explicitly state why it was selected.
+6. Decide effective mode and budget.
+
+### Phase B: Multi-Round Clarification Pack
+
+1. Ask a focused batch of questions.
+2. Cover these dimensions each round until green:
+   - Requirements and success criteria
+   - Project route and memory confidence
+   - Current codebase context and integration points
+   - Constraints and non-goals
+   - Naming conventions at micro level
+   - Naming conventions at macro level
+   - Acceptance criteria and verification strategy
+3. Use adaptive depth from `aggressiveness`.
+4. Continue rounds until gate criteria in `references/gating_rubric.md` are satisfied.
+
+### Phase C: Gate Status After Each Round
+
+Always render a gate snapshot:
+
+```markdown
+## Readiness Score
+- Overall: X/14 (RED|YELLOW|GREEN)
+- Requirements: X/2
+- Project Route and Memory: X/2
+- Codebase Context: X/2
+- Constraints: X/2
+- Naming (Micro): X/2
+- Naming (Macro): X/2
+- Acceptance Criteria: X/2
+- Missing for GREEN: [list]
+```
+
+### Phase D: Tool Trace (When Tools Are Used)
+
+For each tool call, output:
+
+```markdown
+## Tool Trace
+- Tool: <name>
+- Why this tool now: <reason>
+- What it checked: <scope>
+- Impact on certainty: <increase/decrease and why>
+```
+
+Keep this deterministic and concise.
+
+### Phase E: Milestone Coaching Report
+
+At each major milestone, if `milestone_reporting=on`, emit report using `references/report_templates.md`.
+
+Major milestones include:
+
+1. Project routing and memory confidence reaches acceptable threshold.
+2. Requirements gate moved to green.
+3. Naming and architecture decisions are finalized.
+4. A task chunk is completed.
+5. User asks for a checkpoint, wrap-up, or review.
+
+### Phase F: Loop
+
+After each milestone report, return to clarification mode for the next chunk. Do not transition silently into mutating implementation when gate is not green.
+
+## Required Output Contract
+
+When skill is active, structure responses with these sections in this order:
+
+1. `Project Route`
+2. `Current Codebase Considerations`
+3. `Clarification Pack`
+4. `Readiness Score`
+5. `Tool Trace` (only if tools used)
+6. `Milestone Coaching Report` (for milestone events)
+7. `Next Questions`
+
+## Coaching and Correction Rules
+
+1. Call out incorrect assumptions explicitly and with evidence.
+2. Separate confidence levels: confirmed, inferred, unknown.
+3. Tie each correction to a concrete learning action.
+4. Prioritize high-leverage gaps first.
+5. Keep feedback direct and professional.
+
+## Reference Usage
+
+1. Use `references/memory_routing.md` to discover or bootstrap project memory and route to the target codebase.
+2. Use `references/question_bank.md` to choose targeted questions per dimension and aggressiveness.
+3. Use `references/gating_rubric.md` to score readiness and choose auto mode.
+4. Use `references/report_templates.md` to keep milestone reports consistent.

--- a/skills/.experimental/anti-vibecoding/agents/openai.yaml
+++ b/skills/.experimental/anti-vibecoding/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Anti Vibecoding"
+  short_description: "Clarification-first coding guardrail"
+  default_prompt: "Use $anti-vibecoding to clarify requirements before any execution."

--- a/skills/.experimental/anti-vibecoding/references/gating_rubric.md
+++ b/skills/.experimental/anti-vibecoding/references/gating_rubric.md
@@ -1,0 +1,87 @@
+# Gating Rubric
+
+Use this rubric to decide whether implementation can start and how strict pre-green behavior should be.
+
+## Dimensions and Scoring
+
+Score each dimension `0`, `1`, or `2`.
+
+1. Requirements and Scope
+2. Project Route and Memory Confidence
+3. Current Codebase Context
+4. Constraints and Non-Goals
+5. Naming Conventions (Micro)
+6. Naming Conventions (Macro)
+7. Acceptance Criteria and Verification
+
+Score meanings:
+
+- `0`: Missing or contradictory.
+- `1`: Partial, still ambiguous.
+- `2`: Clear, specific, and testable.
+
+Total score range: `0-14`.
+
+## Gate Colors
+
+- `RED`: `0-7`
+- `YELLOW`: `8-11`
+- `GREEN`: `12-14`
+
+Additional gate condition:
+
+- `GREEN` is valid only if Requirements, Project Route and Memory, Current Codebase Context, and Acceptance Criteria are all at least `1`.
+
+## Pre-Green Tool Budget Rules
+
+Default by mode:
+
+- `strict`: `0`
+- `balanced`: `3` read-only calls
+- `light`: `8` read-only calls
+- `auto`: derived by risk profile
+
+If `pre_green_tool_budget` is explicitly provided by user, use it as override.
+
+Budget consumption rules:
+
+1. Count one budget unit per tool call.
+2. Allow only read-only inspection before green.
+3. Treat memory discovery and routing checks as budgeted pre-green calls.
+4. Deny mutating actions before green regardless of remaining budget.
+
+## Auto Mode Selection
+
+Use ambiguity and risk to pick effective mode.
+
+Inputs:
+
+1. Number of dimensions scored `0`.
+2. Presence of conflicting requirements.
+3. Presence of unknown integration points.
+4. Project routing confidence.
+5. User tolerance for assumptions.
+
+Heuristic:
+
+- Choose `strict` if two or more dimensions are `0`, if requirements conflict, or if routing confidence is low.
+- Choose `balanced` if most dimensions are `1` and no hard conflicts exist.
+- Choose `light` if at least five dimensions are `2` and only low-risk unknowns remain.
+
+## Round Completion Logic
+
+After each clarification round:
+
+1. Rescore all seven dimensions.
+2. Publish missing items required for green.
+3. If not green, generate next targeted question batch.
+4. If green, explicitly announce gate pass before any implementation work.
+
+## Assumption Handling
+
+If user declines to answer a question:
+
+1. Record assumption explicitly.
+2. Mark confidence as inferred.
+3. Reflect risk in coaching report.
+4. Continue only if gate can still reach green without violating hard constraints.

--- a/skills/.experimental/anti-vibecoding/references/memory_routing.md
+++ b/skills/.experimental/anti-vibecoding/references/memory_routing.md
@@ -1,0 +1,84 @@
+# Memory Routing
+
+Use this reference to route tasks to the correct project and anchor clarifications in current codebase reality.
+
+## Discovery Priority
+
+Run this order unless user provides explicit `project_hint`.
+
+1. User-provided path, repo name, or branch in current prompt.
+2. Existing project memory files in candidate repos:
+   - `memory.md`
+   - `.codex/memory.md`
+   - `docs/architecture.md`
+   - `docs/context.md`
+3. Agent memory locations if available in current environment:
+   - workspace-level memory files
+   - codex-managed memory files
+4. Repository signals when memory files are missing:
+   - top-level README
+   - package/service manifests
+   - main entrypoints and module maps
+
+## Startup Project Memory (Small)
+
+If memory discovery is missing or insufficient, create a compact startup memory block in-session (do not require immediate file writes).
+
+Template:
+
+```markdown
+## Startup Project Memory (Provisional)
+- Project candidate: <name/path>
+- Primary goal area: <domain capability>
+- Probable entrypoints: <files/modules>
+- Core dependencies: <libraries/services>
+- Naming style clues: <snake/camel/prefix conventions>
+- Open unknowns: <top 3 unknowns>
+- Confidence: inferred
+```
+
+Rules:
+
+1. Keep to 5-8 bullets.
+2. Label as provisional until confirmed.
+3. Use it to guide the next clarification round.
+
+## Routing Decision
+
+Score each candidate project on:
+
+1. Prompt match to domain terms.
+2. Memory confidence and freshness.
+3. Existence of expected entrypoints.
+4. Ownership or boundary fit.
+
+Select highest-confidence candidate and output:
+
+```markdown
+## Project Route
+- Selected project: <name/path>
+- Why selected: <top evidence>
+- Memory source: <existing memory | startup provisional memory>
+- Routing confidence: <high|medium|low>
+```
+
+If routing confidence is low, ask confirmation before deep implementation planning.
+
+## Codebase-Aware Clarification Rules
+
+After route selection, ensure clarifications are anchored to the selected codebase.
+
+1. Ask where in the current project the change should land.
+2. Ask which existing contracts and tests must remain valid.
+3. Ask which naming conventions are already present in that project.
+4. Ask for boundaries: what adjacent modules must not be touched.
+5. Ask for acceptance criteria tied to current behavior, not generic outcomes.
+
+## Memory Reuse for All Tasks
+
+For each new task chunk:
+
+1. Reuse the latest confirmed memory for that project.
+2. Re-score confidence after new evidence.
+3. Refresh startup memory if contradictions appear.
+4. Re-route only if strong conflicting evidence appears.

--- a/skills/.experimental/anti-vibecoding/references/question_bank.md
+++ b/skills/.experimental/anti-vibecoding/references/question_bank.md
@@ -1,0 +1,159 @@
+# Question Bank
+
+Use this bank to generate focused clarification rounds. Ask only what is needed to move readiness toward green.
+
+## Table of Contents
+
+1. Requirements and Scope
+2. Project Route and Memory
+3. Current Codebase Context
+4. Constraints and Non-Goals
+5. Naming Conventions (Micro)
+6. Naming Conventions (Macro)
+7. Acceptance and Verification
+8. Round Construction by Aggressiveness
+
+## Usage Rules
+
+1. Pick at least one question from each unresolved dimension per round.
+2. Increase depth according to `aggressiveness`.
+3. Prefer concrete, answerable questions over broad open prompts.
+4. Keep each round small enough for fast user response.
+
+## Requirements and Scope
+
+Blocking questions:
+
+1. What exact output should be delivered, and in what format?
+2. What is explicitly out of scope for this task?
+3. What does success look like in one sentence?
+
+Quality questions:
+
+1. Which edge cases must be handled on day one?
+2. Which tradeoff is preferred: speed, correctness, or maintainability?
+
+Deep questions:
+
+1. Which failure is unacceptable even if implementation is slower?
+2. Which assumptions are safest to reject before coding?
+
+## Project Route and Memory
+
+Blocking questions:
+
+1. Which project or repo should this task be routed to?
+2. Is there an existing project memory source to trust for this task?
+3. Should provisional startup memory be used if memory is missing?
+
+Quality questions:
+
+1. Which memory fields are most reliable right now, and which are stale?
+2. Which project boundary signals confirm this route is correct?
+
+Deep questions:
+
+1. What evidence would force re-routing to another project?
+2. Which memory assumption is most likely to be wrong for this task?
+
+## Current Codebase Context
+
+Blocking questions:
+
+1. Which files or modules are the source of truth for this change?
+2. Which interfaces must remain backward compatible?
+3. Which existing tests or examples represent current behavior?
+
+Quality questions:
+
+1. What architectural boundaries must this change respect?
+2. Which subsystem owner conventions should be preserved?
+
+Deep questions:
+
+1. What hidden coupling is most likely to break this change?
+2. Which observability hooks are required before rollout?
+
+## Constraints and Non-Goals
+
+Blocking questions:
+
+1. What deadlines, runtime limits, or policy constraints apply?
+2. What should explicitly not be optimized right now?
+3. What dependencies or tools are disallowed?
+
+Quality questions:
+
+1. Which constraints are hard vs negotiable?
+2. Which risk should be accepted vs mitigated?
+
+Deep questions:
+
+1. Under what condition should this approach be abandoned?
+2. What rollback criteria must be pre-defined?
+
+## Naming Conventions (Micro)
+
+Micro means symbol-level names: variables, functions, methods, classes, files.
+
+Blocking questions:
+
+1. What naming style should be followed for symbols in this codebase?
+2. Which domain terms are mandatory in names?
+3. Which abbreviations are forbidden?
+
+Quality questions:
+
+1. Should names optimize for brevity or explicitness?
+2. How should temporary or experimental names be marked?
+
+Deep questions:
+
+1. Which ambiguous terms caused bugs before and should be banned?
+2. Which naming pattern improves code review velocity most?
+
+## Naming Conventions (Macro)
+
+Macro means architecture-level names: packages, services, bounded contexts, API groups, major folders.
+
+Blocking questions:
+
+1. What taxonomy should govern module and service naming?
+2. Which existing macro names must align with this change?
+3. Which ownership boundaries should names encode?
+
+Quality questions:
+
+1. Should macro names reflect business domains or technical layers?
+2. How should cross-team shared modules be prefixed or grouped?
+
+Deep questions:
+
+1. Which naming strategy minimizes future re-org churn?
+2. Which macro name choices create accidental coupling?
+
+## Acceptance and Verification
+
+Blocking questions:
+
+1. What test or check must pass before this is considered done?
+2. What user-visible behavior must be demonstrably correct?
+3. What regression must be explicitly prevented?
+
+Quality questions:
+
+1. What performance or reliability threshold is acceptable?
+2. Which smoke tests are mandatory per milestone?
+
+Deep questions:
+
+1. Which metric should be tracked post-change to validate outcome?
+2. What evidence would disprove the current plan?
+
+## Round Construction by Aggressiveness
+
+1. `1`: Ask one blocking question for each unresolved dimension.
+2. `2`: Ask blocking questions plus one quality question for highest-risk dimension.
+3. `3`: Ask blocking questions and quality questions for all unresolved dimensions.
+4. `4`: Add deep questions for two highest-risk dimensions.
+5. `5`: Add deep questions for every unresolved dimension and challenge assumptions.

--- a/skills/.experimental/anti-vibecoding/references/report_templates.md
+++ b/skills/.experimental/anti-vibecoding/references/report_templates.md
@@ -1,0 +1,121 @@
+# Report Templates
+
+Use these templates to keep reports deterministic and easy to review.
+
+## Project Route Template
+
+```markdown
+## Project Route
+- Selected project: <name/path>
+- Why selected: <top evidence>
+- Memory source: <existing memory | startup provisional memory>
+- Routing confidence: <high|medium|low>
+```
+
+## Current Codebase Considerations Template
+
+```markdown
+## Current Codebase Considerations
+- Confirmed source-of-truth files: <list>
+- Important integration boundaries: <list>
+- Existing behavior constraints: <list>
+- Codebase unknowns still blocking confidence: <list>
+```
+
+## Tool Trace Template
+
+```markdown
+## Tool Trace
+- Tool: <name>
+- Why this tool now: <reason>
+- What it checked: <scope>
+- Result summary: <key fact>
+- Impact on certainty: <up/down and why>
+```
+
+Emit one block per tool action when verbose tracing is required.
+
+## Milestone Coaching Report Template
+
+```markdown
+## Milestone Coaching Report
+- Milestone: <name>
+- Outcome: <achieved/not achieved>
+
+### Mistakes or Weak Assumptions
+1. <issue>
+2. <issue>
+
+### Where the Developer Is Wrong
+1. <incorrect belief or decision>
+   - Correction: <what is correct>
+   - Evidence: <facts from session>
+
+### Missing Knowledge Areas
+1. <gap>
+2. <gap>
+
+### What to Learn Next
+1. <topic> - <why it matters now>
+2. <topic> - <why it matters now>
+
+### Immediate Next Actions
+1. <small concrete action>
+2. <small concrete action>
+```
+
+Rules:
+
+1. Use direct language and evidence.
+2. Avoid vague praise-only summaries.
+3. Prioritize highest-impact correction first.
+4. Keep learning actions specific and bounded.
+
+## Readiness Score Template
+
+```markdown
+## Readiness Score
+- Overall: <score>/14 (<RED|YELLOW|GREEN>)
+- Requirements: <0-2>
+- Project Route and Memory: <0-2>
+- Current Codebase Context: <0-2>
+- Constraints: <0-2>
+- Naming (Micro): <0-2>
+- Naming (Macro): <0-2>
+- Acceptance Criteria: <0-2>
+- Missing for GREEN: <bullet list>
+```
+
+## Clarification Pack Template
+
+```markdown
+## Clarification Pack
+### Requirements
+1. <question>
+
+### Project Route and Memory
+1. <question>
+
+### Current Codebase Context
+1. <question>
+
+### Constraints
+1. <question>
+
+### Naming (Micro)
+1. <question>
+
+### Naming (Macro)
+1. <question>
+
+### Acceptance Criteria
+1. <question>
+```
+
+## Next Questions Template
+
+```markdown
+## Next Questions
+1. <highest-priority unresolved question>
+2. <second unresolved question>
+```


### PR DESCRIPTION
## Summary
Add a new experimental skill, `anti-vibecoding`, under `skills/.experimental/`.

## What this skill does
- Enforces a clarification-first workflow before implementation
- Adds project memory discovery/bootstrap and routes work to the relevant codebase
- Grounds clarification rounds in current codebase constraints
- Uses adaptive gating and configurable pre-green tool-call budgets
- Produces deterministic tool traces and milestone coaching reports

## Files added
- `skills/.experimental/anti-vibecoding/SKILL.md`
- `skills/.experimental/anti-vibecoding/agents/openai.yaml`
- `skills/.experimental/anti-vibecoding/references/question_bank.md`
- `skills/.experimental/anti-vibecoding/references/gating_rubric.md`
- `skills/.experimental/anti-vibecoding/references/memory_routing.md`
- `skills/.experimental/anti-vibecoding/references/report_templates.md`
- `skills/.experimental/anti-vibecoding/LICENSE.txt`

## Notes
This contribution starts in `.experimental` for feedback before any curation consideration.
