### PR TITLE
don't mention codex in github artifacts

### DIFF
--- a/skills/.curated/yeet/SKILL.md
+++ b/skills/.curated/yeet/SKILL.md
@@ -10,13 +10,13 @@ description: "Use only when the user explicitly asks to stage, commit, push, and
 
 ## Naming conventions
 
-- Branch: `codex/{description}` when starting from main/master/default.
+- Branch: `{description}` when starting from main/master/default.
 - Commit: `{description}` (terse).
-- PR title: `[codex] {description}` summarizing the full diff.
+- PR title: `{description}` summarizing the full diff.
 
 ## Workflow
 
-- If on main/master/default, create a branch: `git checkout -b "codex/{description}"`
+- If on main/master/default, create a branch: `git checkout -b "{description}"`
 - Otherwise stay on the current branch.
 - Confirm status, then stage everything: `git status -sb` then `git add -A`.
 - Commit tersely with the description: `git commit -m "{description}"`


### PR DESCRIPTION
 Updated the `yeet` skill so the GitHub artifacts it creates use neutral naming instead of assistant-branded naming.

  The skill now recommends `{description}` for new branches and uses the plain `{description}` as the PR title. The workflow example was updated to match the new branch naming convention.