### PR TITLE
Clarify hatch-pet running row semantics

### DIFF
--- a/skills/.curated/hatch-pet/SKILL.md
+++ b/skills/.curated/hatch-pet/SKILL.md
@@ -68,7 +68,8 @@ State-specific guidance:
 - `jumping`: show vertical motion through body position only. Do not draw shadows, dust, landing marks, impact bursts, bounce pads, or floor cues.
 - `failed`: tears, attached smoke puffs, or attached stars are allowed if they obey the allowed-effects rules; do not use red X marks, floating symbols, detached smoke, detached stars, or separate tear droplets.
 - `review`: show focus through lean, blink, eyes, head tilt, or paw position. Do not add magnifying glasses, papers, code, UI, punctuation, or symbols unless that prop already exists in the base pet identity.
-- `running-right`, `running-left`, and `running`: show locomotion through body, limb, and prop movement only. Do not draw speed lines, dust clouds, floor shadows, or motion trails.
+- `running-right` and `running-left`: show directional locomotion through body, limb, and prop movement only. Do not draw speed lines, dust clouds, floor shadows, or motion trails.
+- `running`: show an active working/in-progress loop, as if the pet is busy running a task. Do not show literal foot-running, jogging, sprinting, treadmill motion, raised knees, long steps, pumping arms, or directional travel.
 
 ## Pet Naming
 
@@ -228,7 +229,7 @@ Subagent handoff contract:
 
 - Give each subagent exactly one row job unless you are intentionally batching adjacent simple rows.
 - Include the row id, the absolute prompt file path, the full prompt text or an instruction to read that exact prompt file, and every input image path with its role label from `imagegen-jobs.json`.
-- Explicitly remind the subagent that the prompt's transparency and effects rules are mandatory: no detached effects, no wave marks for `waving`, no speed lines or dust for running rows, and only attached opaque sprite-like tears/smoke/stars when allowed by the state prompt.
+- Explicitly remind the subagent that the prompt's transparency and effects rules are mandatory: no detached effects, no wave marks for `waving`, no speed lines or dust for directional running rows, no literal foot-running for the non-directional `running` row, and only attached opaque sprite-like tears/smoke/stars when allowed by the state prompt.
 - Tell the subagent to inspect the generated candidate for frame count, identity consistency, clean flat chroma-key background, safe spacing, and forbidden detached effects before returning it.
 - Tell the subagent to return only the selected original `$CODEX_HOME/generated_images/.../ig_*.png` source path plus a one-sentence QA note. The parent decides whether to record or repair it.
 

--- a/skills/.curated/hatch-pet/SKILL.md
+++ b/skills/.curated/hatch-pet/SKILL.md
@@ -64,6 +64,7 @@ Avoid these by default because they usually break transparent-background cleanup
 
 State-specific guidance:
 
+- `idle`: keep this calm and low-distraction. Use only subtle breathing, a tiny blink, a slight head/body bob, a very small material sway, or another quiet persona-preserving motion. Do not show waving, walking, running, jumping, talking, working, reviewing, emotional reactions, large gestures, item interactions, or new props.
 - `waving`: show the wave through paw pose only. Do not draw wave marks, motion arcs, lines, sparkles, or symbols around the paw.
 - `jumping`: show vertical motion through body position only. Do not draw shadows, dust, landing marks, impact bursts, bounce pads, or floor cues.
 - `failed`: tears, attached smoke puffs, or attached stars are allowed if they obey the allowed-effects rules; do not use red X marks, floating symbols, detached smoke, detached stars, or separate tear droplets.

--- a/skills/.curated/hatch-pet/references/animation-rows.md
+++ b/skills/.curated/hatch-pet/references/animation-rows.md
@@ -25,5 +25,5 @@ Unused cells after each row's final used column must be fully transparent.
 - `jumping`: anticipation, lift, peak, descent, settle.
 - `failed`: error/sad/deflated reaction; readable but not visually noisy.
 - `waiting`: patient idle variant; glance, small bounce, or prop motion.
-- `running`: generic/front-facing or in-place run loop.
+- `running`: active working/in-progress loop, as if the pet is busy running a task. This row is not foot-running; avoid jogging, sprinting, treadmill poses, raised knees, long steps, pumping arms, or directional travel.
 - `review`: focused/inspecting/thinking loop suitable for review state.

--- a/skills/.curated/hatch-pet/references/animation-rows.md
+++ b/skills/.curated/hatch-pet/references/animation-rows.md
@@ -18,7 +18,7 @@ Unused cells after each row's final used column must be fully transparent.
 
 ## Row Purposes
 
-- `idle`: neutral breathing/blinking loop; use as the reduced-motion first frame.
+- `idle`: calm, low-distraction breathing/blinking loop; use as the reduced-motion first frame. Keep motion subtle and persona-preserving.
 - `running-right`: locomotion to the right; 8-frame loop should read directionally.
 - `running-left`: mirrored or redrawn locomotion to the left; do not simply reuse right-facing frames unless the design is symmetric.
 - `waving`: greeting or attention gesture; clear start, raised gesture, return.

--- a/skills/.curated/hatch-pet/references/qa-rubric.md
+++ b/skills/.curated/hatch-pet/references/qa-rubric.md
@@ -37,6 +37,7 @@ Do not accept an atlas until all checks pass.
 ## App Fitness
 
 - First idle frame works as a static reduced-motion pet.
+- The `idle` row should be calm and low-distraction; reject it if it reads as waving, walking, running, jumping, talking, working, reviewing, reacting dramatically, changing props, or making large pose/silhouette changes.
 - No important detail is too small to read.
 - No frame is clipped by the cell.
 - Failed/review/waiting states are distinct from ordinary idle.

--- a/skills/.curated/hatch-pet/scripts/prepare_pet_run.py
+++ b/skills/.curated/hatch-pet/scripts/prepare_pet_run.py
@@ -26,7 +26,7 @@ ROWS = [
     ("jumping", 4, 5, "anticipation, lift, peak, descent, settle"),
     ("failed", 5, 8, "sad, failed, or deflated reaction"),
     ("waiting", 6, 6, "patient waiting loop with small motion"),
-    ("running", 7, 6, "generic in-place running loop"),
+    ("running", 7, 6, "active working/in-progress loop"),
     ("review", 8, 6, "focused inspecting or review loop"),
 ]
 
@@ -69,8 +69,8 @@ STATE_REQUIREMENTS = {
         "Do not draw speed lines, dust clouds, floor shadows, motion trails, or detached motion effects.",
     ],
     "running": [
-        "Show in-place running through body, limb, and prop movement only.",
-        "Do not draw speed lines, dust clouds, floor shadows, motion trails, or detached motion effects.",
+        "Show the pet actively working or processing, as if running a task: focused posture, busy hands or paws, purposeful bobbing, thinking motion, tool/prop motion only if already part of the pet identity, or other non-locomotion activity.",
+        "Do not show literal foot-running, jogging, sprinting, treadmill motion, raised knees, long steps, pumping arms, directional travel, speed lines, dust clouds, floor shadows, motion trails, or detached motion effects.",
     ],
 }
 

--- a/skills/.curated/hatch-pet/scripts/prepare_pet_run.py
+++ b/skills/.curated/hatch-pet/scripts/prepare_pet_run.py
@@ -42,6 +42,14 @@ TRANSPARENCY_ARTIFACT_RULES = [
 ]
 
 STATE_REQUIREMENTS = {
+    "idle": [
+        "CRITICAL: idle is the low-distraction baseline state and the first frame is also used as the reduced-motion static pet.",
+        "Use only subtle idle motion: gentle breathing, a tiny blink, a slight head or body bob, a very small material sway, or another quiet motion that fits the pet persona.",
+        "Keep the pet essentially in the same pose, facing direction, silhouette, markings, palette, and prop state across all 6 frames.",
+        "Do not show waving, walking, running, jumping, talking, working, reviewing, emotional reactions, large gestures, item interactions, or new props.",
+        "Feet, base, body, or object anchor should remain planted or nearly planted.",
+        "The first and last frames should be very close visually so the loop feels calm and does not pop.",
+    ],
     "waving": [
         "Show the greeting through paw pose only: paw down, paw raised, paw tilted, paw returning.",
         "Do not draw wave marks, motion arcs, lines, sparkles, symbols, or floating effects around the paw.",


### PR DESCRIPTION
## Summary
- Clarify that the non-directional hatch-pet `running` row is an active working/in-progress task loop, not literal foot-running
- Keep `running-right` and `running-left` as the only directional locomotion rows
- Update the generated row prompt requirements so image generation rejects jogging, sprinting, treadmill poses, raised knees, long steps, pumping arms, and travel for the `running` row
- Port the local low-distraction `idle` guidance into hatch-pet without replacing Gabriel's subagent/imagegen workflow: idle now asks for subtle breathing/blinking/bobbing only and rejects distracting action states
- Improve discovery for plural searches by adding the literal word `pets` to the recommended-skill description and agent short description

## Validation
- `python3 -m py_compile skills/.curated/hatch-pet/scripts/prepare_pet_run.py`
- `python3 skills/.curated/hatch-pet/scripts/prepare_pet_run.py --pet-name Testy --description "A tiny test pet." --pet-notes "a tiny blue test pet" --output-dir /private/tmp/openai-skills-hatch-running-prompt-check --force`
- `rg -n "active working|literal foot-running|running a task|generic in-place|Show in-place running|jogging|sprinting" /private/tmp/openai-skills-hatch-running-prompt-check/prompts/rows/running.md /private/tmp/openai-skills-hatch-running-prompt-check/imagegen-jobs.json`
- `python3 skills/.curated/hatch-pet/scripts/prepare_pet_run.py --pet-name Testy --description "A tiny test pet." --pet-notes "a tiny blue test pet" --output-dir /private/tmp/openai-skills-hatch-idle-prompt-check --force`
- `rg -n "low-distraction|subtle idle|same pose|waving, walking|first and last|active working|literal foot-running" /private/tmp/openai-skills-hatch-idle-prompt-check/prompts/rows/idle.md /private/tmp/openai-skills-hatch-idle-prompt-check/prompts/rows/running.md`
- `rg -n "description:.*pets|short_description:.*pets|animated pets" skills/.curated/hatch-pet/SKILL.md skills/.curated/hatch-pet/agents/openai.yaml`
