### PR TITLE
hatch-pet: send application/json for text-only image generation requests

### DIFF
--- a/skills/.curated/hatch-pet/scripts/generate_pet_images.py
+++ b/skills/.curated/hatch-pet/scripts/generate_pet_images.py
@@ -121,6 +121,12 @@ def run_image_generation(
     api_key: str,
 ) -> dict[str, object]:
     output_json.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "model": model,
+        "prompt": prompt_file.read_text(encoding="utf-8"),
+        "size": size,
+        "output_format": "png",
+    }
     command = [
         "curl",
         "-sS",
@@ -129,14 +135,11 @@ def run_image_generation(
         "https://api.openai.com/v1/images/generations",
         "-H",
         f"Authorization: Bearer {api_key}",
-        "-F",
-        f"model={model}",
-        "-F",
-        f"prompt=<{prompt_file}",
-        "-F",
-        f"size={size}",
-        "-F",
-        "output_format=png",
+        # Generations accept JSON bodies; edits use multipart form data for uploads.
+        "-H",
+        "Content-Type: application/json",
+        "--data-binary",
+        json.dumps(payload),
         "-o",
         str(output_json),
     ]


### PR DESCRIPTION
## Bug

`generate_pet_images.py` sends `multipart/form-data` for text-only image generation requests. The OpenAI Images API rejects this on `/v1/images/generations`, which expects `application/json`. Result: text-only pet generation fails with `unsupported multipart/form-data; endpoint expected application/json`.

Reference-backed pets use `/v1/images/edits`, where multipart upload remains the correct path.

## Fix

Build a JSON payload for text-only generation requests:

- No reference -> `POST /v1/images/generations` with `application/json`
- Reference -> `POST /v1/images/edits` with multipart upload fields, unchanged

Added an inline comment documenting the API contract.

## Verification

Tested locally against copied prepared run directories:

- Text-only base request succeeded with the fix.
- Reference-backed base request succeeded with no regression.
- Both outputs decoded as valid `1024x1024` PNGs.

## Context

Encountered while building The Hatchery, a marketplace for Codex pets. Happy to iterate on the fix shape if there is a preferred convention.
