### PR TITLE
Add AI Native Software Engineering skills

### DIFF
--- a/skills/.curated/ai-native-context-discipline/LICENSE.txt
+++ b/skills/.curated/ai-native-context-discipline/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-context-discipline/SKILL.md
+++ b/skills/.curated/ai-native-context-discipline/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ai-native-context-discipline
+description: "Use in long AI coding sessions to prevent context rot: re-anchor artifacts, summarize state, detect drift, and restore phase boundaries."
+---
+
+# AI Native Context Discipline
+
+Use this skill when a session is getting long, the agent may be drifting, or the user asks to re-anchor, summarize, resume, or restore coherence.
+
+## Workflow
+
+1. Detect the current phase.
+   - Identify whether the project is in problem definition, planning, foundation, implementation, or improvement.
+   - Do not assume the phase from recent conversation alone.
+
+2. Reload durable artifacts.
+   - Prefer `docs/implementation-plan.md`, `docs/progress.md`, `docs/project-guidelines.md`, and `docs/technical-debt.md` when present.
+   - Read relevant source files or tests only as needed.
+   - Avoid flooding context with unrelated files.
+
+3. Produce a structured re-anchor summary.
+   - Current objective
+   - Current phase
+   - Completed work
+   - Active constraints
+   - Decisions already made
+   - Open questions
+   - Next safe action
+
+4. Detect context rot symptoms.
+   - Drift from original problem
+   - Inconsistent naming
+   - Silent architectural shifts
+   - Redundant abstractions
+   - Scope expansion without intent
+   - Reintroduction of rejected decisions
+
+5. Restore boundaries.
+   - Recommend the correct next phase or skill.
+   - If implementation is ongoing, return to the smallest valid batch.
+   - If planning is unstable, return to problem definition or plan refinement.
+
+## Rules
+
+- Maximize signal, not token volume.
+- Prefer durable artifacts over conversational memory.
+- Do not make code changes unless the user explicitly asks for action after re-anchoring.
+- When summarizing, separate confirmed facts from assumptions.
+
+See `references/context-rot-checklist.md` for symptoms and recovery prompts.

--- a/skills/.curated/ai-native-context-discipline/agents/openai.yaml
+++ b/skills/.curated/ai-native-context-discipline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Context Discipline"
+  short_description: "Prevent context rot in long sessions"
+  default_prompt: "Use $ai-native-context-discipline to re-anchor this long coding session and prevent context rot."

--- a/skills/.curated/ai-native-context-discipline/references/context-rot-checklist.md
+++ b/skills/.curated/ai-native-context-discipline/references/context-rot-checklist.md
@@ -1,0 +1,51 @@
+# Context Rot Checklist
+
+Use this reference to recover coherence in long sessions.
+
+## Symptoms
+
+- Drift from the original problem definition
+- Inconsistent naming conventions
+- Silent architectural shifts
+- Redundant abstractions
+- Scope expansion without explicit intent
+- Reintroduction of previously rejected decisions
+- Confusion between plan, progress, and implementation logs
+
+## Structural Defenses
+
+- Persist intent in artifacts.
+- Summarize phase boundaries explicitly.
+- Pause after major implementation batches.
+- Reload the plan and guidelines in long sessions.
+- Keep context focused on current phase and current batch.
+
+## Re-Anchor Prompt
+
+```text
+Re-anchor this session from durable project artifacts.
+
+Read the relevant project artifacts:
+
+- `docs/implementation-plan.md`
+- `docs/progress.md`
+- `docs/project-guidelines.md`
+- `docs/technical-debt.md`
+
+Summarize:
+
+- Current objective
+- Current phase
+- Completed work
+- Active constraints
+- Decisions already made
+- Open questions
+- Next safe action
+
+Separate confirmed facts from assumptions.
+Do not make code changes yet.
+```
+
+## Rule
+
+Do not maximize context. Maximize relevant, structured signal.

--- a/skills/.curated/ai-native-controlled-implementation/LICENSE.txt
+++ b/skills/.curated/ai-native-controlled-implementation/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-controlled-implementation/SKILL.md
+++ b/skills/.curated/ai-native-controlled-implementation/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: ai-native-controlled-implementation
+description: "Use when implementing from docs/implementation-plan.md in small validated batches with progress tracking, pause discipline, and MVP boundaries."
+---
+
+# AI Native Controlled Implementation
+
+Use this skill to implement a planned project without allowing scope drift or uncontrolled generation.
+
+## Workflow
+
+1. Re-anchor before editing.
+   - Read `docs/implementation-plan.md`.
+   - Read `docs/progress.md` if it exists.
+   - Inspect the repo state before changing files.
+   - Identify the smallest coherent batch that moves the MVP toward its first testable state.
+
+2. Enforce MVP scope.
+   - Implement only tasks needed for the current MVP batch.
+   - Do not add future-phase features, polish, or speculative abstractions.
+   - Preserve architectural boundaries defined in the plan.
+
+3. Maintain `docs/progress.md`.
+   - Create the file when missing.
+   - Derive tasks from `docs/implementation-plan.md`.
+   - Update the `Last updated` date whenever modifying the file.
+   - Do not turn progress into an implementation log.
+
+4. Implement one logical batch.
+   - Keep changes closely scoped.
+   - Run appropriate verification for the changed surface.
+   - Work through local failures before reporting completion.
+
+5. Pause at a batch boundary unless the user explicitly asked for continued multi-batch execution.
+   - Summarize what changed.
+   - State what is now testable.
+   - List known limitations and remaining MVP work.
+   - Do not continue beyond the first testable MVP state without explicit instruction.
+
+## Progress File Structure
+
+`docs/progress.md` must follow this structure:
+
+```markdown
+# <Project Name> Implementation Progress
+
+Last updated: YYYY-MM-DD
+
+## Summary
+
+- High-level bullet summary of the current implementation state.
+
+## Milestones Checklist
+
+### Phase X - <Phase Name>
+
+- [ ] Task description
+- [x] Completed task
+- [ ] Blocked task (Blocked: reason)
+- [ ] Deferred task (Deferred)
+```
+
+Use only `[ ]` and `[x]` as task statuses.
+
+See `references/implementation-rules.md` for the full kickoff prompt and boundary rules.

--- a/skills/.curated/ai-native-controlled-implementation/agents/openai.yaml
+++ b/skills/.curated/ai-native-controlled-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Controlled Implementation"
+  short_description: "Build in bounded validated batches"
+  default_prompt: "Use $ai-native-controlled-implementation to implement the MVP in small validated batches."

--- a/skills/.curated/ai-native-controlled-implementation/references/implementation-rules.md
+++ b/skills/.curated/ai-native-controlled-implementation/references/implementation-rules.md
@@ -1,0 +1,55 @@
+# Controlled Implementation Rules
+
+Use this reference while implementing from `docs/implementation-plan.md`.
+
+## Kickoff Prompt
+
+```text
+Start implementing the project according to `docs/implementation-plan.md`.
+
+Scope Constraints:
+
+- Only implement tasks necessary to reach the first testable state of the MVP.
+- Do not implement features beyond the defined MVP scope.
+- Respect architectural boundaries defined in the plan.
+- Maintain coherence with the existing project structure.
+
+Execution Rules:
+
+- Implement in small, logically grouped batches.
+- After completing each major task group, pause.
+- Summarize all changes made.
+- Clearly describe what is now testable.
+- Wait for user validation before continuing.
+
+Progress Tracking:
+
+Create or update `docs/progress.md`.
+
+Stop Condition:
+
+Stop once a minimally testable version of the MVP is achieved.
+```
+
+## Progress Rules
+
+- Tasks must be derived from `docs/implementation-plan.md`.
+- Each task must be actionable and concrete.
+- Use only `[ ]` and `[x]`.
+- Append `(Blocked: reason)` when blocked.
+- Append `(Deferred)` when intentionally postponed.
+- Do not change the file structure.
+- Do not invent new sections.
+- Do not include implementation logs.
+- Do not duplicate plan content.
+- Always update `Last updated` when modifying the file.
+
+## Batch Boundary Summary
+
+At each stop, report:
+
+- What changed
+- What is testable
+- What remains incomplete
+- Known limitations
+- Suggested next step

--- a/skills/.curated/ai-native-implementation-plan/LICENSE.txt
+++ b/skills/.curated/ai-native-implementation-plan/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-implementation-plan/SKILL.md
+++ b/skills/.curated/ai-native-implementation-plan/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: ai-native-implementation-plan
+description: "Use when converting a clarified software problem into an MVP-first phased roadmap with scope, risks, dependencies, and validation criteria."
+---
+
+# AI Native Implementation Plan
+
+Use this skill after problem definition is stable enough to plan execution. The goal is not to design the final system in full; it is to create a bounded MVP and a phased path forward.
+
+## Workflow
+
+1. Re-anchor on the problem.
+   - Load or request the problem statement, target user, candidate solution, constraints, platform, and success criteria.
+   - Refuse to plan around vague ambition; return to problem definition if key inputs are missing.
+
+2. Define the MVP sharply.
+   - Make Phase 1 the smallest system that validates the core hypothesis.
+   - State what is included, what is excluded, and what hypothesis is being tested.
+   - If the MVP cannot fit in one concise paragraph, narrow it.
+
+3. Produce a phased roadmap.
+   - For each phase include objective, scope, key deliverables, dependencies, risks, and validation criteria.
+   - Add value incrementally without forcing rework of prior structure.
+   - Keep architectural stability visible between phases.
+
+4. Recommend a practical tech stack.
+   - Optimize for the problem, constraints, deployment path, and maintenance burden.
+   - Avoid premature optimization and unnecessary infrastructure.
+
+5. Critique the draft plan.
+   - Identify hidden complexity, unrealistic ordering, scope creep, unstable architecture, and weak validation criteria.
+   - Revise only after making the concern explicit.
+
+## Required Output
+
+Produce copy-pastable markdown suitable for `docs/implementation-plan.md` unless the user asks for a different artifact.
+
+The plan must contain:
+
+- Original problem traceability
+- MVP hypothesis
+- MVP included scope
+- MVP excluded scope
+- Recommended tech stack
+- Phased roadmap
+- Validation criteria for each phase
+- Risks and dependencies
+- Open clarifications
+
+## Stop Condition
+
+Stop when the roadmap is coherent, bounded, and aligned with the original problem. Do not start implementation.
+
+See `references/plan-template.md` for the canonical prompt and output shape.

--- a/skills/.curated/ai-native-implementation-plan/agents/openai.yaml
+++ b/skills/.curated/ai-native-implementation-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Implementation Plan"
+  short_description: "MVP-first phased planning workflow"
+  default_prompt: "Use $ai-native-implementation-plan to convert my problem definition into an MVP-first implementation plan."

--- a/skills/.curated/ai-native-implementation-plan/references/plan-template.md
+++ b/skills/.curated/ai-native-implementation-plan/references/plan-template.md
@@ -1,0 +1,83 @@
+# Implementation Plan Template
+
+Use this reference to produce an MVP-first phased roadmap.
+
+## Canonical Planning Prompt
+
+```text
+Generate a structured development plan for this project based on the defined problem statement.
+
+The plan must:
+
+1. Be divided into clearly defined phases.
+2. Isolate a sharply scoped MVP as Phase 1.
+3. Explicitly state what is included and excluded from the MVP.
+4. Define the hypothesis the MVP is validating.
+5. Decompose subsequent phases into incremental expansions.
+6. Preserve architectural stability between phases.
+7. Avoid unnecessary complexity.
+8. Prevent premature optimization.
+9. Suggest a recommended tech stack optimized for the problem requirements.
+
+For each phase, include:
+
+- Objective
+- Scope
+- Key deliverables
+- Dependencies
+- Risks
+- Validation criteria
+
+Constraints:
+
+- Do not design the final system in full detail upfront.
+- Favor progressive complexity over full-system design.
+- Maintain traceability to the original problem.
+- Avoid introducing features that do not directly serve the core problem.
+
+Output the development plan in structured copy-pastable markdown.
+```
+
+## Recommended Plan Shape
+
+```markdown
+# <Project Name> Implementation Plan
+
+## Problem Traceability
+
+## MVP Definition
+
+### Hypothesis
+
+### Included
+
+### Excluded
+
+### First Testable State
+
+## Recommended Tech Stack
+
+## Phase 1 - MVP
+
+### Objective
+### Scope
+### Deliverables
+### Dependencies
+### Risks
+### Validation Criteria
+
+## Phase 2 - <Expansion>
+
+## Phase 3 - <Expansion>
+
+## Open Questions
+```
+
+## Review Checklist
+
+- Is Phase 1 the smallest system that tests the core hypothesis?
+- Are exclusions explicit?
+- Does each phase add coherent value?
+- Are dependencies ordered logically?
+- Are validation criteria observable?
+- Did any feature appear without a direct link to the original problem?

--- a/skills/.curated/ai-native-problem-definition/LICENSE.txt
+++ b/skills/.curated/ai-native-problem-definition/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-problem-definition/SKILL.md
+++ b/skills/.curated/ai-native-problem-definition/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ai-native-problem-definition
+description: "Use when shaping a new software idea before planning: pressure-test problem, assumptions, constraints, platform, MVP direction, and project name."
+---
+
+# AI Native Problem Definition
+
+Use this skill to turn an early software idea into bounded clarity before any implementation planning.
+
+## Workflow
+
+1. Establish the concrete problem.
+   - Identify who experiences it, how often it occurs, and what it costs when unsolved.
+   - Reject vague framing such as "I want to build an app" until the friction is observable.
+
+2. Pressure-test the user's initial direction.
+   - Ask what weakness, edge case, constraint, or simpler framing may invalidate the idea.
+   - Distinguish root problem from symptom.
+   - Compare the candidate solution against at least one simpler alternative when useful.
+
+3. Define constraints and non-goals.
+   - Capture platform, distribution, data, privacy, time, budget, integration, maintenance, and user-behavior constraints.
+   - Mark assumptions explicitly instead of treating them as facts.
+
+4. Choose the platform intentionally.
+   - Explain tradeoffs for web, mobile, CLI, backend service, browser extension, or other candidates.
+   - Treat platform as an architectural constraint, not a default.
+
+5. Use naming as a stress test.
+   - Generate project-name candidates only after the problem and direction are stable enough.
+   - Flag naming difficulty as a possible sign of scope ambiguity.
+
+6. Summarize and iterate.
+   - After each major clarification, restate the current understanding.
+   - If the summary does not match the user's intent, continue refinement instead of moving to planning.
+
+## Required Output
+
+When the phase is complete, produce a concise artifact containing:
+
+- Problem statement
+- Target user or context
+- Cost of the unsolved problem
+- Candidate solution direction
+- Key assumptions
+- Constraints and non-goals
+- Chosen platform and rationale
+- Success criteria
+- Project name or naming shortlist
+- Open questions, if any
+
+## Stop Condition
+
+Do not generate an implementation plan until the problem can be stated clearly and defended under critique.
+
+See `references/phase-1-checklist.md` for the full checklist and reusable critique questions.

--- a/skills/.curated/ai-native-problem-definition/agents/openai.yaml
+++ b/skills/.curated/ai-native-problem-definition/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Problem Definition"
+  short_description: "Pressure-test an idea into clarity"
+  default_prompt: "Use $ai-native-problem-definition to turn my project idea into a clear, bounded problem statement."

--- a/skills/.curated/ai-native-problem-definition/references/phase-1-checklist.md
+++ b/skills/.curated/ai-native-problem-definition/references/phase-1-checklist.md
@@ -1,0 +1,49 @@
+# Phase 1 Checklist
+
+Use this reference when the user is shaping an early software idea.
+
+## Core Questions
+
+- Who experiences the problem?
+- How often does it happen?
+- What is the cost of not solving it?
+- What current workaround exists?
+- What makes the problem observable?
+- What constraints could invalidate the solution?
+- What simpler framing might solve the same problem?
+- Is the proposed solution addressing the root problem or only a symptom?
+
+## Critique Prompts
+
+Ask direct questions such as:
+
+- What are the weaknesses in this approach?
+- What edge cases are being ignored?
+- What constraints might invalidate this?
+- Is there a simpler framing?
+- What would make this project fail even if the implementation works?
+
+## Platform Tradeoffs
+
+Evaluate platform intentionally:
+
+- Web app: easiest distribution, browser constraints, hosting and auth considerations.
+- Mobile app: strong device integration, app-store and install friction.
+- CLI: excellent for technical users, poor for nontechnical adoption.
+- Backend service: useful for integrations and automation, needs API and ops discipline.
+- Browser extension: close to browsing workflows, permission and maintenance constraints.
+
+## Naming Test
+
+Use naming to detect conceptual ambiguity. A good name should reflect the core function, avoid feature-level specificity, avoid trend language, and fit the intended user context.
+
+## Completion Artifact
+
+The phase is complete when this can be written clearly:
+
+- Problem statement
+- Candidate solution direction
+- Constraints and non-goals
+- Platform choice
+- Stable summary
+- Project name or naming direction

--- a/skills/.curated/ai-native-project-foundation/LICENSE.txt
+++ b/skills/.curated/ai-native-project-foundation/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-project-foundation/SKILL.md
+++ b/skills/.curated/ai-native-project-foundation/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ai-native-project-foundation
+description: "Use when setting up a project workspace from a plan: persist docs/implementation-plan.md, review ambiguities, and establish version control."
+---
+
+# AI Native Project Foundation
+
+Use this skill after a phased implementation plan exists. The goal is to create structural readiness before implementation begins.
+
+## Workflow
+
+1. Inspect the workspace first.
+   - Identify whether the user is in an existing repo or creating a new project.
+   - Do not overwrite existing plans or source files without reading them.
+   - If no workspace is clear, ask for the target directory.
+
+2. Persist the plan.
+   - Create `docs/implementation-plan.md` when missing.
+   - Use the previously generated plan as source material.
+   - Keep the file structured for software engineers, not as conversational notes.
+
+3. Run an agent-led plan review.
+   - Surface ambiguous requirements, missing constraints, hidden complexity, unrealistic phase boundaries, architectural risks, and implicit assumptions.
+   - Do not silently rewrite the plan before exposing uncertainties.
+
+4. Resolve clarifications.
+   - Ask concise questions when the plan cannot be made structurally coherent.
+   - Update `docs/implementation-plan.md` only after the clarification is available or a conservative assumption is justified.
+
+5. Establish version-control readiness.
+   - If git is already present, report the current branch and dirty state.
+   - If no version control exists and the user asked to establish the foundation, initialize it or ask first when the target is ambiguous.
+   - Do not begin implementation during this skill.
+
+## Required Output
+
+- Created or confirmed project workspace
+- Created or updated `docs/implementation-plan.md`
+- Plan-review findings and clarifications
+- Version-control status
+- Readiness statement for controlled implementation
+
+## Stop Condition
+
+Stop when the plan is persisted, reviewed, clarified, and structurally stable. Do not start coding the MVP.
+
+See `references/foundation-checklist.md` for the persistence prompt and plan-review checklist.

--- a/skills/.curated/ai-native-project-foundation/agents/openai.yaml
+++ b/skills/.curated/ai-native-project-foundation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Project Foundation"
+  short_description: "Persist and stress-test the plan"
+  default_prompt: "Use $ai-native-project-foundation to create the project foundation and persist the implementation plan."

--- a/skills/.curated/ai-native-project-foundation/references/foundation-checklist.md
+++ b/skills/.curated/ai-native-project-foundation/references/foundation-checklist.md
@@ -1,0 +1,50 @@
+# Foundation Checklist
+
+Use this reference after an implementation plan exists and before coding begins.
+
+## Plan Persistence Prompt
+
+```text
+Produce a structured, phased development plan for an audience of software engineers based on:
+
+<Previously-generated-development-plan>
+
+Separate MVP from subsequent phases.
+
+Persist the output in `docs/implementation-plan.md`.
+```
+
+## Agent-Led Plan Review Prompt
+
+```text
+Review `docs/implementation-plan.md` critically.
+
+Identify:
+
+- Ambiguous requirements
+- Missing constraints
+- Hidden complexity
+- Unrealistic phase boundaries
+- Architectural instability risks
+- Implicit assumptions that require clarification
+
+For each issue found:
+
+- Explain the concern
+- Ask for explicit clarification
+- Suggest a possible refinement if appropriate
+
+Do not modify the plan yet.
+First, surface uncertainties and request precision.
+```
+
+## Workspace Readiness
+
+Confirm:
+
+- The target project directory is clear.
+- `docs/implementation-plan.md` exists and matches the accepted plan.
+- The plan has been reviewed for ambiguity.
+- Clarifications are resolved or listed explicitly.
+- Version control exists or is intentionally initialized.
+- No MVP implementation has started before foundation readiness.

--- a/skills/.curated/ai-native-software-engineering/LICENSE.txt
+++ b/skills/.curated/ai-native-software-engineering/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-software-engineering/SKILL.md
+++ b/skills/.curated/ai-native-software-engineering/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ai-native-software-engineering
+description: "Use when applying the AI Native Software Engineering lifecycle across problem definition, planning, foundation, implementation, and improvement."
+---
+
+# AI Native Software Engineering
+
+Use this umbrella skill when the user asks to apply the methodology broadly or does not specify which lifecycle phase they are in.
+
+## Phase Router
+
+Choose the narrowest phase skill that matches the user's current need:
+
+1. Use `ai-native-problem-definition` when the project is still an idea, problem, opportunity, or vague solution direction.
+2. Use `ai-native-implementation-plan` when the problem is clear and the user needs an MVP-first phased roadmap.
+3. Use `ai-native-project-foundation` when a plan exists and the user needs a controlled workspace, persisted plan, plan review, and version-control readiness.
+4. Use `ai-native-controlled-implementation` when the user is ready to implement from `docs/implementation-plan.md`.
+5. Use `ai-native-structured-improvement` when an MVP works and the user wants hardening, review, technical debt, or guidelines.
+6. Use `ai-native-context-discipline` when the session is long, confusing, drifting, or needs a reset.
+
+## Lifecycle Rules
+
+- Specification precedes implementation.
+- Constraints precede generation.
+- Verification precedes merge.
+- Clarity precedes speed.
+- Ambiguity compounds.
+- Structure scales.
+
+## Artifact Model
+
+Prefer durable project artifacts over conversational state:
+
+- `docs/implementation-plan.md`
+- `docs/progress.md`
+- `docs/project-guidelines.md`
+- `docs/technical-debt.md`
+
+## Output
+
+State the detected phase, the selected skill or workflow, and the next concrete action. If phase is ambiguous, ask one concise clarification or make the safest conservative assumption.
+
+See `references/lifecycle.md` for the full phase map.

--- a/skills/.curated/ai-native-software-engineering/agents/openai.yaml
+++ b/skills/.curated/ai-native-software-engineering/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Software Engineering"
+  short_description: "Route work through the AI-native lifecycle"
+  default_prompt: "Use $ai-native-software-engineering to guide this project through the right AI-native engineering phase."

--- a/skills/.curated/ai-native-software-engineering/references/lifecycle.md
+++ b/skills/.curated/ai-native-software-engineering/references/lifecycle.md
@@ -1,0 +1,74 @@
+# AI Native Software Engineering Lifecycle
+
+Use this reference to route broad methodology requests to the right phase.
+
+## Phase 1 - Identify the Problem
+
+Objective: replace enthusiasm with structured clarity.
+
+Deliverables:
+
+- Precise problem statement
+- Candidate solution direction
+- Constraints
+- Chosen platform
+- Stable conceptual summary
+- Project name
+
+Transition: the problem can be articulated clearly and defended under critique.
+
+## Phase 2 - Translate to a Structured Plan
+
+Objective: convert clarity into a phased execution roadmap.
+
+Deliverables:
+
+- MVP definition
+- Phased roadmap
+- Recommended tech stack
+- Validation criteria
+
+Transition: the plan is coherent, bounded, and aligned with the original problem.
+
+## Phase 3 - Establish the Foundation
+
+Objective: create a controlled execution environment.
+
+Deliverables:
+
+- Project workspace
+- Persisted `docs/implementation-plan.md`
+- Plan review and clarifications
+- Version control readiness
+
+Transition: the plan is persisted, clarified, reviewed, and structurally stable.
+
+## Phase 4 - Controlled Implementation
+
+Objective: execute the plan in bounded, validated increments.
+
+Deliverables:
+
+- MVP implementation batches
+- `docs/progress.md`
+- Verification results
+- First testable system state
+
+Transition: the MVP reaches a stable, testable state.
+
+## Phase 5 - Structured Improvement
+
+Objective: strengthen durability without expanding scope.
+
+Deliverables:
+
+- `docs/project-guidelines.md`
+- Expanded verification where useful
+- AI-assisted pre-merge review
+- `docs/technical-debt.md`
+
+Transition: system stability is reinforced and technical risk is visible.
+
+## Lifecycle Loop
+
+After Phase 5, return to Phase 2 for the next product expansion cycle.

--- a/skills/.curated/ai-native-structured-improvement/LICENSE.txt
+++ b/skills/.curated/ai-native-structured-improvement/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/.curated/ai-native-structured-improvement/SKILL.md
+++ b/skills/.curated/ai-native-structured-improvement/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: ai-native-structured-improvement
+description: "Use after a functional MVP to harden durability without scope creep: guidelines, verification, expert review, code review, and technical debt."
+---
+
+# AI Native Structured Improvement
+
+Use this skill after the MVP works. The objective is durability, not new capability.
+
+## Workflow
+
+1. Re-anchor on the working MVP.
+   - Confirm what behavior is already functional.
+   - Identify current tests, critical paths, and known risks.
+   - Do not add features unless the user explicitly asks for a new planning cycle.
+
+2. Generate and curate `docs/project-guidelines.md`.
+   - Draft constraints from the real codebase.
+   - Remove generic advice, boilerplate, and redundant rules.
+   - Keep only project-specific architectural invariants and non-negotiable constraints.
+
+3. Strengthen verification before risky changes.
+   - Add or improve tests around critical behavior when practical.
+   - Prefer tests before refactoring behavior.
+   - If tests are not feasible, state the residual risk.
+
+4. Run targeted expert review passes.
+   - Use focused lenses such as performance, maintainability, security, refactoring, data model, or UX.
+   - Ask for risks and simplifications, not broad rewrites.
+
+5. Perform AI-assisted pre-merge review when on a feature branch.
+   - Compare the branch against main or the appropriate base branch.
+   - Prioritize logical errors, behavioral regressions, architectural inconsistency, guideline violations, hidden complexity, and missing tests.
+   - Do not rewrite code during the review pass unless the user asks to fix findings.
+
+6. Generate `docs/technical-debt.md`.
+   - Convert review findings into a technical backlog.
+   - Include description, risk level, expected benefit, estimated complexity, and priority.
+
+## Required Output
+
+- Concise project guidelines, if requested or missing
+- Verification gaps and test improvements
+- Targeted review findings
+- Technical debt roadmap
+- Recommended next improvement batch
+
+## Boundary Rule
+
+Improvement must strengthen the existing system. It must not expand product scope.
+
+See `references/improvement-playbook.md` for review prompts and debt templates.

--- a/skills/.curated/ai-native-structured-improvement/agents/openai.yaml
+++ b/skills/.curated/ai-native-structured-improvement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Native Structured Improvement"
+  short_description: "Harden an MVP without scope creep"
+  default_prompt: "Use $ai-native-structured-improvement to harden this MVP without expanding scope."

--- a/skills/.curated/ai-native-structured-improvement/references/improvement-playbook.md
+++ b/skills/.curated/ai-native-structured-improvement/references/improvement-playbook.md
@@ -1,0 +1,69 @@
+# Structured Improvement Playbook
+
+Use this reference after the MVP works and the goal is durability.
+
+## Project Guidelines
+
+`docs/project-guidelines.md` should be short and specific. Keep:
+
+- Architectural invariants
+- Non-negotiable constraints
+- Testing expectations for critical paths
+- Data, API, deployment, or state-management rules that are project-specific
+
+Remove:
+
+- Generic coding advice
+- Boilerplate
+- Redundant rules
+- Long tutorials
+
+## AI-Assisted Code Review Prompt
+
+```text
+Review the changes in this feature branch compared to the main branch.
+
+Analyze the diff for:
+
+- Logical errors
+- Edge cases
+- Unintended behavioral changes
+- Performance regressions
+- Architectural inconsistencies
+- Violations of `docs/project-guidelines.md`
+- Increased coupling or hidden complexity
+- Missing test coverage (if tests exist)
+
+For each issue:
+
+- Explain the risk clearly.
+- Classify severity (low, medium, high).
+- Suggest corrective action.
+- Indicate whether it should block the merge.
+
+Do not rewrite the code.
+Focus on analysis and risk identification.
+```
+
+## Technical Debt Template
+
+```markdown
+# Technical Debt Roadmap
+
+## <Item Title>
+
+- Description:
+- Risk level:
+- Expected benefit:
+- Estimated complexity:
+- Suggested priority:
+- Related files or systems:
+```
+
+## Refactoring Rules
+
+- Do not change external behavior unintentionally.
+- Protect changes with tests when possible.
+- Refactor in isolated commits.
+- Re-run verification after each improvement.
+- Treat new feature work as a new planning cycle.


### PR DESCRIPTION
## Summary

Adds a seven-skill AI Native Software Engineering suite to `skills/.curated`:

- `ai-native-software-engineering` lifecycle router
- `ai-native-problem-definition`
- `ai-native-implementation-plan`
- `ai-native-project-foundation`
- `ai-native-controlled-implementation`
- `ai-native-structured-improvement`
- `ai-native-context-discipline`

The suite packages a methodology for moving from problem definition through planning, foundation setup, controlled implementation, structured improvement, and long-session context discipline.

## Validation

- Ran `quick_validate.py` on all seven copied skill folders.
- Ran `git diff --check`.
- Each skill includes `LICENSE.txt` with Apache License 2.0 text.