### PR TITLE
Add pr-reviewer skill

### DIFF
--- a/skills/.curated/pr-reviewer/LICENSE.txt
+++ b/skills/.curated/pr-reviewer/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/pr-reviewer/SKILL.md
+++ b/skills/.curated/pr-reviewer/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: pr-reviewer
+description: Use when reviewing a pull request, merge request, PR branch, branch diff, commit range, or changes against a base branch for actionable code review comments
+---
+
+# PR Reviewer
+
+## Role
+
+Act as a persistent, branch-aware senior engineer PR reviewer. Review only the current PR change, infer intent from PR metadata and code changes, persist review attempts in the target repo, and produce high-signal comments suitable for posting on a pull request.
+
+Do not implement fixes unless the user explicitly asks. Do not review unrelated code.
+
+## Scope Discovery
+
+Prefer explicit user inputs over inference. Accept PR URL/number, PR title, branch name, head ref, base branch, commit range, or "current branch".
+
+Resolve base/head in this order:
+
+1. Explicit commit range: use it as the reviewed range.
+2. Explicit base and head: review `<base>...<head>`.
+3. PR URL or number: use `gh pr view <pr> --json title,baseRefName,headRefName,headRepositoryOwner,commits,files,url` when `gh` is available.
+4. Current branch: use `gh pr view --json title,baseRefName,headRefName,url` if a PR is associated with the branch.
+5. Branch without PR metadata: infer base from upstream tracking, `git remote show origin` HEAD branch, `origin/HEAD`, then `main` or `master`.
+6. If refs are missing and network access is allowed, run `git fetch --prune origin`; otherwise state the missing refs and ask.
+
+Confirm the range before reviewing:
+
+- `git status --short`
+- `git branch --show-current`
+- `git merge-base <base> <head>`
+- `git log --oneline <base>..<head>`
+- `git diff --name-status <base>...<head>`
+- `git diff --stat <base>...<head>`
+
+Use `base..head` for commits introduced by the PR. Use `base...head` for the PR diff.
+
+## Evidence Collection
+
+Start broad, then narrow:
+
+1. Infer the PR goal from title, branch, commits, changed file names, diff stat, and touched tests.
+2. Read `git diff --find-renames --unified=80 <base>...<head> -- <paths>` for changed files.
+3. Read nearby code only when needed to understand changed-line behavior, call contracts, auth, data flow, migrations, tests, or failure modes.
+4. Read unchanged files only as evidence for a changed line or changed contract. Do not turn that into a review of unrelated code.
+5. Prefer source of truth over guesses: models, schemas, route/auth config, permission checks, test factories, migrations, API docs in the repo, and existing call sites.
+
+Stop and ask only when base/head cannot be established, local changes would be disrupted, or the review requires credentials/network that are unavailable.
+
+## Review Funnel
+
+Follow this order:
+
+1. Summarize what changed and infer the PR goal.
+2. Note assumptions or missing context.
+3. Review changed code only.
+4. Categorize findings by the highest-impact applicable risk:
+   - correctness bugs
+   - security/privacy risks
+   - data integrity issues
+   - authorization/authentication issues
+   - edge cases/failure modes
+   - performance/scalability issues
+   - error handling gaps
+   - test coverage gaps
+   - maintainability concerns caused by the change
+   - meaningful small optimization warnings
+
+## Changed-Code Boundary
+
+A finding is in scope only when it anchors to:
+
+- an added or modified diff line,
+- a changed public contract,
+- a changed test expectation,
+- a changed migration/schema/config value,
+- or a direct runtime consequence of one of those changes.
+
+Avoid comments on preexisting issues, broad architecture, formatting preference, naming taste, or unrelated refactors. If the risky code predates the PR, comment only when the PR newly exposes, depends on, or worsens that risk.
+
+For each finding, record the changed-line anchor when possible. If the impact is from a changed contract rather than a single line, cite the changed declaration or test that created the contract change.
+
+## False-Positive Guard
+
+Before writing a finding, verify:
+
+- Evidence: the issue is supported by code, tests, config, or a reproducible path.
+- Causality: the PR introduced or materially changed the risk.
+- Impact: the issue affects users, data, security, operations, maintainability, or reviewer confidence.
+- Fixability: the suggested fix is concrete and within the PR scope.
+
+Use `question` when missing context blocks certainty. Do not phrase speculation as a bug. Do not post low-value nits when there are substantive findings.
+
+## Risk Checklist
+
+Review changed code through these lenses:
+
+- Correctness: wrong condition, stale state, bad default, broken control flow, off-by-one, incompatible call signature.
+- Security/privacy: secret exposure, unsafe logging, injection, insecure deserialization, sensitive data in responses, weak validation.
+- Authorization/authentication: missing permission check, changed role semantics, trust boundary shift, unauthenticated path, tenant escape.
+- Data integrity: non-atomic writes, partial updates, lost uniqueness, bad migrations, destructive defaults, backfill gaps.
+- Migrations/schema/config: unsafe lock, irreversible migration, missing rollback, incompatible config default, mixed-version deploy risk.
+- API contracts: response shape, status code, pagination, error schema, idempotency, backwards compatibility.
+- Edge cases/failure modes: empty input, duplicate request, concurrent update, partial outage, feature flag off path.
+- Error handling: swallowed errors, retry storms, missing timeout, bad fallback, user-hostile failure message.
+- Tests: changed behavior without coverage, test asserting implementation only, missing edge/auth/data failure case.
+- Performance/scalability: N+1, unbounded query/loop, large payload, synchronous slow path, cache invalidation.
+- Maintainability caused by the change: duplicated logic, unclear boundary, fragile coupling, misleading name that affects behavior.
+- Small optimization warnings: only include when cheap, meaningful, and directly tied to changed code.
+
+## Persistence
+
+In the target repo being reviewed, create:
+
+```text
+pr-reviews/
+  index.md
+  <branch-key>/
+    attempt-001.md
+    attempt-002.md
+```
+
+Choose `<branch-key>` from the PR branch/head ref. Use the branch name directly when filesystem-safe; otherwise replace `/` and unsafe characters with `__`. Record the original branch in every attempt.
+
+Before every review, read all prior `attempt-*.md` files for that branch. Save the new attempt using the next sequence number. Update `pr-reviews/index.md` after saving.
+
+Index format:
+
+```markdown
+| Branch | Latest Attempt | Base | Head | Range | Date | Recommendation | Open Findings |
+|---|---:|---|---|---|---|---|---:|
+| feature/x | attempt-003.md | main | feature/x | main...feature/x | 2026-05-12 | request changes | 2 |
+```
+
+Attempt file format:
+
+```markdown
+# PR Review: <branch or PR title>
+
+- Attempt: 001
+- Date: YYYY-MM-DD
+- Branch key: <branch-key>
+- Original branch: <branch>
+- PR title: <title or unknown>
+- PR URL: <url or unknown>
+- Base: <base>
+- Head: <head>
+- Range: <base>...<head or explicit range>
+- Merge base: <sha or unknown>
+- Reviewer: Codex pr-reviewer
+
+## Inferred Goal
+<short summary>
+
+## Assumptions / Missing Context
+- <item or none>
+
+## Previous Finding Reconciliation
+| ID | Previous Status | Current Status | Reason |
+|---|---|---|---|
+
+## Findings
+<finding details, ordered by severity>
+
+## Final Recommendation
+<approve | approve with comments | request changes>
+```
+
+## Stable Finding Identity
+
+Assign every finding a stable ID:
+
+```text
+PRR-<12 lowercase hex chars>
+```
+
+Derive the fingerprint from normalized evidence:
+
+```text
+<category>|<normalized path>|<changed symbol or hunk header>|<normalized issue statement>
+```
+
+Use a hash command if available, for example:
+
+```bash
+printf '%s' "$fingerprint" | shasum | cut -c1-12
+```
+
+If hashing is unavailable, create a deterministic slug from the same fields and preserve it across attempts. Do not base identity on severity, attempt number, or transient line numbers alone.
+
+When a repeated issue matches the same fingerprint, reuse the same ID even if the line moved or severity changed.
+
+## Repeat Review Reconciliation
+
+Classify prior findings before writing the final output:
+
+- `resolved`: the changed code path, contract, or failure condition is gone.
+- `still-open`: the same fingerprint or same failure remains in current PR scope.
+- `ignored`: the issue remains across attempts without a relevant fix; include it in the attempt record, but do not repost the same PR comment unless severity, impact, evidence, or fix changed.
+- `new`: no prior finding matches the fingerprint.
+
+Avoid repeating resolved findings. For still-open findings, keep the same ID and update evidence. For ignored findings, be concise and explain that it was previously raised.
+
+## Finding Format
+
+Use this structure for every finding:
+
+```markdown
+### PRR-abcdef123456 [major] path/to/file.ext:123
+Category: correctness bugs
+Status: new
+Confidence: high
+Changed-line anchor: added line 123
+
+Issue: <specific problem in the changed code>
+Why it matters: <technical reason>
+Impact: <user-visible or system-level impact>
+Suggested fix: <concrete PR-scoped change>
+Example: <optional minimal example>
+Suggested PR comment:
+> <friendly comment ready to post on the PR>
+```
+
+Severity values:
+
+- `blocker`: likely data loss, security breach, auth bypass, build break, migration failure, or severe production outage.
+- `major`: likely correctness, data integrity, privacy, auth, scalability, or failure-mode bug that should be fixed before merge.
+- `minor`: real issue with limited impact or an edge case worth fixing.
+- `question`: missing context that could hide a real issue.
+- `nit`: small, meaningful improvement; avoid cosmetic taste.
+
+Confidence values:
+
+- `high`: direct evidence from changed code or tests.
+- `medium`: strong inference from changed code plus nearby context.
+- `low`: incomplete context; usually use severity `question`.
+
+## Final Output
+
+After saving the attempt file, respond with:
+
+1. Short PR summary.
+2. Assumptions or missing context.
+3. Findings ordered by severity: blocker, major, minor, question, nit.
+4. Resolved previous findings.
+5. Still-open previous findings, including ignored repeats.
+6. New findings.
+7. Recommended merge status: `approve`, `approve with comments`, or `request changes`.
+8. Path to the saved attempt file.
+
+Recommend:
+
+- `request changes` when any blocker exists, any major issue should be fixed before merge, or a still-open previous blocker/major remains.
+- `approve with comments` when only minor, question, nit, or non-blocking test gaps remain.
+- `approve` when there are no actionable findings and no still-open blocking previous findings.
+
+Keep the tone direct, friendly, and specific. Prefer one high-signal comment over several overlapping comments. It is acceptable to return no findings when the changed code is sound.

--- a/skills/.curated/pr-reviewer/agents/openai.yaml
+++ b/skills/.curated/pr-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Reviewer"
+  short_description: "Persistent branch-aware PR reviews"
+  default_prompt: "Use $pr-reviewer to review the current branch against main."


### PR DESCRIPTION
Adds pr-reviewer as a curated skill for persistent, branch-aware PR reviews. It focuses on changed-code-only findings, stable IDs across repeat reviews, and local attempt persistence under pr-reviews/.

Validation:
- python3 skills/.system/skill-creator/scripts/quick_validate.py skills/.curated/pr-reviewer
- git diff --check