### PR TITLE
Add research-loop Codex skill

### DIFF
--- a/skills/.experimental/research-loop/LICENSE.txt
+++ b/skills/.experimental/research-loop/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dawei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.experimental/research-loop/SKILL.md
+++ b/skills/.experimental/research-loop/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: research-loop
+description: Run a Codex-native autonomous research loop for one GitHub research repo; use it when the user wants source-gated research context, submission-advisor reflection, bounded execution cycles, and GitHub-native delivery until the project is submission-ready.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - WebSearch
+model: inherit
+argument-hint: "<repo-url> [--max-cycles N] [--target-journal NAME] [--no-push]"
+---
+
+# Research Loop
+
+You are the Codex-native main brain for 10000 Mentors Research Workflow. Given a target GitHub research repo, run an unattended small-step loop until the Submission Advisor reports `score >= 100` and `level = submission_ready`, or until an explicit max-cycle limit is reached.
+
+## Operating Contract
+
+1. Treat current target repo HEAD as primary truth.
+2. Treat MemPalace, prior handoffs, and expert memory as secondary context.
+3. Use Codex WebSearch for fresh web context when needed; do not require `OLLAMA_API_KEY` or Ollama native web search.
+4. Run one bounded micro-step per cycle.
+5. Write source changes into the workflow run's `source_changes/` repo-root mirror.
+6. Write the executor manifest with `python3 -m autonomous_research_workflow.cli write-executor-manifest`.
+7. Do not mark empirical progress unless runnable code or checkable result artifacts were produced.
+8. Do not stop early because the project is merely "improved"; stop only on the submission-ready completion gate.
+
+## Phase Order
+
+Run the 15-phase loop described in [phases](references/phases.md):
+
+1. `source_intake`
+2. `mempalace_context`
+3. `council_knowledge`
+4. `expert_forum_coverage`
+5. `literature_refresh`
+6. `knowledge_publish`
+7. `advisor_design`
+8. `execution_packet`
+9. `executor_run`
+10. `advisor_reflection`
+11. `openspace_retrospective`
+12. `next_cycle_handoff`
+13. `star_office_status`
+14. `overwatcher_check`
+15. `github_publish`
+
+## Native Executor
+
+Phase 9 is the key Codex-native phase:
+
+- Read the execution packet.
+- Read the source clone.
+- Generate the smallest useful runnable research asset.
+- Write only to `source_changes/`.
+- Run lightweight checks when possible.
+- Write `executor_manifest.json`.
+
+Use [executor-template](references/executor-template.md) as the output contract.
+
+## Continuation
+
+If interrupted, resume from the latest completed cycle. If a cycle was incomplete, rerun that incomplete cycle instead of trusting partial artifacts.
+
+## Completion Gate
+
+Only stop when all are true:
+
+- Submission Advisor score is at least `100`.
+- Submission Advisor level is `submission_ready`.
+- Executor manifest status is `completed`.
+- Delivery status is `published` or explicitly `local_only` for dry runs.
+

--- a/skills/.experimental/research-loop/references/advisor-rubric.md
+++ b/skills/.experimental/research-loop/references/advisor-rubric.md
@@ -1,0 +1,22 @@
+# Submission Advisor Rubric
+
+Score from `0` to `100` with `100` reserved for a repo that is ready to deliver as a submission package.
+
+Axes:
+
+- Problem definition and novelty
+- Methodological rigor
+- Result quality and analysis
+- Manuscript or package completeness
+- Reproducibility and asset hygiene
+- Venue fit
+
+The advisor must use current repo files and current literature as primary evidence. Prior memory and expert profiles can pressure-test conclusions but cannot support a claim alone.
+
+Completion requires:
+
+- `overall_readiness.score >= 100`
+- `overall_readiness.level == "submission_ready"`
+- A completed executor manifest
+- Published or explicitly local-only delivery
+

--- a/skills/.experimental/research-loop/references/executor-template.md
+++ b/skills/.experimental/research-loop/references/executor-template.md
@@ -1,0 +1,45 @@
+# Codex Executor Output Template
+
+The executor must produce a bounded, runnable micro-step.
+
+## Required Files
+
+- At least one runnable Python file unless the micro-step is explicitly a config/test-only edit.
+- `requirements.txt` only when new dependencies are required.
+- Optional `docs/agentic_research/<cycle_id>/...` notes for protocol context.
+- `executor_manifest.json` written via the CLI helper.
+
+## Manifest Shape
+
+```json
+{
+  "cycle_id": "20260411_120451",
+  "generated_at": "2026-04-11T12:04:51Z",
+  "status": "completed",
+  "mode": "codex_native_executor",
+  "source": "codex_exec",
+  "selected_micro_step": {"title": "..."},
+  "summary": "What changed and why this is the next smallest useful step.",
+  "limitations": ["What this step still does not prove."],
+  "next_probe": "The next smallest follow-up probe.",
+  "generated_files": [
+    {
+      "destination": "source_repo",
+      "repo_path": "scripts/run_pilot.py",
+      "local_path": "/absolute/path/under/source_changes/scripts/run_pilot.py",
+      "purpose": "Minimal executable experiment script"
+    }
+  ],
+  "claim_rule": "No empirical claim is supported unless tied to generated runnable evidence."
+}
+```
+
+## Rules
+
+1. Keep one micro-step per cycle.
+2. Read the target repo before writing.
+3. Write into the `source_changes/` repo-root mirror, not directly into the source clone.
+4. Prefer deterministic offline checks over secret-dependent API calls.
+5. Do not require `OLLAMA_API_KEY`.
+6. If a model call is optional, make it explicit and document the fallback.
+

--- a/skills/.experimental/research-loop/references/phases.md
+++ b/skills/.experimental/research-loop/references/phases.md
@@ -1,0 +1,24 @@
+# Codex Research Loop Phases
+
+All phases are small and inspectable. Python helper phases write deterministic artifacts; Codex-native phases perform judgment and code generation.
+
+| Phase | Owner | Output |
+| --- | --- | --- |
+| `source_intake` | Python + Codex | source snapshot and inventory |
+| `mempalace_context` | Python | current-head memory pack |
+| `council_knowledge` | Python | expert council route |
+| `expert_forum_coverage` | Python | coverage score and expansion queue |
+| `literature_refresh` | OpenAlex + Codex WebSearch | papers and web evidence |
+| `knowledge_publish` | Python | cycle knowledge base |
+| `advisor_design` | Codex | advisor manifest and action backlog |
+| `execution_packet` | Python | one selected micro-step |
+| `executor_run` | Codex | runnable source changes and executor manifest |
+| `advisor_reflection` | Python | post-execution constraints |
+| `openspace_retrospective` | Python | loop improvement notes |
+| `next_cycle_handoff` | Python | next-cycle handoff |
+| `star_office_status` | Python | local dashboard status |
+| `overwatcher_check` | Python | observe-only workflow health report |
+| `github_publish` | Python | target repo delivery |
+
+Do not rely on Ollama native web search. If fresh web evidence is needed inside a Codex-native phase, use Codex WebSearch and pass short, attributed snippets into the relevant helper stage.
+

--- a/skills/.experimental/research-loop/references/state-schema.md
+++ b/skills/.experimental/research-loop/references/state-schema.md
@@ -1,0 +1,27 @@
+# State Schema
+
+Each run writes a durable local state tree and publishes sanitized artifacts to the target repo under `.autonomous-research-workflow/`.
+
+Important paths:
+
+```text
+<run-dir>/
+  events.jsonl
+  manifest.json
+  payload/.autonomous-research-workflow/
+    cycles/<cycle_id>/cycle_manifest.json
+    execution/<cycle_id>/execution_packet.json
+    execution/<cycle_id>/executor_manifest.json
+    knowledge/<cycle_id>/knowledge_base.json
+    memory/<cycle_id>/mempalace_context.json
+    reflections/<cycle_id>/advisor_reflection.json
+    retrospectives/<cycle_id>/openspace_retrospective.json
+    handoffs/<cycle_id>/next_cycle_handoff.json
+    office_status/<cycle_id>/star_office_status.json
+    overwatcher/<cycle_id>/overwatcher_status.json
+  source/<cycle_id>/<repo>/
+  source_changes/
+```
+
+`source_changes/` mirrors the target repository root and is copied into the source clone during publish.
+


### PR DESCRIPTION
## Summary

Adds `research-loop`, an experimental Codex skill for running a source-gated autonomous research loop over one GitHub research repository.

The skill is designed for users who want Codex to:

- intake the current target repo as primary evidence
- build MemPalace / expert-council context as secondary evidence
- run Submission Advisor style reflection
- execute one bounded micro-step per cycle
- require an executor manifest before treating a run as completed
- avoid Ollama API key requirements on the default Codex route

Project source: https://github.com/wd041216-bit/10000-mentors-research-workflow

## Notes

I placed it under `skills/.experimental/research-loop` because it is a heavier agentic workflow skill and should be reviewed before any curated placement.
