### PR TITLE
Add fast-codex-workflow skill

### DIFF
--- a/skills/.curated/fast-codex-workflow/LICENSE.txt
+++ b/skills/.curated/fast-codex-workflow/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ridwannurudeen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/.curated/fast-codex-workflow/SKILL.md
+++ b/skills/.curated/fast-codex-workflow/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fast-codex-workflow
+description: Fast, focused execution loop for Codex. Triage first, read narrowly, change minimally, verify only what proves the result. Use for routine bug fixes, small features, environment fixes, and prompts like "be fast", "tight scope", "quick fix", or "minimize scope". Skip for full security audits, broad architecture changes, or production migrations - those need deeper exploration than this skill enforces.
+---
+
+# Fast Codex Workflow
+
+Reduce time-to-correct-result. Verify the minimum source of truth needed, choose the smallest correct action, and avoid broad exploration unless the task genuinely requires it. Fast means focused, not shallow.
+
+## Operating Loop
+
+1. Classify depth before acting: tiny (one command or direct answer), normal (narrow inspection plus minimal change plus relevant check), or deep (escalate, see triggers below).
+2. State the next move in one short sentence when tools or edits are needed.
+3. Discover targeted: `git status`, `rg --files`, exact named files, manifests, failing logs. Avoid broad recursive scans unless targeted search failed.
+4. Parallelize independent reads when the harness supports it.
+5. Verify with the narrowest command that proves the result: focused tests, typecheck for touched code, build for compile risk, runtime check for UI behavior.
+6. Stop when the user goal is satisfied. Report residual risk; do not chase adjacent cleanup.
+
+## Response Modes
+
+- **Direct** - stable facts, simple commands, tiny edits. Answer or run. No plan.
+- **Execute** - normal fixes. Inspect entry point, patch the smallest surface, verify, report.
+- **Review** - audits and code reviews. Lead with findings and evidence, then risks and tests.
+- **Deep** - security, production, deployments, three-plus file changes, unclear root cause. Make a short file-specific plan after initial inspection. Keep it updated.
+
+## First-Minute Triage
+
+1. Identify the requested outcome and the success check.
+2. Find the entry point with the cheapest reliable signal: named file, error line, route, command, manifest script, or symbol search.
+3. Decide depth: tiny, normal, or deep.
+4. If editing is likely, inspect the target and the nearest existing pattern before patching.
+5. If guessing risks wrong work, ask one concise question and stop.
+
+## Command Strategy
+
+- Start with the cheapest reliable batch - `git status`, `rg --files`, exact reads, manifest reads, targeted `rg`. Run them in parallel.
+- Avoid broad recursive filesystem scans unless targeted search failed or the task is repo-wide by definition.
+- Keep build, lint, and test commands scoped to the touched behavior. Broaden only when shared contracts, production paths, or unexplained failures justify it.
+- Do not start servers, browsers, network calls, installs, or long-running commands unless they prove the user goal.
+
+## Speed Rules
+
+- Do not reread the whole repo when a symbol search, manifest, or stack trace gives the entry point.
+- Do not run full test suites before a first targeted check unless the change touches shared behavior or release-critical paths.
+- Do not ask questions answerable by reading local files or command output.
+- Do ask one concise question when guessing could send work in the wrong direction.
+- Do not add broad refactors, new abstractions, new dependencies, or extra polish unless required for the requested outcome.
+- Do not let speed override security, data safety, explicit user constraints, or required approval gates.
+- If two attempts fail, stop retrying. Re-read the error, name the root cause if known, and choose a genuinely different next step.
+
+## Escalate To Deeper Work When
+
+- The user asks for a full audit, brutal review, security review, production-readiness check, or a "no more bugs" loop.
+- The change touches auth, payments, crypto, permissions, secrets, migrations, deployment, or shared libraries.
+- A targeted test fails for a reason that is not already explained.
+- The first likely root cause is disproven.
+- Multiple files must change and their contracts are not obvious from local context.
+- Current external information is needed for correctness - pricing, rules, docs, API behavior, or recommendations.
+
+## Stop Conditions
+
+The task is done when the requested outcome is achieved, the relevant verification has passed or a blocker is clearly identified, and no necessary command is still running. Do not continue into adjacent cleanup, broad refactors, or extra audits unless the user asked for them or current evidence shows they are required.
+
+## Final Answer Contract
+
+- Say what changed or what was found.
+- Name the files touched when code or config changed.
+- Report the verification command and result.
+- State any blocker or residual risk plainly.
+- No long process narration.
+
+## Shortcut Triggers
+
+When the user says "be fast", "move faster", "speed mode", "quick fix", "tight scope", or similar, interpret it as:
+
+> Verify only what is necessary. Use parallel reads. Make the smallest correct fix. Run the relevant test only. Keep updates and final answer concise.
+
+## See Also
+
+- `references/playbook.md` - task recipes for bug fixes, features, audits, UI, tooling, and recommendations; verification budget by task type; coding defaults.
+- `references/examples.md` - before/after transcripts showing the loop in action.

--- a/skills/.curated/fast-codex-workflow/agents/openai.yaml
+++ b/skills/.curated/fast-codex-workflow/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Fast Codex Workflow"
+  short_description: "Fast triage, focused edits, lean verification"
+  default_prompt: "Apply the fast operating loop: classify depth, find the entry point with the cheapest reliable signal, read only the narrow source of truth needed, make the smallest correct change, and run only the verification that proves the result."
+policy:
+  allow_implicit_invocation: true
+metadata:
+  version: "0.2.1"

--- a/skills/.curated/fast-codex-workflow/agents/openai.yaml
+++ b/skills/.curated/fast-codex-workflow/agents/openai.yaml
@@ -1,8 +1,3 @@
 interface:
   display_name: "Fast Codex Workflow"
   short_description: "Fast triage, focused edits, lean verification"
-  default_prompt: "Apply the fast operating loop: classify depth, find the entry point with the cheapest reliable signal, read only the narrow source of truth needed, make the smallest correct change, and run only the verification that proves the result."
-policy:
-  allow_implicit_invocation: true
-metadata:
-  version: "0.2.1"

--- a/skills/.curated/fast-codex-workflow/references/examples.md
+++ b/skills/.curated/fast-codex-workflow/references/examples.md
@@ -1,0 +1,64 @@
+# Before / After Examples
+
+Three transcripts showing the operating loop versus default behavior on the same task. Filenames and commands are illustrative; the shape generalizes.
+
+## Example 1 - Off-by-one in pagination
+
+**Prompt:** "The pagination shows page 0 instead of page 1 in the UI."
+
+**Without skill:**
+- Reads twelve files across `src/components/`, `src/api/`, `src/store/`.
+- Runs the full Jest suite (~3 min).
+- Notices a generic `parseInt` and refactors it into a shared utility.
+- Writes a 200-word summary.
+
+**With skill:**
+- `rg "page 0|currentPage" src/` returns one hit in `Pagination.tsx:42`.
+- Reads `Pagination.tsx`, finds `useState(0)` for the current page.
+- Patches to `useState(1)`.
+- `npx jest Pagination.test` passes.
+- Final answer: "Patched `Pagination.tsx:42` (`useState(0)` to `useState(1)`). Verification: `Pagination.test` passed."
+
+## Example 2 - Add an env-driven feature flag
+
+**Prompt:** "Add a `FEATURE_NEW_CHECKOUT` env var that toggles the new checkout flow."
+
+**Without skill:**
+- Builds a generic `FeatureFlagService` class.
+- Adds a new `flags.ts` module, a `useFeatureFlag` hook, and a YAML config loader.
+- Writes tests for the abstraction.
+- Updates eight files.
+
+**With skill:**
+- Inspects existing checkout entry: `Checkout.tsx` already branches on a local `useNewCheckout` boolean.
+- `rg "process.env\." src/` confirms the existing pattern is direct env reads, no abstraction.
+- Patches `Checkout.tsx:12` to `const useNewCheckout = process.env.FEATURE_NEW_CHECKOUT === 'true';`.
+- Adds `FEATURE_NEW_CHECKOUT=` to `.env.example` with a one-line comment.
+- `npm test -- Checkout` passes.
+- Final answer: "Added `FEATURE_NEW_CHECKOUT` to `Checkout.tsx:12` and `.env.example`. Verification: `Checkout.test` passed."
+
+## Example 3 - CI is red on main
+
+**Prompt:** "CI is red on main. Fix it."
+
+**Without skill:**
+- Runs the full test suite locally.
+- Reads every workflow file under `.github/workflows/`.
+- Refactors a flaky test.
+- Adds retry logic to the CI runner.
+
+**With skill:**
+- `gh run list --branch main --limit 1` returns the failing run ID.
+- `gh run view <id> --log-failed` shows one failing step: `npm run lint` on `src/utils/format.ts:88`.
+- Reads line 88: trailing whitespace in a string literal flagged by a new ESLint rule.
+- Patches the trailing space.
+- `npm run lint` passes locally.
+- Final answer: "Patched trailing whitespace in `src/utils/format.ts:88`. Verification: `npm run lint` passes locally; pushing the fix should clear CI."
+
+## What Each Example Proves
+
+| Example | Bad pattern avoided | Speed lever applied |
+|---|---|---|
+| 1 | Reading the whole UI tree on a one-line bug | First-minute triage via `rg` |
+| 2 | Building an abstraction for a single call site | Match existing pattern; minimal complete change |
+| 3 | Running every test before reading the failure | Read the failing log first |

--- a/skills/.curated/fast-codex-workflow/references/playbook.md
+++ b/skills/.curated/fast-codex-workflow/references/playbook.md
@@ -1,0 +1,28 @@
+# Playbook: Task Recipes, Verification Budget, Coding Defaults
+
+Reference content for the `fast-codex-workflow` operating loop. Codex loads this on demand when the active task matches one of the recipes below or when escalation requires the deeper budget.
+
+## Task Recipes
+
+- **Bug fix** - read the exact error or failing behavior, inspect the smallest owning code path, search for the existing pattern, patch the root cause, run the narrowest regression check.
+- **Feature or change** - identify owning files and existing pattern, make the smallest complete implementation, avoid optional polish, verify the touched behavior.
+- **Review or audit** - map the surface quickly, inspect high-risk paths first, lead with evidence-backed findings, then note test gaps and residual risk.
+- **Frontend or UI** - inspect the component and styling path, run build/typecheck when relevant, use browser/screenshot checks when layout or interaction can regress.
+- **Environment or tooling** - check versions/config/list output first, run a direct smoke test before changing config, patch the smallest setting, then verify with the same command that exposed the issue.
+- **Recommendation or research** - verify current sources when facts can drift, choose the best option, state why it beats the alternatives.
+
+## Verification Budget
+
+- **Tiny tasks** - one direct command, exact answer, or no tool call when the answer is already known and stable.
+- **Normal code changes** - targeted test, typecheck, lint, or build command that covers the touched behavior.
+- **UI changes** - run or inspect the app when feasible; use Playwright or screenshot checks for layout, rendering, and interaction risks.
+- **Deep audits or security work** - broaden verification intentionally, but still parallelize independent reads and avoid unrelated cleanup.
+- **Environment or tooling slowness** - prefer narrow diagnostics first. Only widen to environment-level maintenance when local bloat or slow startup is the proven cause.
+
+## Coding Defaults
+
+- Read before editing.
+- Match existing style and local helpers.
+- Make the smallest complete change.
+- Re-read touched code for obvious mistakes.
+- Run the relevant verification command and report exactly what passed or failed.


### PR DESCRIPTION
## Summary

Adds `fast-codex-workflow` to `skills/.curated/`. It is a meta-workflow skill that gives Codex an explicit operating loop — triage first, read narrowly, change minimally, verify only what proves the result. Designed for routine bug fixes and small features; explicitly steps aside for full audits, security reviews, or architecture changes (the description has both positive **and** negative triggers so it does not crowd out other skills).

The shape mirrors recently-merged curated skills (`migrate-to-codex`, `cli-creator`): `SKILL.md` + `LICENSE.txt` + `agents/openai.yaml` + `references/`.

## Why this skill

A common Codex failure mode on routine tasks: a one-line off-by-one becomes 12 file reads, a full Jest suite run, an unrelated refactor, and a long summary. The skill replaces that with first-minute triage, narrow reads, smallest correct change, and targeted verification — closing out with a short final-answer contract.

`references/examples.md` shows three concrete before/after transcripts (off-by-one, env flag, CI red on main) so the differential value is visible, not just described.

## Skill shape

- `SKILL.md` — frontmatter + ~80-line operating loop. Description is ~370 chars and includes explicit when-to-trigger ("be fast", "tight scope", "quick fix") and when-NOT-to-trigger ("full audit", "security review", "production migration") guidance so it stays inside Codex's ~8000-char initial-list budget without crowding selection.
- `LICENSE.txt` — MIT.
- `agents/openai.yaml` — `interface.{display_name, short_description, default_prompt}` + `policy.allow_implicit_invocation: true` + `metadata.version: 0.2.1`. Optional fields that I'm happy to trim if curation prefers the minimal `interface` shape used by `migrate-to-codex`.
- `references/playbook.md` — lazy-loaded task recipes, verification budget, and coding defaults.
- `references/examples.md` — three before/after transcripts showing the loop versus default behavior on the same task.

## Source

- Repo: https://github.com/Ridwannurudeen/fast-codex-workflow
- Release: [v0.2.1](https://github.com/Ridwannurudeen/fast-codex-workflow/releases/tag/v0.2.1)
- CI: green on `ubuntu-latest` + `windows-latest` (schema validator, shellcheck, end-to-end install/uninstall smoke tests with sha256 idempotency, no-BOM, and stale-file assertions)

## Test plan

- [ ] Frontmatter parses; name matches folder name (`fast-codex-workflow`)
- [ ] Skill auto-loads when prompts include "be fast" / "tight scope" / "quick fix"
- [ ] Skill stays silent when prompts include "full audit" / "security review" / "production migration"
- [ ] Adjust `agents/openai.yaml` to whatever subset of optional fields curation prefers

Happy to iterate on description tone, body length, or `agents/openai.yaml` shape based on review.