### PR TITLE
fix(openai-docs): sync duplicated skill copies

### DIFF
--- a/skills/.curated/openai-docs/SKILL.md
+++ b/skills/.curated/openai-docs/SKILL.md
@@ -8,6 +8,12 @@ description: "Use when the user asks how to build with OpenAI products or APIs a
 
 Provide authoritative, current guidance from OpenAI developer docs using the developers.openai.com MCP server. Always prioritize the developer docs MCP tools over web.run for OpenAI-related questions. This skill also owns model selection, API model migration, and prompt-upgrade guidance. Only if the MCP server is installed and returns no meaningful results should you fall back to web search.
 
+## API Key Setup
+
+For requests to build, run, configure, debug, or implement an API-backed app, script, CLI, generator, or tool, use `openai-platform-api-key` first when available. After that credential gate is resolved, return here for current docs as needed.
+
+Use this skill directly for docs-only questions, citations, model/API guidance, conceptual explanations, and examples that do not require building or running an API-backed artifact.
+
 ## Quick start
 
 - Use `mcp__openaiDeveloperDocs__search_openai_docs` to find the most relevant doc pages.

--- a/skills/.system/openai-docs/references/latest-model.md
+++ b/skills/.system/openai-docs/references/latest-model.md
@@ -16,7 +16,8 @@ This file is a curated helper. Every recommendation here must be verified agains
 | `gpt-4.1-nano` | Fastest and cheapest no-reasoning text |
 | `gpt-5.3-codex` | Agentic coding, code editing, and tool-heavy coding workflows |
 | `gpt-5.1-codex-mini` | Cheaper coding workflows |
-| `gpt-image-1.5` | Best image generation and edit quality |
+| `gpt-image-2` | Best image generation and edit quality |
+| `gpt-image-1.5` | Less expensive image generation and edit quality |
 | `gpt-image-1-mini` | Cost-optimized image generation |
 | `gpt-4o-mini-tts` | Text-to-speech |
 | `gpt-4o-mini-transcribe` | Speech-to-text, fast and cost-efficient |


### PR DESCRIPTION
## Summary
- sync the `.system/openai-docs` fallback model reference with `.curated/openai-docs` so `gpt-image-2` is listed as the best image generation/edit model
- sync the API-key setup routing guidance from `.system/openai-docs` into `.curated/openai-docs`
- leave all other skill content unchanged

## Note
- `openai-docs` is duplicated under both `.system` and `.curated`; this PR keeps the duplicate copies in sync to avoid stale guidance depending on which copy an agent uses.

## Validation
- `diff -qr skills/.system/openai-docs skills/.curated/openai-docs`
- `node skills/.system/openai-docs/scripts/resolve-latest-model-info.js`
- `node skills/.curated/openai-docs/scripts/resolve-latest-model-info.js`

## Source
- OpenAI image generation model guidance recommends `gpt-image-2` as the default for most production workflows: https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide#when-to-use-which-model