### PR TITLE
Add PyTorch skill

### DIFF
--- a/skills/.curated/pytorch/LICENSE.txt
+++ b/skills/.curated/pytorch/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/pytorch/SKILL.md
+++ b/skills/.curated/pytorch/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: pytorch
+description: Build, debug, train, evaluate, or optimize PyTorch models. Use when working with torch tensors, nn.Module code, Dataset/DataLoader pipelines, autograd, CUDA/MPS devices, distributed training, mixed precision, checkpointing, model export, or performance and memory issues in PyTorch projects.
+---
+
+# PyTorch
+
+Use this skill for PyTorch code paths. First understand the tensor shapes, device placement, and training/evaluation mode boundaries; most PyTorch bugs are contract bugs around those three areas.
+
+## Validated Version Evidence
+
+This guidance was checked against a mined PyTorch source checkout at commit `e2dc2224743`, with `requires-python = ">=3.10"` and `sympy>=1.13.3`, plus downstream locked environments using `torch` 2.9.1. PyTorch behavior is highly version-, device-, and backend-sensitive, so capture the active runtime before debugging:
+
+```bash
+python - <<'PY'
+import torch
+print("torch", torch.__version__)
+print("cuda available", torch.cuda.is_available())
+print("cuda runtime", getattr(torch.version, "cuda", None))
+print("mps available", getattr(torch.backends, "mps", None) and torch.backends.mps.is_available())
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to make a PyTorch path correct and reproducible. A complete run produces:
+
+- A version/device report for `torch`, CUDA/MPS, and the active accelerator.
+- A tiny batch or inference smoke test that exercises the repo's real model/data path.
+- A diagnosis of the failing contract: shape, dtype, device, mode, gradient, memory, checkpoint, or export.
+- A minimal code/config change plus the command that verifies it.
+
+## Standalone Quick Start
+
+If the repo has no obvious test, create a temporary smoke path around the existing `model`, `loader`, and `criterion`. For pure inference modules, run one forward pass and print output shape:
+
+```python
+model.eval()
+with torch.inference_mode():
+    output = model(example.to(device))
+print(tuple(output.shape) if hasattr(output, "shape") else type(output))
+```
+
+For training code, use the finite-loss/gradient check below before changing architecture.
+
+## Workflow
+
+1. Inspect the local stack and available accelerators:
+
+```bash
+python - <<'PY'
+import torch
+print("torch", torch.__version__)
+print("cuda", torch.cuda.is_available())
+print("mps", getattr(torch.backends, "mps", None) and torch.backends.mps.is_available())
+PY
+```
+
+2. Locate model construction, data loading, loss computation, optimizer/scheduler setup, and checkpoint save/load code.
+3. Trace one tiny batch end to end before changing architecture or training logic.
+4. Prefer focused tests or smoke scripts that assert shapes, dtypes, devices, and finite losses.
+
+Use a minimal batch smoke check when the project has a loader, model, and criterion available:
+
+```python
+model.train()
+batch = next(iter(loader))
+inputs, labels = batch
+outputs = model(inputs.to(device))
+loss = criterion(outputs, labels.to(device))
+assert torch.isfinite(loss), loss
+loss.backward()
+assert all(p.grad is None or torch.isfinite(p.grad).all() for p in model.parameters())
+```
+
+Adapt the unpacking to the repo's batch structure; the point is to verify the real data contract, not to create a separate synthetic path.
+
+## Model Code
+
+- Keep `nn.Module` state in registered modules, parameters, or buffers.
+- Avoid creating new trainable tensors inside `forward` unless that is intentional and tested.
+- Make input and output shape contracts explicit near complex modules.
+- Use `model.train()` and `model.eval()` deliberately around dropout, batch norm, and evaluation.
+- Keep random seeds and deterministic settings in test or experiment entrypoints, not hidden in library code.
+
+## Data and Training
+
+- Validate dataset item structure before debugging the model.
+- Check collate behavior for variable-length inputs, padding, masks, and label dtypes.
+- Ensure loss functions receive the expected logits/probabilities and target dtype.
+- Call `optimizer.zero_grad()` in the intended place and verify gradients are finite.
+- For mixed precision, use the repo's existing AMP pattern; do not mix multiple scaler strategies.
+
+## Device, Memory, and Performance
+
+- Move tensors and modules to the same device at clear boundaries.
+- For CUDA OOM, reduce batch/sequence size first, then inspect activation checkpointing, dtype, gradient accumulation, and retained graph references.
+- Use `torch.no_grad()` or `torch.inference_mode()` for inference-only paths.
+- Profile only after correctness is established.
+
+Memory triage order:
+
+1. Reproduce with batch size 1.
+2. Print tensor shapes and dtypes at the failing boundary.
+3. Check accidental graph retention (`losses.append(loss)` instead of `loss.item()`).
+4. Only then add checkpointing, lower precision, accumulation, or model surgery.
+
+## Checkpointing and Export
+
+- Save enough state to resume: model, optimizer, scheduler, scaler, epoch/step, config, and RNG state when needed.
+- Load checkpoints with explicit device mapping.
+- For TorchScript, ONNX, or `torch.export`, add a small exported-model smoke test.
+
+## References
+
+Open `references/workflows.md` for detailed recipes covering model/data contract debugging, training loops, memory triage, distributed runs, checkpointing, export, and PR review artifacts.
+
+Open `references/mastery.md` for PyTorch mental models, module/state rules, autograd pitfalls, data pipeline design, backend differences, and review standards.
+
+Open `references/source-evidence.md` when reviewing whether the skill covers workflows observed in the PyTorch repository evidence.
+
+## Done Criteria
+
+- A tiny batch or minimal inference path runs locally.
+- Shape, dtype, and device assumptions are verified or documented.
+- Training changes include a loss/gradient sanity check where practical.
+- The final notes state the exact device/backend and the command used to prove the path.

--- a/skills/.curated/pytorch/agents/openai.yaml
+++ b/skills/.curated/pytorch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PyTorch"
+  short_description: "Build and debug PyTorch models"
+  default_prompt: "Use $pytorch to build, train, or debug this PyTorch model."

--- a/skills/.curated/pytorch/references/mastery.md
+++ b/skills/.curated/pytorch/references/mastery.md
@@ -1,0 +1,41 @@
+# PyTorch Mastery Notes
+
+## Mental Model
+
+PyTorch programs are contracts between tensors, modules, autograd, devices, and optimizer state. Most bugs are mismatches in shape, dtype, device, mode, or graph lifetime.
+
+## Module State
+
+Trainable state belongs in `nn.Parameter` or child modules. Non-trainable persistent tensors belong in buffers. Temporary tensors created in `forward` should not silently become trainable state.
+
+## Autograd Pitfalls
+
+- Calling `.item()` detaches a scalar.
+- Appending losses without detaching can retain graphs.
+- In-place ops can break gradients.
+- `no_grad()` and `inference_mode()` are for inference paths.
+- `model.eval()` changes dropout and batch norm behavior but does not disable gradients.
+
+## Data Pipeline
+
+Debug dataset and collate before debugging the model:
+
+- one raw sample
+- one collated batch
+- tensor shapes/dtypes
+- masks and padding
+- label semantics
+
+## Backend Differences
+
+CUDA, CPU, and MPS can differ in dtype support, determinism, memory behavior, and kernel availability. Always report the backend used for validation.
+
+## Review Standard
+
+A complete PyTorch change proves:
+
+- one real batch or inference path runs
+- shape/dtype/device assumptions are visible
+- loss and gradients are finite for training changes
+- checkpoint/export reload works when touched
+- memory changes are justified by measurement

--- a/skills/.curated/pytorch/references/source-evidence.md
+++ b/skills/.curated/pytorch/references/source-evidence.md
@@ -1,0 +1,87 @@
+# PyTorch Source Evidence Map
+
+This reference records high-signal workflows retrieved from the PyTorch source checkout and repository-library export. Use it to keep the skill grounded in real repository practices.
+
+## Retrieved Sources
+
+- Repository checkout: `pytorch/pytorch`, source revision observed locally as `e2dc2224743`.
+- Version evidence: `requires-python = ">=3.10"` and `sympy>=1.13.3`; downstream mined environments included `torch` 2.9.1.
+- Source documents consulted: `README.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`, `CLAUDE.md`, and `test/HowToWriteTestsUsingFileCheck.md`.
+
+## Workflows Found in Source
+
+### Targeted Testing
+
+PyTorch contributor docs warn against running broad test suites by default. High-signal patterns:
+
+```bash
+python test/test_torch.py TestTorch.test_specific_case
+python test/test_jit.py TestJit.test_Sequential
+pytest test/test_nn.py -k Loss -v
+```
+
+The skill should tell agents to create a standalone reproduction first, then run targeted tests.
+
+### Test Structure
+
+Source guidance uses:
+
+```python
+from torch.testing._internal.common_utils import run_tests, TestCase
+```
+
+It also recommends:
+
+- `assertEqual` for tensor equality
+- `@parametrize` for multiple inputs
+- `instantiate_device_type_tests` for device-generic numeric tests
+
+The skill should include this for PyTorch repo changes, not only user-model debugging.
+
+### Architecture Map
+
+Repository docs identify major areas:
+
+- `aten/`: tensor library foundation without autograd
+- `torch/csrc/autograd/`: reverse-mode automatic differentiation
+- `torch/csrc/distributed/`: distributed training
+- `tools/autograd/derivatives.yaml`: gradient definitions
+- `test/`: Python frontend tests
+- `test/cpp`: C++ tests
+
+The skill should help agents route changes to the correct subsystem.
+
+### Config and Compile Workflows
+
+`CLAUDE.md` recommends `torch._dynamo.config.patch` for temporary config changes in tests. This indicates the skill should include `torch.compile`/Dynamo config patching as a first-class workflow for modern PyTorch debugging.
+
+### FileCheck
+
+`test/HowToWriteTestsUsingFileCheck.md` shows PyTorch uses FileCheck for graph/compiler optimization tests. The skill should cover this when tasks involve JIT, generated graphs, or compiler passes.
+
+## Remaining Coverage Gaps
+
+The current skill covers end-user PyTorch model debugging better than it covers PyTorch-repository contribution workflows. It is not complete unless it adds guidance for:
+
+- targeted PyTorch repo tests
+- `TestCase`, `run_tests`, `assertEqual`, `parametrize`, and device-generic tests
+- subsystem routing across ATen, autograd, distributed, compiler, Python frontend, and C++ tests
+- `torch.compile`/Dynamo config patching
+- FileCheck for graph/compiler tests
+- C++ extension or C++ test boundaries when relevant
+
+## Evidence-Grounded Review Standard
+
+A complete PyTorch skill should let a fresh agent handle:
+
+```text
+end-user model/data debugging:
+training loop correctness:
+checkpoint/export:
+memory/performance:
+distributed/mixed precision:
+PyTorch repo bug fix:
+device-generic tests:
+compiler/FileCheck tests:
+targeted test selection:
+```

--- a/skills/.curated/pytorch/references/workflows.md
+++ b/skills/.curated/pytorch/references/workflows.md
@@ -1,0 +1,113 @@
+# PyTorch Workflows
+
+Use these workflows when the task needs implementation detail beyond the entry checklist.
+
+## Contents
+
+- [Model and Data Contract](#model-and-data-contract)
+- [Shape, Dtype, Device Debugging](#shape-dtype-device-debugging)
+- [Training Loop](#training-loop)
+- [Memory Triage](#memory-triage)
+- [Checkpoint Contract](#checkpoint-contract)
+- [Export Contract](#export-contract)
+- [Final Artifact](#final-artifact)
+
+## Model and Data Contract
+
+Trace one batch through the real loader and model:
+
+```python
+batch = next(iter(loader))
+print(type(batch), batch)
+model = model.to(device)
+model.train()
+inputs, labels = batch
+outputs = model(inputs.to(device))
+loss = criterion(outputs, labels.to(device))
+print("outputs", getattr(outputs, "shape", type(outputs)), "loss", loss.item())
+```
+
+If the batch is a dict, preserve names and move tensors key by key. Do not invent a synthetic path unless the bug is isolated to a layer.
+
+## Shape, Dtype, Device Debugging
+
+Add temporary prints at boundaries:
+
+```python
+def describe(name, x):
+    print(name, tuple(x.shape), x.dtype, x.device)
+```
+
+Check:
+
+- Inputs and labels are on the same device as the model.
+- Loss receives logits vs probabilities as expected.
+- Classification targets are `torch.long`; regression targets are floating point.
+- Masks are boolean or numeric as expected by the module.
+
+## Training Loop
+
+Correctness order:
+
+1. Zero gradients.
+2. Forward pass.
+3. Finite loss assertion.
+4. Backward pass.
+5. Finite gradient assertion.
+6. Optimizer step.
+7. Scheduler step only in the repo's intended place.
+
+Minimal guard:
+
+```python
+assert torch.isfinite(loss), loss
+loss.backward()
+for name, p in model.named_parameters():
+    if p.grad is not None:
+        assert torch.isfinite(p.grad).all(), name
+```
+
+## Memory Triage
+
+1. Reproduce at batch size 1.
+2. Reduce sequence/image size.
+3. Disable graph retention in logging.
+4. Add `torch.inference_mode()` for inference.
+5. Try AMP or lower dtype.
+6. Add gradient accumulation/checkpointing.
+7. Profile only after the path is correct.
+
+## Checkpoint Contract
+
+Save:
+
+```python
+{
+    "model": model.state_dict(),
+    "optimizer": optimizer.state_dict(),
+    "scheduler": scheduler.state_dict() if scheduler else None,
+    "scaler": scaler.state_dict() if scaler else None,
+    "step": step,
+    "config": config,
+}
+```
+
+Reload in a fresh process with explicit `map_location`.
+
+## Export Contract
+
+For ONNX, TorchScript, or `torch.export`, run a real inference through the exported artifact and compare shape and a small numeric tolerance against eager output.
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+torch/backend versions:
+device:
+batch shape:
+loss/gradient result:
+checkpoint/export path:
+command run:
+residual risks:
+```


### PR DESCRIPTION
## Summary

Adds the `pytorch` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined PyTorch source evidence plus downstream locked environments using Torch 2.9.1.

## Validation

- Ran the local skill validator against `skills/.curated/pytorch`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.