### PR TITLE
Make yeet PRs ready by default

### DIFF
--- a/skills/.curated/yeet/SKILL.md
+++ b/skills/.curated/yeet/SKILL.md
@@ -23,6 +23,7 @@ description: "Use only when the user explicitly asks to stage, commit, push, and
 - Run checks if not already. If checks fail due to missing deps/tools, install dependencies and rerun once.
 - Push with tracking: `git push -u origin $(git branch --show-current)`
 - If git push fails due to workflow auth errors, pull from master and retry the push.
-- Open a PR and edit title/body to reflect the description and the deltas: `GH_PROMPT_DISABLED=1 GIT_TERMINAL_PROMPT=0 gh pr create --draft --fill --head $(git branch --show-current)`
+- Open a PR and edit title/body to reflect the description and the deltas: `GH_PROMPT_DISABLED=1 GIT_TERMINAL_PROMPT=0 gh pr create --fill --head $(git branch --show-current)`
+- Use a draft PR only when the user explicitly asks for one or when the repository's own instructions require a temporary placeholder before code is pushed.
 - Write the PR description to a temp file with real newlines (e.g. pr-body.md ... EOF) and run pr-body.md to avoid \\n-escaped markdown.
 - PR description (markdown) must be detailed prose covering the issue, the cause and effect on users, the root cause, the fix, and any tests or checks used to validate.


### PR DESCRIPTION
## Summary

- Remove the hard-coded `--draft` flag from the curated yeet skill's PR creation command.
- Document that draft PRs should only be used when explicitly requested or when a repository requires a temporary placeholder before code is pushed.

## Why

The skill currently teaches agents to open draft PRs by default, which conflicts with repositories that expect validated, pushed code to be ready for review.

## Validation

- Inspected `skills/.curated/yeet` for remaining hard-coded draft PR creation guidance.
- Confirmed no remaining `gh pr create --draft` command in the yeet skill.
