### PR TITLE
Add AI output evals skill

### DIFF
--- a/skills/.curated/ai-output-evals/LICENSE.txt
+++ b/skills/.curated/ai-output-evals/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Mukunda Katta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/skills/.curated/ai-output-evals/SKILL.md
+++ b/skills/.curated/ai-output-evals/SKILL.md
@@ -1,0 +1,50 @@
+# AI Output Evals
+
+## Description
+
+Use this skill when the user wants to evaluate, compare, or regression-test AI, LLM, RAG, or agent outputs.
+
+## Workflow
+
+1. Identify the behavior under test: the user input, expected output, actual output, and any retrieved sources or tool calls.
+2. Choose the smallest reliable checks before suggesting model-based judging:
+   - exact match for deterministic strings
+   - substring checks for required facts
+   - regular expressions for structured patterns
+   - JSON validity and JSON-path checks for structured output
+   - citation coverage for grounded RAG answers
+   - token F1 or overlap for short natural-language answers
+3. Separate required checks from advisory checks so a useful response is not rejected for harmless wording differences.
+4. Report failures as actionable regressions with the case id, failed check, observed output, and expected evidence.
+5. Recommend adding the eval to CI when the case protects product behavior, safety policy, retrieval quality, or a previously fixed bug.
+
+## Output Shape
+
+When creating an eval, prefer a compact table:
+
+| case | check | pass/fail | note |
+| --- | --- | --- | --- |
+
+When writing a fixture, prefer JSON or JSONL records with:
+
+```json
+{
+  "id": "refund-policy",
+  "input": "Can I refund after 45 days?",
+  "expected": "Refunds are available within 30 days.",
+  "actual": "Refunds are only available within 30 days.",
+  "checks": [
+    { "type": "contains", "value": "30 days" },
+    { "type": "token_f1", "min": 0.6 }
+  ]
+}
+```
+
+## Guidance
+
+- Do not overfit evals to one exact phrasing unless the product contract requires it.
+- For RAG, score retrieval and answer generation separately when possible.
+- For agents, include tool-call assertions for important side effects.
+- For safety behavior, include both refusal and allowed-helpfulness cases.
+- Keep eval datasets small at first; expand them when regressions reveal missing coverage.
+


### PR DESCRIPTION
Adds a curated AI output evals skill for building pragmatic regression tests for LLM, RAG, and agent outputs. The skill focuses on deterministic checks first, then citation coverage, token overlap, and tool-call assertions where relevant.