### PR TITLE
Add Hugging Face Transformers skill

### DIFF
--- a/skills/.curated/huggingface-transformers/LICENSE.txt
+++ b/skills/.curated/huggingface-transformers/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/huggingface-transformers/SKILL.md
+++ b/skills/.curated/huggingface-transformers/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: huggingface-transformers
+description: Build, debug, fine-tune, evaluate, or ship models with Hugging Face Transformers. Use when working with AutoModel/AutoTokenizer, pipelines, generation configs, model cards, Trainer or Accelerate integration, model conversion, quantization, multimodal processors, or Transformers examples.
+---
+
+# Hugging Face Transformers
+
+Use this skill for projects built on `transformers`. Prefer official APIs and the repo's existing model-loading conventions over one-off loading code.
+
+## Validated Version Evidence
+
+This guidance was checked against a mined `transformers` source checkout at `transformers` 5.0.0.dev0, plus locked downstream environments using `transformers` 4.57.6 and 5.0.0. The source checkout declares `tokenizers>=0.22.0,<=0.23.0`, `torch>=2.2`, `accelerate>=1.1.0`, `safetensors>=0.4.3`, and `sentencepiece>=0.1.91,!=0.1.92`.
+
+Before changing version-sensitive model loading, capture the active stack:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["transformers", "tokenizers", "torch", "accelerate", "huggingface-hub", "safetensors", "sentencepiece"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to leave the user with one of these concrete outcomes:
+
+- A model/tokenizer load path that works in the target environment.
+- A minimal inference, training, evaluation, conversion, or export smoke test.
+- A diagnosis that names the exact failing compatibility boundary: model id, revision, config, tokenizer, dtype, device, dependency version, or artifact layout.
+- A small code change that follows the repo's existing Transformers pattern and includes a repeatable verification command.
+
+Do not stop at general advice. Produce or run the smallest command that proves the model path works.
+
+## Standalone Quick Start
+
+When the repo does not already provide a smoke command, create one in the task context or run it inline with a tiny public model unless the user has supplied a private model:
+
+```bash
+python - <<'PY'
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model_id = "sshleifer/tiny-gpt2"
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+model = AutoModelForCausalLM.from_pretrained(model_id)
+inputs = tokenizer("Transformers smoke test:", return_tensors="pt")
+outputs = model.generate(**inputs, max_new_tokens=8)
+print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+PY
+```
+
+For classification-style models, use `AutoModelForSequenceClassification` and assert logits shape. For seq2seq, use `AutoModelForSeq2SeqLM`. For multimodal projects, use `AutoProcessor` and the model-specific `AutoModel*` class already used by the repo.
+
+## Workflow
+
+1. Identify the task: inference, training, evaluation, conversion, serving, or debugging.
+2. Inspect installed versions and local dependencies before changing code:
+
+```bash
+python - <<'PY'
+import transformers, torch
+print("transformers", transformers.__version__)
+print("torch", torch.__version__)
+PY
+```
+
+3. Locate the model family, tokenizer/processor, and config path. Check whether the project uses `Auto*` classes, model-specific classes, or custom code.
+4. Make the smallest change that preserves existing checkpoints, config names, and tensor shapes.
+5. Validate with a tiny input, then a realistic input.
+
+When model loading is the risk area, record the exact model id/path, `revision`, cache location, and whether loading is allowed to hit the network. For reproducible or private deployments, prefer pinned revisions and explicit `local_files_only` behavior over implicit Hub defaults.
+
+## Decision Rules
+
+- If the failure happens before weights load, inspect dependency versions, auth, cache, `revision`, `trust_remote_code`, and config class first.
+- If the model loads but output is wrong, inspect tokenizer special tokens, chat template, padding/truncation, generation config, and preprocessing.
+- If training runs but quality is broken, inspect dataset columns, label construction, masking, collator behavior, and whether the saved tokenizer/config match training.
+- If export or conversion fails, compare config fields, state dict keys, tensor shapes, tied embeddings, dtype, and target runtime support.
+- If memory is the blocker, reduce batch/sequence length first; then inspect dtype, `device_map`, quantization, activation checkpointing, KV cache, and retained tensors.
+
+## Inference
+
+- Use `AutoTokenizer`, `AutoProcessor`, `AutoConfig`, and `AutoModel*` unless model-specific APIs are already used.
+- Set `trust_remote_code` only when necessary and make the risk visible.
+- Keep generation parameters in a config object or named dictionary, not scattered across call sites.
+- For GPU memory issues, check dtype, device map, quantization, batch size, sequence length, and KV cache behavior.
+- For pipelines, verify task names and return shapes; pipeline abstractions can hide tokenizer/model mismatch.
+- For offline or cached execution, inspect `HF_HOME`, `TRANSFORMERS_CACHE`, `HF_HUB_OFFLINE`, and any project-specific cache settings before changing code.
+
+Minimal load contract for PR notes or debugging output:
+
+```text
+model_id/path:
+revision:
+transformers/tokenizers/torch:
+trust_remote_code:
+dtype/device/device_map:
+input shape:
+output shape or generated text:
+```
+
+## Training and Fine-Tuning
+
+- Prefer existing `Trainer`, `Seq2SeqTrainer`, `Accelerate`, or custom loop conventions in the repo.
+- Validate dataset columns before wiring a trainer.
+- Confirm tokenizer padding/truncation and label masking for causal language modeling or seq2seq tasks.
+- For distributed training, inspect launch commands and environment variables before changing code.
+- Save tokenizer, processor, config, generation config, and model weights together.
+
+Before a long training run, force a tiny run that completes end to end:
+
+```bash
+python train.py --max_steps 2 --per_device_train_batch_size 1
+```
+
+Adapt the command to the repo's launcher. If no launcher exists, add a minimal smoke path that tokenizes two examples, runs one forward/backward pass, saves to a temp directory, and reloads the artifact.
+
+## Conversion and Compatibility
+
+- When converting weights, compare config fields, state dict keys, tensor shapes, and tied embeddings.
+- Pin model revision or source checkpoint when reproducibility matters.
+- Add a smoke test that loads the converted artifact and runs one forward pass.
+- Preserve model card metadata when publishing or repackaging.
+
+## References
+
+Open `references/workflows.md` when the task needs detailed recipes for model loading, inference, Trainer/Accelerate debugging, conversion/export, caching/offline behavior, quantization, or PR review artifacts.
+
+Open `references/mastery.md` when the task requires broader Transformers reasoning: API selection, artifact anatomy, generation behavior, model/tokenizer compatibility, training stack choices, and version-sensitive pitfalls.
+
+Open `references/source-evidence.md` when reviewing whether the skill covers the workflows observed in the mined `transformers` repository evidence.
+
+## Debugging Checklist
+
+- Tokenizer/model vocab size mismatch.
+- Model download works locally but fails in CI or production because auth, cache, `revision`, or offline settings differ.
+- Missing `pad_token`, wrong chat template, or wrong special token IDs.
+- Incorrect dtype or device placement.
+- Sequence length exceeding model or rotary embedding limits.
+- Labels not shifted or masked correctly.
+- Config changes not saved with the model artifact.
+
+## Done Criteria
+
+- The model/tokenizer load path is explicit and reproducible.
+- A tiny inference or training smoke test runs.
+- Any version, revision, dtype, quantization, or trust boundary assumption is documented in code or the PR notes.
+- The final answer names the exact command run and the observed output shape, generated text, or failure boundary.

--- a/skills/.curated/huggingface-transformers/agents/openai.yaml
+++ b/skills/.curated/huggingface-transformers/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Hugging Face Transformers"
+  short_description: "Build and debug Transformers model workflows"
+  default_prompt: "Use $huggingface-transformers to implement or debug this Transformers workflow."

--- a/skills/.curated/huggingface-transformers/references/mastery.md
+++ b/skills/.curated/huggingface-transformers/references/mastery.md
@@ -1,0 +1,159 @@
+# Hugging Face Transformers Mastery Notes
+
+This reference gives an agent the conceptual map needed to work effectively with `transformers` without assuming the user already knows the library.
+
+## Contents
+
+- [Mental Model](#mental-model)
+- [Choosing APIs](#choosing-apis)
+- [Artifact Anatomy](#artifact-anatomy)
+- [Tokenizer and Model Compatibility](#tokenizer-and-model-compatibility)
+- [Generation Behavior](#generation-behavior)
+- [Trainer Stack](#trainer-stack)
+- [Accelerate and Distributed Runs](#accelerate-and-distributed-runs)
+- [Quantization](#quantization)
+- [Common Breaking Boundaries](#common-breaking-boundaries)
+- [Review Checklist](#review-checklist)
+
+## Mental Model
+
+Transformers projects are built from a small set of artifact contracts:
+
+- **Config**: architecture and model hyperparameters. Usually loaded with `AutoConfig`.
+- **Tokenizer or processor**: converts user data into model tensors. Text uses `AutoTokenizer`; multimodal uses `AutoProcessor` or task-specific processors.
+- **Model class**: task-specific `AutoModel*` wrapper or model-specific class.
+- **Generation config**: decoding behavior for generation models.
+- **Weights**: PyTorch, safetensors, TensorFlow, Flax, or sharded checkpoints.
+- **Training/eval script**: `Trainer`, `Seq2SeqTrainer`, `Accelerate`, or custom loop.
+
+Most failures come from a mismatch between these artifacts, not from the model code itself.
+
+## Choosing APIs
+
+Use `Auto*` classes by default:
+
+| Task | Preferred class |
+|---|---|
+| causal language modeling | `AutoModelForCausalLM` |
+| seq2seq generation | `AutoModelForSeq2SeqLM` |
+| classification | `AutoModelForSequenceClassification` |
+| token classification | `AutoModelForTokenClassification` |
+| embeddings/features | `AutoModel` or library-specific embedding wrapper |
+| multimodal | `AutoProcessor` plus model-specific `AutoModel*` |
+
+Use model-specific classes only when the repo already does, or when the model requires methods not exposed by the auto class.
+
+## Artifact Anatomy
+
+Expected files often include:
+
+```text
+config.json
+generation_config.json
+tokenizer.json
+tokenizer_config.json
+special_tokens_map.json
+vocab/merges or sentencepiece model
+model.safetensors or pytorch_model.bin
+model.safetensors.index.json for sharded checkpoints
+preprocessor_config.json for vision/audio/multimodal models
+```
+
+If a saved model cannot reload, inspect missing files before changing code.
+
+## Tokenizer and Model Compatibility
+
+Always compare:
+
+```python
+len(tokenizer)
+model.get_input_embeddings().weight.shape[0]
+tokenizer.pad_token_id
+tokenizer.eos_token_id
+tokenizer.bos_token_id
+getattr(tokenizer, "chat_template", None)
+```
+
+If tokens are added, resize embeddings and save the model/tokenizer pair together. If the chat template changes, generated behavior can change even when token IDs do not.
+
+## Generation Behavior
+
+Generation output depends on:
+
+- prompt formatting
+- chat template
+- tokenizer special tokens
+- `max_new_tokens` vs `max_length`
+- sampling parameters
+- stopping criteria
+- KV cache behavior
+- dtype and device
+
+When output quality is the issue, print the exact rendered prompt before changing model settings.
+
+## Trainer Stack
+
+`Trainer` handles boilerplate but hides important contracts:
+
+- dataset column names
+- data collator behavior
+- label masking
+- distributed launcher
+- mixed precision
+- save/eval/logging cadence
+
+Before changing trainer code, run a tiny dataset through preprocessing and inspect one batch. A successful `Trainer` run with bad labels is still a broken result.
+
+## Accelerate and Distributed Runs
+
+Distributed failures can come from launch configuration rather than code. Record:
+
+```text
+accelerate config:
+process count:
+mixed precision:
+gradient accumulation:
+device map:
+FSDP/DeepSpeed config:
+```
+
+Debug single-process first unless the bug is explicitly distributed-only.
+
+## Quantization
+
+Quantized loading affects:
+
+- supported devices
+- merge/export support
+- dtype assumptions
+- adapter training compatibility
+- save format
+
+Do not assume a quantized model can be merged, exported, or uploaded in the same way as full precision weights.
+
+## Common Breaking Boundaries
+
+- `transformers` and `tokenizers` version ranges.
+- `trust_remote_code` model classes changing behavior.
+- Hub `revision` moving when not pinned.
+- private model auth missing in CI or production.
+- old tokenizer artifacts with newer model configs.
+- `pad_token_id` absent for batching.
+- sequence length exceeding model limit.
+
+## Review Checklist
+
+Use this checklist before finalizing a Transformers change:
+
+```text
+versions captured:
+model id/path and revision pinned:
+config loaded:
+tokenizer/processor loaded:
+special tokens checked:
+tiny input run:
+realistic input run:
+artifact save/reload checked, if applicable:
+offline/private behavior documented:
+trust_remote_code documented:
+```

--- a/skills/.curated/huggingface-transformers/references/source-evidence.md
+++ b/skills/.curated/huggingface-transformers/references/source-evidence.md
@@ -1,0 +1,116 @@
+# Transformers Source Evidence Map
+
+This reference records high-signal workflows retrieved from the mined `transformers` repository export and source checkout. Use it to keep the skill grounded in real repository practices.
+
+## Contents
+
+- [Retrieved Sources](#retrieved-sources)
+- [Workflows Found in Source](#workflows-found-in-source)
+- [New Model Implementation](#new-model-implementation)
+- [Test Selection](#test-selection)
+- [Pipeline Usage](#pipeline-usage)
+- [Trainer and Accelerate](#trainer-and-accelerate)
+- [Tokenizer and Processor Tests](#tokenizer-and-processor-tests)
+- [Quantization Tests](#quantization-tests)
+- [Remaining Coverage Gaps](#remaining-coverage-gaps)
+- [Evidence-Grounded Review Standard](#evidence-grounded-review-standard)
+
+## Retrieved Sources
+
+- Repository checkout: `huggingface/transformers`, source revision observed locally as `0a8ab33f7a`.
+- Mined export: `repository_library/exports/transformers/structured/repo_skills_miner.skills.jsonl` and annotations.
+- Version evidence: source `transformers` reports `5.0.0.dev0`; dependency table includes `tokenizers>=0.22.0,<=0.23.0`, `torch>=2.2`, `accelerate>=1.1.0`, `safetensors>=0.4.3`, and `sentencepiece>=0.1.91,!=0.1.92`.
+
+## Workflows Found in Source
+
+### New Model Implementation
+
+`CONTRIBUTING.md` describes a full new-model path:
+
+- provide model information before implementation
+- use the modular architecture pattern with `modular_<model_name>.py`
+- add integration tests with exact output matching
+- add docs/model card material including pipeline and `AutoModel` usage
+- run impacted model tests, not the entire suite
+
+The skill should therefore cover more than model loading. It must guide agents through new model integration, modular implementation, exact-output integration tests, docs, and targeted test commands.
+
+### Test Selection
+
+`AGENTS.md` and `CONTRIBUTING.md` emphasize targeted tests:
+
+```bash
+pytest tests/models/[name]/test_modeling_[name].py
+pytest tests/models/[name]/test_processing_[name].py
+pytest tests/models/[name]/test_tokenization_[name].py
+RUN_SLOW=1 python -m pytest tests/models/my_new_model/test_my_new_model.py
+```
+
+The skill should tell agents not to run the entire test suite by default.
+
+### Pipeline Usage
+
+`README.md` includes pipeline patterns for:
+
+- text generation
+- chat-style text generation with dtype and `device_map`
+- automatic speech recognition
+- image classification
+- visual question answering
+
+The skill should include pipeline return-shape validation and when to drop below `pipeline` to `AutoProcessor`/`AutoModel`.
+
+### Trainer and Accelerate
+
+Source/docs show both `Trainer` and no-trainer Accelerate workflows. The skill should cover:
+
+- `Trainer` for standard supervised training
+- `Seq2SeqTrainer` generation kwargs
+- `Accelerate` when a custom training loop needs distributed/mixed precision support
+- tiny runs before distributed launch
+
+### Tokenizer and Processor Tests
+
+Mined annotations surfaced tokenizer tests such as `CTRLTokenizationTest`, `PerceiverTokenizationTest`, and processor tests such as `VideoLlama3ProcessorTest`. These point to required skill coverage:
+
+- tokenizer save/load behavior
+- special token edge cases
+- processor input preparation for multimodal models
+- truncation and vision-token risks
+
+### Quantization Tests
+
+Mined annotations surfaced quantization integration tests such as `QuantoQuantizationSerializationCudaTest` and `VptqConfigTest`. The skill should cover:
+
+- CPU vs CUDA quantization behavior
+- serialization/reload checks
+- quantization config compatibility
+- memory/runtime risks
+
+## Remaining Coverage Gaps
+
+The skill is much stronger than the original, but it is not complete unless it adds or preserves guidance for:
+
+- implementing a new Transformers model in the repo's modular style
+- adding or modifying tokenizers/processors with targeted tests
+- multimodal processors and exact-output integration tests
+- quantization config and serialization validation
+- model card/documentation update expectations
+- targeted test command selection
+
+## Evidence-Grounded Review Standard
+
+A complete Transformers skill should let a fresh agent handle these task classes:
+
+```text
+load/debug existing model:
+pipeline inference:
+Trainer fine-tuning:
+Accelerate/custom loop:
+tokenizer/processor change:
+new model integration:
+quantization/serialization:
+conversion/export:
+docs/model card:
+targeted tests:
+```

--- a/skills/.curated/huggingface-transformers/references/workflows.md
+++ b/skills/.curated/huggingface-transformers/references/workflows.md
@@ -1,0 +1,134 @@
+# Hugging Face Transformers Workflows
+
+Use these workflows when the basic `SKILL.md` checklist is not enough. Prefer the repository's existing scripts and config format; these recipes define the checks and artifacts that should exist by the end.
+
+## Contents
+
+- [Model Loading and Inference](#model-loading-and-inference)
+- [Trainer and Accelerate Debugging](#trainer-and-accelerate-debugging)
+- [Offline, Private, and Reproducible Loads](#offline-private-and-reproducible-loads)
+- [Quantization and Memory](#quantization-and-memory)
+- [Conversion and Export](#conversion-and-export)
+- [PR Review Artifact](#pr-review-artifact)
+
+## Model Loading and Inference
+
+1. Record model identity: model id or path, `revision`, local cache behavior, `trust_remote_code`, and task class.
+2. Load config first with `AutoConfig.from_pretrained(...)` and inspect `model_type`, architectures, vocab size, max positions, and special IDs.
+3. Load tokenizer/processor and check special tokens before loading weights.
+4. Load model with explicit dtype/device choices.
+5. Run a tiny input and print decoded output or output shape.
+
+Minimal causal LM check:
+
+```python
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+model_id = "sshleifer/tiny-gpt2"
+revision = None
+config = AutoConfig.from_pretrained(model_id, revision=revision)
+tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
+model = AutoModelForCausalLM.from_pretrained(model_id, revision=revision)
+inputs = tokenizer("hello", return_tensors="pt")
+outputs = model.generate(**inputs, max_new_tokens=8)
+print(config.model_type, len(tokenizer), tokenizer.decode(outputs[0], skip_special_tokens=True))
+```
+
+If this works but the target model does not, compare config class, tokenizer files, `revision`, auth, and remote code requirements.
+
+## Trainer and Accelerate Debugging
+
+1. Print dataset column names and one raw example.
+2. Print one tokenized example with labels and masks.
+3. Run `max_steps=2`, batch size 1, and no distributed launcher first.
+4. Save a tiny checkpoint and reload it in a fresh process.
+5. Only then restore distributed launch, mixed precision, gradient accumulation, and full dataset.
+
+Common label checks:
+
+- Causal LM labels should mask prompt/user tokens when doing instruction tuning.
+- Seq2Seq labels should use `-100` for ignored positions.
+- Classification labels must be integer class IDs unless the loss expects floats.
+- Token classification labels must align with offset mappings or word IDs.
+
+## Offline, Private, and Reproducible Loads
+
+Record these before changing code:
+
+```text
+HF_HOME:
+TRANSFORMERS_CACHE:
+HF_HUB_OFFLINE:
+local_files_only:
+model id/path:
+revision:
+tokenizer files present:
+```
+
+For private or production loads, prefer:
+
+```python
+AutoTokenizer.from_pretrained(model_id, revision=revision, local_files_only=True)
+AutoModelForCausalLM.from_pretrained(model_id, revision=revision, local_files_only=True)
+```
+
+Use `local_files_only=False` only when network access is intentional.
+
+## Quantization and Memory
+
+Debug order:
+
+1. Confirm unquantized CPU or small-device load works.
+2. Confirm dtype and device map.
+3. Add quantization config.
+4. Run one forward/generate call.
+5. Save and reload if the workflow expects persisted artifacts.
+
+Record:
+
+```text
+torch:
+cuda:
+transformers:
+quantization package:
+dtype:
+device_map:
+max memory:
+input length:
+```
+
+## Conversion and Export
+
+Before conversion:
+
+- Compare source and target config fields.
+- Compare state dict key counts and missing/unexpected keys.
+- Check tied embeddings and vocab size.
+- Check dtype and sharding.
+
+After conversion:
+
+```python
+from transformers import AutoModel, AutoTokenizer
+model = AutoModel.from_pretrained("converted-output")
+tokenizer = AutoTokenizer.from_pretrained("converted-output")
+print(model.__class__.__name__, len(tokenizer))
+```
+
+For ONNX/TorchScript/export tasks, run one inference with the exported artifact, not only the source model.
+
+## PR Review Artifact
+
+Include this in final notes or PR body:
+
+```text
+Task:
+Model id/path:
+Revision:
+Versions:
+Smoke command:
+Smoke result:
+Changed files:
+Known version assumptions:
+Residual risks:
+```


### PR DESCRIPTION
## Summary

Adds the `huggingface-transformers` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined Transformers evidence from a 5.0.0.dev0 source checkout and downstream locked environments using Transformers 4.57.6 and 5.0.0.

## Validation

- Ran the local skill validator against `skills/.curated/huggingface-transformers`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.