### PR TITLE
Fix skill-creator YAML frontmatter generation

### DIFF
--- a/skills/.system/skill-creator/SKILL.md
+++ b/skills/.system/skill-creator/SKILL.md
@@ -339,6 +339,7 @@ Write the YAML frontmatter with `name` and `description`:
   - Include both what the Skill does and specific triggers/contexts for when to use it.
   - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Codex.
   - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Codex needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+- When generating or editing frontmatter, keep values YAML-safe. Quote any description that contains `:`, `#`, `"`, `'`, or other special characters, or emit the frontmatter through a serializer instead of hand-writing bare text.
 
 Do not include any other fields in YAML frontmatter.
 

--- a/skills/.system/skill-creator/scripts/init_skill.py
+++ b/skills/.system/skill-creator/scripts/init_skill.py
@@ -14,6 +14,7 @@ Examples:
 """
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -23,11 +24,25 @@ from generate_openai_yaml import write_openai_yaml
 MAX_SKILL_NAME_LENGTH = 64
 ALLOWED_RESOURCES = {"scripts", "references", "assets"}
 
-SKILL_TEMPLATE = """---
-name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
----
+SKILL_DESCRIPTION = (
+    "[TODO: Complete and informative explanation of what the skill does and when to use it. "
+    "Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]"
+)
 
+
+def render_skill_frontmatter(skill_name):
+    """Render skill frontmatter with YAML-safe quoted scalars."""
+    return "\n".join(
+        [
+            "---",
+            f"name: {json.dumps(skill_name)}",
+            f"description: {json.dumps(SKILL_DESCRIPTION)}",
+            "---",
+        ]
+    )
+
+
+SKILL_TEMPLATE = """{frontmatter}
 # {skill_title}
 
 ## Overview
@@ -286,7 +301,10 @@ def init_skill(skill_name, path, resources, include_examples, interface_override
 
     # Create SKILL.md from template
     skill_title = title_case_skill_name(skill_name)
-    skill_content = SKILL_TEMPLATE.format(skill_name=skill_name, skill_title=skill_title)
+    skill_content = SKILL_TEMPLATE.format(
+        frontmatter=render_skill_frontmatter(skill_name),
+        skill_title=skill_title,
+    )
 
     skill_md_path = skill_dir / "SKILL.md"
     try:

--- a/skills/.system/skill-creator/scripts/quick_validate.py
+++ b/skills/.system/skill-creator/scripts/quick_validate.py
@@ -35,7 +35,11 @@ def validate_skill(skill_path):
         if not isinstance(frontmatter, dict):
             return False, "Frontmatter must be a YAML dictionary"
     except yaml.YAMLError as e:
-        return False, f"Invalid YAML in frontmatter: {e}"
+        return (
+            False,
+            f"Invalid YAML in frontmatter: {e} "
+            "Hint: quote special characters in frontmatter values, or emit frontmatter with a YAML serializer.",
+        )
 
     allowed_properties = {"name", "description", "license", "allowed-tools", "metadata"}
 


### PR DESCRIPTION
## Summary
- Emit generated SKILL.md frontmatter with quoted scalars so YAML-sensitive characters in the placeholder description do not create malformed YAML.
- Add a validator hint for YAML parse failures that points users toward quoting or serializer-generated frontmatter.
- Document the YAML-safe frontmatter requirement in the skill-creator instructions.

Fixes #276.

## Validation
- git diff --check
- Manually exercised the generated frontmatter format and confirmed the placeholder description containing ':' is emitted as a quoted scalar.
- python3 skills/.system/skill-creator/scripts/quick_validate.py skills/.system/skill-creator could not run in this environment because PyYAML is not installed (existing script dependency).