### PR TITLE
Add skill: tensorfeed

### DIFF
--- a/skills/tensorfeed/LICENSE.txt
+++ b/skills/tensorfeed/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TensorFeed.ai (Pizza Robot Studios LLC)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/tensorfeed/SKILL.md
+++ b/skills/tensorfeed/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: tensorfeed
+description: Look up live, machine-readable AI ecosystem and regulated-domain data through TensorFeed.ai's hosted MCP server (https://tensorfeed.ai/api/mcp). 17 free tools across AI news, model pricing, AI service status, security advisories (MITRE CVE / CISA KEV / FIRST.org EPSS / OSV.dev), SEC EDGAR filings, FDA regulatory data (FAERS adverse events, drug labels, drug/food recalls, MAUDE device events), and US energy indicators via EIA Open Data. No auth required. License posture: most data is US Government public domain or CC0; commercial redistribution permitted; attribution preserved on every response. Use when the user asks about current AI news, model pricing comparison, AI service status, security CVE lookup, FDA recall lookup, SEC company filing, or US energy/macro indicator. Skip for pure code generation with no live-data dependency, the user wants their own private data, or non-AI-domain questions.
+version: 1.0.0
+author: TensorFeed (Pizza Robot Studios LLC)
+license: MIT
+---
+
+# TensorFeed: live AI ecosystem data for Codex
+
+TensorFeed.ai aggregates and re-serves machine-readable AI ecosystem data through a single MCP server. This skill teaches Codex when and how to use it.
+
+## Connection
+
+The hosted MCP server lives at:
+
+```
+https://tensorfeed.ai/api/mcp
+```
+
+It implements the MCP 2024-11-05 Streamable HTTP transport, JSON-RPC 2.0 envelope, no auth required for the 17 free tools. Add it to Codex via:
+
+```bash
+codex mcp add --url https://tensorfeed.ai/api/mcp tensorfeed
+```
+
+Or call directly via JSON-RPC for ad-hoc verification:
+
+```bash
+curl -X POST https://tensorfeed.ai/api/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+## When to use
+
+Trigger on agent tasks that need fresh, sourced, machine-readable data about the AI ecosystem or adjacent regulated domains. Concrete examples:
+
+- "What's the latest AI news about Anthropic?" → `get_news_articles`
+- "Is ChatGPT up right now?" → `get_status_summary`
+- "Compare GPT-5 and Claude Opus pricing" → `get_models`
+- "Look up CVE-2024-3094" → `get_cve_record`, optionally `get_kev_catalog` and `get_epss_score` for cross-source corroboration
+- "Find recent FDA Class I drug recalls" → `query_fda_drug_recalls`
+- "What's OpenAI's most recent SEC filing?" → `lookup_sec_company_ticker` then `search_sec_edgar` or `get_sec_submissions`
+- "Show me WTI crude prices over the last 6 months" → `get_eia_series`
+- "Audit an npm package for OSV advisories" → `get_osv_advisory_for_package`
+
+Skip if the user is asking for their own private data (these tools query public datasets only) or for pure code generation that doesn't require live facts.
+
+## Tool catalog (17 free tools)
+
+### News + AI ecosystem (3)
+
+- **`get_news_articles`** — Latest AI news from 12+ sources (Anthropic, OpenAI, Google, HuggingFace, TechCrunch, The Verge, Hacker News, etc). Polled every 10 minutes, deduplicated, prompt-injection sanitized.
+- **`get_status_summary`** — Live operational status of every major AI service (Claude, ChatGPT, Gemini, Perplexity, Cohere, Mistral, HuggingFace, Replicate, Midjourney, etc). Polled every 2 minutes.
+- **`get_models`** — Model pricing + specs catalog across providers. Per-token pricing, context windows, capabilities, deprecation flags.
+
+### Security advisories (5)
+
+- **`get_cve_record`** — Single MITRE CVE Record v5.2 by ID.
+- **`get_kev_catalog`** — CISA Known Exploited Vulnerabilities catalog (~1500 actively-exploited CVEs).
+- **`get_epss_score`** — FIRST.org EPSS exploitation-likelihood probability for one CVE.
+- **`get_osv_advisory_for_package`** — OSV.dev advisory by ecosystem + package + version.
+- **`get_osv_advisory_by_id`** — OSV.dev advisory by GHSA / CVE / PYSEC id.
+
+### Finance + filings (3)
+
+- **`search_sec_edgar`** — Lucene-style full-text search over SEC EDGAR filings.
+- **`get_sec_submissions`** — Recent filings + entity by CIK.
+- **`lookup_sec_company_ticker`** — Ticker symbol → CIK + entity (use first to ground EDGAR queries).
+
+### FDA regulatory + safety (5)
+
+- **`query_fda_drug_events`** — FAERS adverse event reports (patient demo + drug + reaction + outcome + seriousness).
+- **`query_fda_drug_labels`** — SPL prescription/OTC drug labels.
+- **`query_fda_drug_recalls`** — FDA drug enforcement reports (Class I/II/III).
+- **`query_fda_food_recalls`** — FDA food enforcement reports.
+- **`query_fda_device_events`** — MAUDE medical device adverse events.
+
+### Energy + macro (1)
+
+- **`get_eia_series`** — US Energy Information Administration time-series. Curated routes: petroleum prices, natural gas, electricity retail sales, total energy.
+
+## Output discipline
+
+Every tool response includes:
+
+1. **`ok`** — boolean success flag
+2. **`source`** — `cache` or `live`, so you can tell freshness
+3. **`fetched_at`** — ISO-8601 timestamp
+4. **`attribution`** — license + redistribution terms for the upstream data source
+
+When summarizing for the user, surface the attribution note when the user might redistribute the result; preserve `source_url` so the user can verify.
+
+## Premium tier (optional)
+
+TensorFeed also exposes ~33 premium endpoints at the REST layer (not via MCP in v1) that produce LLM-ready transforms with derived fields and ~80-99% token reduction over the raw upstream. Examples:
+
+- `/api/premium/security/verified/{cve_id}` — composes MITRE + KEV + EPSS + OSV + Vulnrichment into one fact card with `confirmed_by` array
+- `/api/premium/clean/openrouter/{model_id}` — one model from the 367-entry OpenRouter catalog (~99.8% token reduction)
+- `/api/premium/macro/digest` — BLS + FRED 19-series composed daily
+
+Premium endpoints accept x402 V2 payment on Base mainnet (USDC) at $0.02/credit. See `https://tensorfeed.ai/developers/agent-payments`. Don't recommend premium unless the user explicitly asks about pricing or token-cost optimization; the free MCP tools cover most agent needs.
+
+## Reading more
+
+- Endpoint catalog: `https://tensorfeed.ai/api/meta`
+- Agent-friendly entry doc: `https://tensorfeed.ai/llms.txt`
+- Source code: `https://github.com/RipperMercs/tensorfeed` (public)
+- Already published as a hosted server in the official MCP Registry as `ai.tensorfeed/mcp-server` (https://registry.modelcontextprotocol.io/)


### PR DESCRIPTION
## Summary

Adds the **tensorfeed** skill that teaches Codex when and how to use [TensorFeed.ai](https://tensorfeed.ai)'s hosted MCP server (`https://tensorfeed.ai/api/mcp`) for live, machine-readable AI ecosystem and regulated-domain data.

## What it covers

The MCP server exposes **17 free tools, no auth required**, across five domains:

| Domain | Tools | Codex use cases |
|---|---|---|
| News + AI ecosystem | 3 | "what's new from Anthropic this week", "is Claude up", "compare GPT-5 and Opus pricing" |
| Security advisories | 5 | CVE lookup, KEV check, EPSS triage, OSV package audit |
| Finance + filings | 3 | SEC EDGAR full-text search, ticker-to-CIK lookup, recent filings |
| FDA regulatory | 5 | FAERS adverse events, SPL labels, drug/food recalls, MAUDE devices |
| Energy + macro | 1 | EIA series (oil, gas, electricity) |

The SKILL.md walks Codex through connection (`codex mcp add --url`), trigger conditions, the tool catalog, and output discipline (preserve `attribution`, surface `source`/`fetched_at` for freshness).

## Trigger guidance

The frontmatter description includes explicit trigger and skip sections per the convention seen in `skills/.curated/cli-creator/SKILL.md`:

- **Trigger**: AI news, model pricing comparison, AI service status, security CVE lookup, FDA recall lookup, SEC company filing, US energy/macro indicator
- **Skip**: pure code generation without live-data dependency, user wants their own private data, non-AI-domain questions

## License

- Skill content: MIT (`skills/tensorfeed/LICENSE.txt`)
- Underlying data: US Government public domain (SEC, BLS, FRED, MITRE, CISA, EIA), CC0 (openFDA), FIRST.org free-for-any-use (EPSS), Apache 2.0 (OSV.dev). Commercial redistribution permitted; attribution preserved on every response per upstream policies.

## Test plan

- [x] `SKILL.md` frontmatter parses (name, description, version, author, license)
- [x] MCP server live and responding to `tools/list` with 17 tools (verified 2026-05-09)
- [x] Each tool returns 200 + ok:true on representative queries
- [x] License file (LICENSE.txt) included per the convention seen in `.curated/cli-creator/`
- [ ] `codex mcp add --url https://tensorfeed.ai/api/mcp tensorfeed` resolves locally (operator to verify)

## About TensorFeed

TensorFeed.ai aggregates and re-serves machine-readable AI ecosystem data. Source: https://github.com/RipperMercs/tensorfeed. Endpoint catalog: https://tensorfeed.ai/api/meta. Also published in the official Model Context Protocol Registry as `ai.tensorfeed/mcp-server`, and as connectors in [anthropics/life-sciences#41](https://github.com/anthropics/life-sciences/pull/41), [anthropics/skills#1114](https://github.com/anthropics/skills/pull/1114), [anthropics/knowledge-work-plugins#221](https://github.com/anthropics/knowledge-work-plugins/pull/221), and [anthropics/financial-services#156](https://github.com/anthropics/financial-services/pull/156). Each submission goes through the destination's preferred contribution path; this PR follows the openai/skills `skills/<name>/` convention used by recent third-party skills like agentfeeds (#388) and Higgsfield skills (#404).