### PR TITLE
Fix skill-creator scaffold frontmatter

### DIFF
--- a/skills/.system/skill-creator/scripts/init_skill.py
+++ b/skills/.system/skill-creator/scripts/init_skill.py
@@ -25,7 +25,7 @@ ALLOWED_RESOURCES = {"scripts", "references", "assets"}
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: "[TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]"
 ---
 
 # {skill_title}

--- a/skills/.system/skill-creator/tests/test_init_skill.py
+++ b/skills/.system/skill-creator/tests/test_init_skill.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import init_skill
+import quick_validate
+
+
+class InitSkillTemplateTests(unittest.TestCase):
+    def test_generated_skill_template_passes_validator(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with contextlib.redirect_stdout(io.StringIO()):
+                skill_dir = init_skill.init_skill(
+                    "example-skill",
+                    tmpdir,
+                    [],
+                    False,
+                    [],
+                )
+
+            self.assertIsNotNone(skill_dir)
+
+            valid, message = quick_validate.validate_skill(skill_dir)
+            self.assertTrue(valid, message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`skills/.system/skill-creator/scripts/init_skill.py` generates a `SKILL.md` whose frontmatter `description` placeholder is written as a YAML list:

```yaml
description: [TODO: ...]
```

That means a freshly generated skill fails validation immediately instead of producing a valid starter template.

## Root Cause
The scaffold uses square-bracket YAML syntax for the placeholder, so `description` is parsed as a list rather than a string. The validator then rejects the generated file with:

```text
Description must be a string, got list
```

## Fix
- quote the generated `description` placeholder so it is parsed as a YAML string
- add a regression test that generates a new skill and validates it immediately

## Validation
- `python3 skills/.system/skill-creator/tests/test_init_skill.py`
- `python3 skills/.system/skill-creator/scripts/init_skill.py repro-skill-final --path /tmp`
- `python3 skills/.system/skill-creator/scripts/quick_validate.py /tmp/repro-skill-final`