### PR TITLE
[codex] Add GitHub skill instruction hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ $skill-installer install https://github.com/openai/skills/tree/main/skills/.expe
 
 After installing a skill, restart Codex to pick up new skills.
 
+## Skill instruction hooks
+
+Some curated GitHub skills can optionally load repo-specific instructions while remaining useful as standalone vendor skills:
+
+| Skill | User hook | Project hook |
+| --- | --- | --- |
+| `yeet` | `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md` | `<repo-root>/PULL_REQUESTS.md` |
+| `gh-fix-ci` | `${CODEX_HOME:-$HOME/.codex}/gh-ci.md` | `<repo-root>/gh-ci.md` |
+| `gh-address-comments` | `${CODEX_HOME:-$HOME/.codex}/gh-comments.md` | `<repo-root>/gh-comments.md` |
+
+When a hook file exists, the skill reads the user hook first and the project hook second. Project instructions override user instructions for conflicts, user instructions override vendor instructions, and non-conflicting instructions all apply. Missing hook files are ignored; unreadable hook files are reported as blockers.
+
 ## License
 
 The license of an individual skill can be found directly inside the skill's directory inside the `LICENSE.txt` file.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Some curated GitHub skills can optionally load repo-specific instructions while 
 
 | Skill | User hook | Project hook |
 | --- | --- | --- |
-| `yeet` | `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md` | `<repo-root>/PULL_REQUESTS.md` |
+| `yeet` | `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md`, then `${CODEX_HOME:-$HOME/.codex}/qa-and-ship.md` | `<repo-root>/PULL_REQUESTS.md`, then `<repo-root>/qa-and-ship.md` |
 | `gh-fix-ci` | `${CODEX_HOME:-$HOME/.codex}/gh-ci.md` | `<repo-root>/gh-ci.md` |
 | `gh-address-comments` | `${CODEX_HOME:-$HOME/.codex}/gh-comments.md` | `<repo-root>/gh-comments.md` |
 
-When a hook file exists, the skill reads the user hook first and the project hook second. Project instructions override user instructions for conflicts, user instructions override vendor instructions, and non-conflicting instructions all apply. Missing hook files are ignored; unreadable hook files are reported as blockers.
+When hook files exist, the skill reads user hooks first and project hooks second, using the order listed in the table. Project instructions override user instructions for conflicts, user instructions override vendor instructions, and non-conflicting instructions all apply. Missing hook files are ignored; unreadable hook files are reported as blockers.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After installing a skill, restart Codex to pick up new skills.
 
 Some curated GitHub skills can optionally load repo-specific instructions while remaining useful as standalone vendor skills:
 
-| Skill | User hook | Project hook |
+| Skill | User hooks | Project hooks |
 | --- | --- | --- |
 | `yeet` | `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md`, then `${CODEX_HOME:-$HOME/.codex}/qa-and-ship.md` | `<repo-root>/PULL_REQUESTS.md`, then `<repo-root>/qa-and-ship.md` |
 | `gh-fix-ci` | `${CODEX_HOME:-$HOME/.codex}/gh-ci.md` | `<repo-root>/gh-ci.md` |

--- a/skills/.curated/gh-address-comments/SKILL.md
+++ b/skills/.curated/gh-address-comments/SKILL.md
@@ -11,6 +11,17 @@ Guide to find the open PR for the current branch and address its comments with g
 
 Prereq: ensure `gh` is authenticated (for example, run `gh auth login` once), then run `gh auth status` with escalated permissions (include workflow/repo scopes) so `gh` commands succeed. If sandboxing blocks `gh auth status`, rerun it with `sandbox_permissions=require_escalated`.
 
+## Instruction Hooks
+
+Before running the workflow, build the effective instructions from the vendor skill plus optional hook files:
+
+- User hook: `${CODEX_HOME:-$HOME/.codex}/gh-comments.md`
+- Project hook: `<repo-root>/gh-comments.md`
+
+Resolve `<repo-root>` from an explicit repo/cwd input when one is provided; otherwise use `git rev-parse --show-toplevel` from the current checkout. Read each hook file only when that exact path exists. Do not scan parent directories, nested directories, or alternate filenames.
+
+Apply instructions in this order: vendor skill, then user hook, then project hook. Later instructions override earlier ones only when they conflict; non-conflicting instructions all apply. Current system, developer, and user messages still outrank all hook files. If a hook file exists but cannot be read, stop and report the unreadable path instead of silently skipping it. If no hook exists, run this vendor skill as written.
+
 ## 1) Inspect comments needing attention
 - Run scripts/fetch_comments.py which will print out all the comments and review threads on the PR
 

--- a/skills/.curated/gh-address-comments/SKILL.md
+++ b/skills/.curated/gh-address-comments/SKILL.md
@@ -24,6 +24,7 @@ Apply instructions in this order: vendor skill, then user hook, then project hoo
 
 ## 1) Inspect comments needing attention
 - Run scripts/fetch_comments.py which will print out all the comments and review threads on the PR
+- The fetcher resolves comments against the PR's base repository, so fork-backed PRs work when `gh pr view` can resolve the current branch PR.
 
 ## 2) Ask the user for clarification
 - Number all the review threads and comments and provide a short summary of what would be required to apply a fix for it

--- a/skills/.curated/gh-address-comments/scripts/fetch_comments.py
+++ b/skills/.curated/gh-address-comments/scripts/fetch_comments.py
@@ -19,6 +19,7 @@ import json
 import subprocess
 import sys
 from typing import Any
+from urllib.parse import urlparse
 
 QUERY = """\
 query(
@@ -116,19 +117,31 @@ def _ensure_gh_authenticated() -> None:
 
 
 def gh_pr_view_json(fields: str) -> dict[str, Any]:
-    # fields is a comma-separated list like: "number,headRepositoryOwner,headRepository"
+    # fields is a comma-separated list like: "number,url"
     return _run_json(["gh", "pr", "view", "--json", fields])
+
+
+def parse_pr_url(pr_url: str) -> tuple[str, str, int]:
+    """Extract the base repository owner, repository name, and PR number from a PR URL."""
+    parsed = urlparse(pr_url)
+    path_parts = parsed.path.strip("/").split("/")
+    if len(path_parts) < 4 or path_parts[2] != "pull":
+        raise RuntimeError(f"Unexpected pull request URL format: {pr_url}")
+    owner, repo, number = path_parts[0], path_parts[1], path_parts[3]
+    if not owner or not repo or not number.isdigit():
+        raise RuntimeError(f"Unexpected pull request URL format: {pr_url}")
+    return owner, repo, int(number)
 
 
 def get_current_pr_ref() -> tuple[str, str, int]:
     """
     Resolve the PR for the current branch (whatever gh considers associated).
-    Works for cross-repo PRs too, by reading head repository owner/name.
+    Works for cross-repo PRs too, by reading the base repository from the PR URL.
     """
-    pr = gh_pr_view_json("number,headRepositoryOwner,headRepository")
-    owner = pr["headRepositoryOwner"]["login"]
-    repo = pr["headRepository"]["name"]
-    number = int(pr["number"])
+    pr = gh_pr_view_json("number,url")
+    owner, repo, number = parse_pr_url(str(pr["url"]))
+    if int(pr["number"]) != number:
+        raise RuntimeError(f"PR number mismatch in GitHub response: {pr}")
     return owner, repo, number
 
 

--- a/skills/.curated/gh-address-comments/scripts/test_fetch_comments.py
+++ b/skills/.curated/gh-address-comments/scripts/test_fetch_comments.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Regression tests for PR reference resolution in fetch_comments.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).with_name("fetch_comments.py")
+MODULE_SPEC = importlib.util.spec_from_file_location("fetch_comments", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Failed to load module spec from {MODULE_PATH}")
+fetch_comments = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(fetch_comments)
+
+
+class FetchCommentsPrResolutionTests(unittest.TestCase):
+    """Lock down base-repository resolution for fork-backed pull requests."""
+
+    def test_parse_pr_url_extracts_base_repository(self) -> None:
+        self.assertEqual(
+            fetch_comments.parse_pr_url("https://github.com/openai/skills/pull/406"),
+            ("openai", "skills", 406),
+        )
+
+    def test_current_pr_ref_uses_pr_url_not_head_repository(self) -> None:
+        response = {
+            "number": 406,
+            "url": "https://github.com/openai/skills/pull/406",
+            "headRepositoryOwner": {"login": "TheCookieLab"},
+            "headRepository": {"name": "skills"},
+        }
+
+        with patch.object(fetch_comments, "gh_pr_view_json", return_value=response):
+            self.assertEqual(fetch_comments.get_current_pr_ref(), ("openai", "skills", 406))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/.curated/gh-fix-ci/SKILL.md
+++ b/skills/.curated/gh-fix-ci/SKILL.md
@@ -13,6 +13,17 @@ Use gh to locate failing PR checks, fetch GitHub Actions logs for actionable fai
 
 Prereq: authenticate with the standard GitHub CLI once (for example, run `gh auth login`), then confirm with `gh auth status` (repo + workflow scopes are typically required).
 
+## Instruction Hooks
+
+Before running the workflow, build the effective instructions from the vendor skill plus optional hook files:
+
+- User hook: `${CODEX_HOME:-$HOME/.codex}/gh-ci.md`
+- Project hook: `<repo-root>/gh-ci.md`
+
+Resolve `<repo-root>` from an explicit repo/cwd input when one is provided; otherwise use `git rev-parse --show-toplevel` from the current checkout. Read each hook file only when that exact path exists. Do not scan parent directories, nested directories, or alternate filenames.
+
+Apply instructions in this order: vendor skill, then user hook, then project hook. Later instructions override earlier ones only when they conflict; non-conflicting instructions all apply. Current system, developer, and user messages still outrank all hook files. If a hook file exists but cannot be read, stop and report the unreadable path instead of silently skipping it. If no hook exists, run this vendor skill as written.
+
 ## Inputs
 
 - `repo`: path inside the repo (default `.`)

--- a/skills/.curated/yeet/SKILL.md
+++ b/skills/.curated/yeet/SKILL.md
@@ -12,12 +12,12 @@ description: "Use only when the user explicitly asks to stage, commit, push, and
 
 Before running the workflow, build the effective instructions from the vendor skill plus optional hook files:
 
-- User hook: `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md`
-- Project hook: `<repo-root>/PULL_REQUESTS.md`
+- User hooks: `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md`, then `${CODEX_HOME:-$HOME/.codex}/qa-and-ship.md`
+- Project hooks: `<repo-root>/PULL_REQUESTS.md`, then `<repo-root>/qa-and-ship.md`
 
 Resolve `<repo-root>` from an explicit repo/cwd input when one is provided; otherwise use `git rev-parse --show-toplevel` from the current checkout. Read each hook file only when that exact path exists. Do not scan parent directories, nested directories, or alternate filenames.
 
-Apply instructions in this order: vendor skill, then user hook, then project hook. Later instructions override earlier ones only when they conflict; non-conflicting instructions all apply. Current system, developer, and user messages still outrank all hook files. If a hook file exists but cannot be read, stop and report the unreadable path instead of silently skipping it. If no hook exists, run this vendor skill as written.
+Apply instructions in this order: vendor skill, then user hooks in listed order, then project hooks in listed order. Later instructions override earlier ones only when they conflict; non-conflicting instructions all apply. Current system, developer, and user messages still outrank all hook files. If a hook file exists but cannot be read, stop and report the unreadable path instead of silently skipping it. If no hook exists, run this vendor skill as written.
 
 ## Naming conventions
 

--- a/skills/.curated/yeet/SKILL.md
+++ b/skills/.curated/yeet/SKILL.md
@@ -8,6 +8,17 @@ description: "Use only when the user explicitly asks to stage, commit, push, and
 - Require GitHub CLI `gh`. Check `gh --version`. If missing, ask the user to install `gh` and stop.
 - Require authenticated `gh` session. Run `gh auth status`. If not authenticated, ask the user to run `gh auth login` (and re-run `gh auth status`) before continuing.
 
+## Instruction Hooks
+
+Before running the workflow, build the effective instructions from the vendor skill plus optional hook files:
+
+- User hook: `${CODEX_HOME:-$HOME/.codex}/PULL_REQUESTS.md`
+- Project hook: `<repo-root>/PULL_REQUESTS.md`
+
+Resolve `<repo-root>` from an explicit repo/cwd input when one is provided; otherwise use `git rev-parse --show-toplevel` from the current checkout. Read each hook file only when that exact path exists. Do not scan parent directories, nested directories, or alternate filenames.
+
+Apply instructions in this order: vendor skill, then user hook, then project hook. Later instructions override earlier ones only when they conflict; non-conflicting instructions all apply. Current system, developer, and user messages still outrank all hook files. If a hook file exists but cannot be read, stop and report the unreadable path instead of silently skipping it. If no hook exists, run this vendor skill as written.
+
 ## Naming conventions
 
 - Branch: `{description}` when starting from main/master/default.


### PR DESCRIPTION
## Summary

Add optional instruction hooks to the curated GitHub skills so the vendor workflows remain standalone while allowing user- and repo-specific guidance to refine behavior when present.

## Changes

- Teach `yeet` to load `PULL_REQUESTS.md` and `qa-and-ship.md` from user scope, then repo scope.
- Teach `gh-fix-ci` to load `gh-ci.md` from user scope, then repo scope.
- Teach `gh-address-comments` to load `gh-comments.md` from user scope, then repo scope.
- Document hook lookup order, missing-hook behavior, unreadable-hook blocking, and precedence in the curated skills README.
- Harden the PR comment fetcher so fork-backed PRs resolve review data from the base repository instead of the head fork.

## Validation

- Ran diff whitespace checks across the branch.
- Compiled the existing GitHub helper scripts to confirm packaging stayed intact.
- Exercised hook lookup as a black-box flow across no-hook, user-only, user-plus-project, CI-specific, and unreadable-hook scenarios.
- Exercised the PR comment fetcher against this fork-backed PR and confirmed it returns the upstream PR review context.
- Confirmed the active local plugin cache mirrors the same hook and fetcher behavior for immediate runtime use.
