### PR TITLE
Improve hatch-pet search metadata

### DIFF
--- a/skills/.curated/hatch-pet/SKILL.md
+++ b/skills/.curated/hatch-pet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hatch-pet
-description: Create, repair, validate, preview, and package Codex-compatible animated pet spritesheets from character art, screenshots, generated images, or visual references. Use when a user wants to hatch a Codex pet, create a custom animated pet, or build a built-in pet asset with an 8x9 atlas, transparent unused cells, row-by-row animation prompts, QA contact sheets, preview videos, and pet.json packaging. This skill composes the installed $imagegen system skill for visual generation and uses bundled scripts for deterministic spritesheet assembly.
+description: Create, repair, validate, preview, and package Codex-compatible animated pets and pet spritesheets from character art, screenshots, generated images, or visual references. Use when a user wants to hatch a Codex pet, create a custom animated pet, or build a built-in pet asset with an 8x9 atlas, transparent unused cells, row-by-row animation prompts, QA contact sheets, preview videos, and pet.json packaging. This skill composes the installed $imagegen system skill for visual generation and uses bundled scripts for deterministic spritesheet assembly.
 ---
 
 # Hatch Pet

--- a/skills/.curated/hatch-pet/agents/openai.yaml
+++ b/skills/.curated/hatch-pet/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Hatch Pet"
-  short_description: "Hatch Codex-compatible animated pet spritesheets"
+  short_description: "Hatch Codex-compatible animated pets and pet spritesheets"
   default_prompt: "Hatch a Codex-compatible animated pet from a concept, reference images, or both. Infer missing names/descriptions, use $imagegen for the base and grounded row strips, generate running-right before deciding whether running-left can be safely mirrored, then use this skill's deterministic scripts to ingest outputs, validate frames, assemble the spritesheet, and package the pet under ${CODEX_HOME:-$HOME/.codex}/pets/<pet-name>/."


### PR DESCRIPTION
## Summary
- Improve hatch-pet discovery for plural searches by adding the literal word `pets` to the recommended-skill description
- Update the agent short description with the same plural wording so both metadata surfaces match

## Discovery context
- Codex App recommended skill search is substring-based over `name`, `description`, and `shortDescription`; it does not stem `pet` to `pets`
- `hatch-pet` previously had `pet spritesheets`, which matches `pet` but not contiguous `pets`

## Validation
- `rg -n "description:.*pets|short_description:.*pets|animated pets" skills/.curated/hatch-pet/SKILL.md skills/.curated/hatch-pet/agents/openai.yaml`
