### PR TITLE
Fix hatch-pet chroma-key halo and webp transparent-RGB loss

### DIFF
--- a/skills/.curated/hatch-pet/scripts/compose_atlas.py
+++ b/skills/.curated/hatch-pet/scripts/compose_atlas.py
@@ -112,7 +112,14 @@ def save_outputs(atlas: Image.Image, output: Path, webp_output: Path | None) -> 
     atlas.save(output)
     if webp_output is not None:
         webp_output.parent.mkdir(parents=True, exist_ok=True)
-        atlas.save(webp_output, format="WEBP", lossless=True, quality=100, method=6)
+        atlas.save(
+            webp_output,
+            format="WEBP",
+            lossless=True,
+            quality=100,
+            method=6,
+            exact=True,
+        )
 
 
 def main() -> None:

--- a/skills/.curated/hatch-pet/scripts/extract_strip_frames.py
+++ b/skills/.curated/hatch-pet/scripts/extract_strip_frames.py
@@ -74,7 +74,10 @@ def remove_chroma_background(
         for x in range(rgba.width):
             red, green, blue, alpha = pixels[x, y]
             if color_distance(red, green, blue, chroma_key) <= threshold:
-                pixels[x, y] = (red, green, blue, 0)
+                # Zero RGB along with alpha so the LANCZOS resize in
+                # fit_to_cell does not pull chroma-key color into edge
+                # pixels and produce a tinted halo around the sprite.
+                pixels[x, y] = (0, 0, 0, 0)
     return rgba
 
 


### PR DESCRIPTION
## Summary

Two related fixes in the curated `hatch-pet` skill that together cause a magenta (or other chroma-key) tinted halo around extracted pet sprites in the final spritesheet.

## Root cause

1. **`scripts/extract_strip_frames.py` — `remove_chroma_background`** only zeros alpha on chroma-keyed pixels and keeps the original RGB:
   ```python
   pixels[x, y] = (red, green, blue, 0)
   ```
   The subsequent `fit_to_cell` resize uses `Image.Resampling.LANCZOS`, which interpolates RGB and alpha independently. Transparent pixels still carrying chroma RGB then leak color into neighboring partially-opaque edge pixels during downscaling, producing a faint tinted halo (e.g. `(127, 0, 127, 2)`, `(85, 0, 85, 3)` for a magenta key) around every sprite.

2. **`scripts/compose_atlas.py` — `save_outputs`** writes the WebP atlas with `lossless=True` but without `exact=True`. Without `exact=True`, libwebp is free to overwrite RGB on fully-transparent pixels during compression for better packing. Combined with #1, this can also re-introduce non-zero RGB on alpha=0 pixels in the published atlas, which any renderer that ignores the alpha channel will display as solid chroma-key color.

## Fixes

1. In `remove_chroma_background`, set chroma-keyed pixels to `(0, 0, 0, 0)` so the resize cannot pull chroma color into sprite edges.
2. In `save_outputs`, pass `exact=True` alongside `lossless=True` so transparent-pixel RGB is preserved as-written.

Both changes are tiny and surgical — no behavior change for non-chroma-key pixels.

## Test plan

- [ ] Run `extract_strip_frames.py` on a strip with a magenta (`#FF00FF`) chroma-key background and verify post-extraction frames have no `(R≈B, G≈0, alpha>0)` pixels along sprite edges.
- [ ] Compose an atlas via `compose_atlas.py --webp-output ...` and verify with PIL that there are no chroma-family RGB values on `alpha==0` pixels in the saved WebP.
- [ ] Visually check the final spritesheet in a renderer that ignores alpha (e.g. some sprite preview tools) — there should be no solid chroma-key fill where transparency is expected.