### PR TITLE
Add FastMCP skill

### DIFF
--- a/skills/.curated/fastmcp/LICENSE.txt
+++ b/skills/.curated/fastmcp/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/fastmcp/SKILL.md
+++ b/skills/.curated/fastmcp/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: fastmcp
+description: Build, test, inspect, package, or deploy Python MCP servers with FastMCP. Use when creating MCP tools/resources/prompts, wrapping an API or database as an MCP server, debugging stdio/HTTP MCP transport, generating clients from server schemas, or preparing an MCP server for Codex, ChatGPT Apps, Claude Desktop, or other MCP clients.
+---
+
+# FastMCP
+
+Use this skill for Python MCP servers built with FastMCP. Prefer the current project conventions when an MCP server already exists; otherwise create a small, explicit server module that can run locally before adding deployment or client configuration.
+
+## Validated Version Evidence
+
+This guidance was checked against mined repositories using `fastmcp` 2.12.5, 3.2.0, 3.2.4, and 3.3.0, plus `mcp` 1.12.4 through 1.27.0. The CLI and transport surface changes across those versions, so capture installed versions before relying on a specific command:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["fastmcp", "mcp"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to leave the user with a working MCP server or a precise compatibility diagnosis. A complete run produces:
+
+- The installed `fastmcp`/`mcp` versions and chosen transport.
+- A minimal server entrypoint or a patch to the repo's existing server.
+- A list of discoverable tools/resources/prompts from an MCP client or inspector.
+- At least one read-only tool call result, and one write/action call result when the server exposes side effects.
+- Client configuration notes for Codex, ChatGPT Apps, Claude Desktop, or the target runtime.
+
+## Standalone Quick Start
+
+If the project has no server yet, create the smallest server that proves FastMCP works:
+
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("demo")
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+Run it locally, then inspect it with the MCP client or inspector available in that FastMCP version. If the project already has a server, do not replace it; add one narrow tool/resource and verify discovery.
+
+## Workflow
+
+1. Inspect the repo for existing MCP code, package tooling, and runtime entrypoints.
+2. Identify the client target: Codex, ChatGPT Apps, Claude Desktop, a web service, or a custom MCP client.
+3. Choose transport deliberately:
+   - `stdio` for local desktop/client integrations.
+   - `streamable-http` or HTTP/SSE for hosted or multi-client access.
+4. Define a narrow capability surface: tools for actions, resources for readable state, prompts for reusable task templates.
+5. Add input validation and clear error messages before wiring external APIs or databases.
+6. Run the server locally and inspect the exposed tools/resources before declaring it complete.
+
+## Client Configuration Checklist
+
+- `stdio`: record the command, working directory, and required environment variables.
+- HTTP/streamable HTTP: record host, port, auth method, CORS/origin requirements, and health endpoint if present.
+- Desktop clients: provide the exact server config block only after confirming the entrypoint command works.
+- Hosted clients: state how secrets are injected and which tools have side effects.
+
+## References
+
+Open `references/workflows.md` for detailed server design, client configuration, testing, auth, transport, deployment, and review workflows.
+
+Open `references/mastery.md` for MCP design principles, primitive selection, schema quality, transport tradeoffs, security boundaries, and review standards.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in mined/source repository evidence.
+
+## Implementation Guidance
+
+- Keep tool names stable, verb-oriented, and specific.
+- Use typed function signatures and docstrings; MCP clients use these as interface documentation.
+- Return structured JSON-compatible data for tools unless the client specifically expects text.
+- Avoid hidden writes. Tool names and descriptions should make side effects obvious.
+- For network or filesystem actions, document required environment variables and permissions in the server code or project docs.
+- Keep authentication outside the prompt surface: read tokens from environment variables, keychains, or the hosting platform secret store.
+
+## Local Checks
+
+Use the package manager already present in the repository. Typical checks:
+
+```bash
+python -m pytest
+python <server-file>
+```
+
+Before testing through a client, verify the server module imports cleanly and registers its decorators:
+
+```bash
+python - <<'PY'
+import importlib.util
+
+path = "<server-file>"
+spec = importlib.util.spec_from_file_location("mcp_server_under_test", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+print(f"loaded {path}")
+PY
+```
+
+Replace `<server-file>` with the actual entrypoint discovered in the repository. Then run the server and use the project-supported MCP client, SDK, `fastmcp dev`, or MCP Inspector to list tools/resources and call one read-only tool. Prefer capability discovery from the client protocol over assuming a command exists in every FastMCP version.
+
+## Debugging
+
+- If a client sees no tools, verify the server process starts cleanly and that tool decorators execute at import time.
+- If calls hang, check whether a synchronous tool is doing blocking network or subprocess work without timeouts.
+- If JSON schema generation fails, simplify annotations to standard Python types or Pydantic models.
+- If hosted auth fails, confirm the server can read the same environment variables in the deployed runtime.
+
+## Done Criteria
+
+- The server starts from a documented command.
+- Tools/resources/prompts are discoverable by an MCP client or inspector.
+- At least one read-only call and one representative write/action call are tested when applicable.
+- Required secrets, network access, and side effects are explicit.
+- The final notes include the client config or the exact reason it cannot be produced.

--- a/skills/.curated/fastmcp/agents/openai.yaml
+++ b/skills/.curated/fastmcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FastMCP"
+  short_description: "Build and debug Python MCP servers"
+  default_prompt: "Use $fastmcp to create or update a FastMCP server for this project."

--- a/skills/.curated/fastmcp/references/mastery.md
+++ b/skills/.curated/fastmcp/references/mastery.md
@@ -1,0 +1,54 @@
+# FastMCP Mastery Notes
+
+## Mental Model
+
+An MCP server is a capability boundary between an AI client and external state. The server must make capabilities discoverable, typed, safe, and testable.
+
+## Primitive Selection
+
+- Use **tools** for operations the model invokes.
+- Use **resources** for readable state the model can inspect.
+- Use **prompts** for reusable task templates.
+
+Do not expose a write operation as a resource. Do not hide side effects behind vague names like `run` or `process`.
+
+## Schema Quality
+
+Good tool schemas:
+
+- use typed parameters
+- describe required fields
+- avoid arbitrary string blobs when structured inputs are possible
+- return stable JSON-compatible fields
+- include actionable errors
+
+## Transport Decisions
+
+Use stdio for local desktop/client workflows. Use HTTP/streamable HTTP for hosted, multi-client, or remotely managed servers. Record timeout, auth, and lifecycle expectations.
+
+## Safety Boundaries
+
+Before adding a tool, classify it:
+
+```text
+read-only
+write/action
+networked
+filesystem
+secret-dependent
+destructive
+```
+
+Destructive tools need explicit names, narrow inputs, and confirmation handled outside prompt text when possible.
+
+## Review Standard
+
+A complete FastMCP change proves:
+
+- server starts
+- capabilities are discoverable
+- schema descriptions are useful
+- at least one read-only call works
+- side effects are documented
+- secrets are not accepted through prompt text
+- client config is provided or blocker is explicit

--- a/skills/.curated/fastmcp/references/source-evidence.md
+++ b/skills/.curated/fastmcp/references/source-evidence.md
@@ -1,0 +1,49 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. It is not a replacement for the workflows and mastery references; it explains which real repository patterns the skill is expected to cover.
+
+## Retrieved Sources
+
+- `OpenHands/OpenHands`: dependency evidence for `fastmcp>=3.2,<4`, `mcp>=1.25`, and lock evidence for `fastmcp` 3.2.4.
+- `pydantic/pydantic-ai`: optional MCP extras, `fastmcp` dependency paths, and lock evidence for `fastmcp` 3.3.0 / `fastmcp-slim` 3.3.0.
+- `modelcontextprotocol/python-sdk`: source package using `mcp[cli,ws]` and the Python SDK entrypoint model.
+- `lastmile-ai/mcp-agent`: agent runtime dependency evidence for `mcp>=1.20.0`.
+
+## Workflows Reflected In The Skill
+
+### Server Capability Design
+
+The skill must teach an agent to design a server around MCP primitives, not just import `FastMCP`. Evidence from source repos shows MCP used as an integration boundary for agents and applications, so the skill covers:
+
+- Choosing tools for actions, resources for readable state, and prompts for reusable task templates.
+- Keeping tool names stable and side-effect descriptions explicit.
+- Returning structured, JSON-compatible outputs rather than unstructured prose when clients need to compose results.
+
+### Version And Transport Diagnosis
+
+The mined repos include FastMCP 2.x and 3.x era packages plus MCP SDK 1.20+ through 1.27. Because CLI and transport names can move, the skill requires version capture before recommending a command. It also requires choosing transport by client target:
+
+- `stdio` for desktop and local agent clients.
+- HTTP/SSE/streamable HTTP for hosted, multi-client, or web deployments.
+- Explicit client configuration only after the server entrypoint has been run locally.
+
+### Inspection And Client Compatibility
+
+The source repos use MCP to connect server capabilities to clients, so the skill requires protocol-level discovery:
+
+- List exposed tools/resources/prompts from an MCP client or inspector.
+- Call at least one read-only tool before claiming success.
+- Call a side-effecting tool only when the server exposes one and the test environment is safe.
+- Diagnose empty discovery by checking import-time registration, process startup, and transport mismatch.
+
+### Deployment And Security
+
+MCP servers frequently bridge local secrets, remote APIs, and filesystem/network access. The skill therefore requires:
+
+- Environment-variable or secret-store based credentials.
+- Clear permission notes for filesystem, network, and write actions.
+- Hosted deployment notes for auth, CORS/origin handling, and health checks.
+
+## Remaining Review Questions
+
+When reviewing this skill, reject changes that make it a library summary. It must leave a fresh agent able to produce a runnable server, inspect it through MCP, diagnose transport/version problems, and produce client configuration grounded in a verified entrypoint.

--- a/skills/.curated/fastmcp/references/workflows.md
+++ b/skills/.curated/fastmcp/references/workflows.md
@@ -1,0 +1,114 @@
+# FastMCP Workflows
+
+Use these workflows to produce a complete MCP server change rather than a decorator summary.
+
+## Contents
+
+- [Server Design](#server-design)
+- [Local Server Verification](#local-server-verification)
+- [Client Configuration](#client-configuration)
+- [Auth and Secrets](#auth-and-secrets)
+- [Deployment Review](#deployment-review)
+- [Final Artifact](#final-artifact)
+
+## Server Design
+
+1. Name the server for the domain, not the implementation.
+2. List user tasks, then map them to MCP primitives:
+   - Tools: actions or computations.
+   - Resources: readable state or documents.
+   - Prompts: reusable task templates.
+3. Mark every side effect in the tool name, docstring, and final notes.
+4. Keep inputs typed and JSON-compatible.
+5. Return structured results with stable fields.
+
+Tool contract template:
+
+```text
+tool:
+purpose:
+inputs:
+side effects:
+auth/env:
+success response:
+failure modes:
+read-only test:
+```
+
+## Local Server Verification
+
+Run these before client configuration:
+
+```bash
+python -m pytest
+python - <<'PY'
+import importlib.util
+path = "server.py"
+spec = importlib.util.spec_from_file_location("server_under_test", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+print("loaded", path)
+PY
+python server.py
+```
+
+Then use the MCP client, SDK, `fastmcp dev`, or MCP Inspector supported by the installed version to list tools/resources and call at least one read-only tool.
+
+## Client Configuration
+
+For stdio clients, produce:
+
+```json
+{
+  "command": "python",
+  "args": ["server.py"],
+  "cwd": "<repo root>",
+  "env": {
+    "SERVICE_API_KEY": "set outside config when possible"
+  }
+}
+```
+
+For HTTP deployments, record:
+
+```text
+url:
+transport:
+auth:
+headers:
+health check:
+allowed origins:
+timeout:
+```
+
+## Auth and Secrets
+
+- Read secrets from environment, keychain, or hosting secret store.
+- Do not accept secrets as prompt text or tool arguments unless the task is explicitly secret management.
+- Add startup checks for required environment variables.
+- Return actionable errors when auth is missing.
+
+## Deployment Review
+
+Before shipping:
+
+- Confirm process manager or hosting command.
+- Confirm logs do not print secrets.
+- Confirm side-effect tools have names that make writes obvious.
+- Confirm client discovery shows descriptions and schemas.
+- Confirm one representative failure response is useful.
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+server entrypoint:
+transport:
+client config:
+versions:
+tools/resources/prompts discovered:
+tested calls:
+required secrets:
+known side effects:
+```


### PR DESCRIPTION
## Summary

Adds the `fastmcp` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined FastMCP/MCP evidence from FastMCP 2.12.5 through 3.3.0 and MCP 1.12.4 through 1.27.0.

## Validation

- Ran the local skill validator against `skills/.curated/fastmcp`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.