### PR TITLE
Add PEFT and LoRA skill

### DIFF
--- a/skills/.curated/peft-lora/LICENSE.txt
+++ b/skills/.curated/peft-lora/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/peft-lora/SKILL.md
+++ b/skills/.curated/peft-lora/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: peft-lora
+description: Fine-tune, debug, merge, evaluate, or export parameter-efficient adapters for LLMs and diffusion models with PEFT, LoRA, QLoRA, TRL, Axolotl, Unsloth, or Accelerate. Use when working with adapter configs, target modules, quantized training, adapter composition, checkpoint merging, or low-memory fine-tuning.
+---
+
+# PEFT and LoRA
+
+Use this skill for parameter-efficient fine-tuning. Preserve the base model contract first: tokenizer, chat template, quantization config, target modules, and adapter checkpoint layout must line up.
+
+## Validated Version Evidence
+
+This guidance was checked against a mined `peft` source checkout at `peft` 0.18.0. That source contains version-sensitive branches for `transformers` around 4.33.0, 4.53.1, 4.54.0.dev0, and 4.56.0, and depends on `accelerate`, `torch`, `safetensors`, `bitsandbytes`, `transformers`, `datasets`, and related training packages.
+
+Before changing adapter code or configs, capture the active stack:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["peft", "transformers", "torch", "accelerate", "bitsandbytes", "datasets", "safetensors"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to make adapter training, loading, merging, or export reproducible. A complete run produces:
+
+- A base-model/adaptor compatibility record: base model id, revision, tokenizer/chat template, adapter type, and package versions.
+- A trainable-parameter count proving the intended modules are unfrozen.
+- A tiny train or inference smoke test.
+- A fresh-process reload of the saved adapter or merged artifact.
+- Notes on whether the final artifact is an adapter, merged model, quantized model, or private-base-dependent artifact.
+
+## Standalone Quick Start
+
+When the repo lacks a smoke test, verify adapter attachment with the smallest model or the user's target model:
+
+```python
+from transformers import AutoModelForCausalLM
+from peft import LoraConfig, get_peft_model
+
+base_model = "sshleifer/tiny-gpt2"
+model = AutoModelForCausalLM.from_pretrained(base_model)
+config = LoraConfig(r=8, lora_alpha=16, target_modules=["c_attn"], lora_dropout=0.05)
+model = get_peft_model(model, config)
+model.print_trainable_parameters()
+```
+
+The `c_attn` target is for the tiny GPT-2 smoke model. For the user's target model, list module names and choose real linear layers from that architecture:
+
+```python
+for name, module in model.named_modules():
+    if "Linear" in type(module).__name__:
+        print(name)
+```
+
+## Workflow
+
+1. Identify the base model, adapter method, training framework, quantization mode, and expected output artifact.
+2. Inspect current package versions and GPU memory before changing configs.
+3. Validate the dataset formatting and tokenizer behavior on a few examples.
+4. Run a tiny train/eval smoke before launching a long job.
+5. Test loading the saved adapter separately from training.
+
+Check trainable parameters before any real run:
+
+```python
+if hasattr(model, "print_trainable_parameters"):
+    model.print_trainable_parameters()
+else:
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    print(f"trainable params: {trainable:,} / {total:,} ({trainable / total:.4%})")
+assert any(p.requires_grad for p in model.parameters())
+```
+
+## Configuration Checks
+
+- Confirm `base_model_name_or_path` and adapter checkpoint ancestry.
+- Match `target_modules` to actual module names in the model.
+- Set LoRA rank, alpha, dropout, bias, and task type intentionally.
+- For QLoRA, verify bitsandbytes availability, compute dtype, quantization type, and device map.
+- For chat models, preserve the chat template and special tokens used during training.
+- For sequence classification or embedding tasks, confirm the head/pooling layer is trainable if needed.
+
+## Training Guidance
+
+- Prefer the repo's existing launcher: raw PEFT, TRL, Axolotl, Unsloth, or Accelerate.
+- Use small max steps and a tiny dataset slice for the first verification run.
+- Watch for loss becoming `nan`, no trainable parameters, frozen target modules, or empty labels.
+- Log effective batch size: per-device batch size, gradient accumulation, process count, and sequence length.
+- Save adapter config, tokenizer files, training config, and evaluation notes together.
+
+## Merge and Export
+
+- Load the base model and adapter in a fresh process before merge/export.
+- Run one generation or prediction before and after merge.
+- Keep both unmerged adapter and merged artifact when practical.
+- Document whether the merged model is safe to upload, quantized, or tied to a private base checkpoint.
+
+Fresh-process reload contract:
+
+```text
+base model:
+base revision:
+adapter path:
+peft/transformers/torch:
+trainable parameter count:
+sample prompt/input:
+pre-merge output:
+post-merge output, if merged:
+```
+
+## References
+
+Open `references/workflows.md` for detailed adapter target-module discovery, QLoRA setup, dataset formatting, tiny training runs, merge/export checks, and artifact review.
+
+Open `references/mastery.md` for PEFT/LoRA mental models, adapter artifact contracts, quantization interactions, target module strategy, and review standards.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in mined/source repository evidence.
+
+## Common Failure Modes
+
+- `target_modules` do not match after a model architecture or library version change.
+- Tokenizer pad/eos settings differ between train and inference.
+- Quantized weights are accidentally merged or saved in an unsupported format.
+- Adapter loads but has no effect because it is inactive or attached to the wrong base model.
+- Adapter checkpoint cannot be reproduced because base model revision, tokenizer files, or chat template were not pinned with it.
+- Training appears to run but all labels are masked.
+
+## Done Criteria
+
+- Trainable parameter count is checked.
+- A tiny training run completes or the inference-only adapter load path is tested.
+- The final adapter or merged model can be loaded in a fresh process.
+- The final notes state exactly which artifact should be kept, uploaded, or treated as private-base-dependent.

--- a/skills/.curated/peft-lora/agents/openai.yaml
+++ b/skills/.curated/peft-lora/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PEFT and LoRA"
+  short_description: "Fine-tune and merge lightweight model adapters"
+  default_prompt: "Use $peft-lora to fine-tune, debug, or merge a PEFT/LoRA adapter."

--- a/skills/.curated/peft-lora/references/mastery.md
+++ b/skills/.curated/peft-lora/references/mastery.md
@@ -1,0 +1,36 @@
+# PEFT and LoRA Mastery Notes
+
+## Mental Model
+
+PEFT trains small adapter weights around a frozen or mostly frozen base model. The adapter is only meaningful with the exact base model, tokenizer, and task formatting used to train it.
+
+## Artifact Types
+
+- **Adapter only**: small, depends on base model.
+- **Merged model**: larger, can often be loaded without PEFT but may inherit base license/privacy constraints.
+- **Quantized training setup**: memory-saving path, not always merge/export compatible.
+
+## Target Module Strategy
+
+Target modules must match real module names. Good choices usually affect attention and/or MLP projections. Bad choices produce zero useful learning or no trainable parameters.
+
+## Training Quality Risks
+
+- all labels masked
+- wrong chat template
+- tokenizer pad/eos mismatch
+- target modules absent
+- adapter inactive at inference
+- base revision drift
+- quantized merge unsupported
+
+## Review Standard
+
+A complete adapter change proves:
+
+- base model/revision recorded
+- tokenizer/chat template recorded
+- trainable parameters are nonzero
+- tiny training or adapter-load smoke succeeds
+- adapter reloads in a fresh process
+- merge status and upload safety are explicit

--- a/skills/.curated/peft-lora/references/source-evidence.md
+++ b/skills/.curated/peft-lora/references/source-evidence.md
@@ -1,0 +1,42 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. The skill should make a fresh agent able to run, debug, and review PEFT/LoRA workflows, not merely describe adapter concepts.
+
+## Retrieved Sources
+
+- `huggingface/peft`: examples and source around `LoraConfig`, `get_peft_model`, `PeftModel.from_pretrained`, EVA initialization, DoRA/offloading, non-transformer LoRA targets, and `merge_and_unload`.
+- `artidoro/qlora`: QLoRA training script patterns using `bitsandbytes`, `prepare_model_for_kbit_training`, adapter-only checkpoint callbacks, target-module discovery, and adapter reload for generation.
+- Mined package evidence: `peft` 0.18.0 source with compatibility branches around several `transformers` versions.
+
+## Workflows Reflected In The Skill
+
+### Target Module Discovery
+
+PEFT examples show architecture-specific targets such as `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, and `down_proj`. They also show LoRA can apply outside transformer attention blocks. The skill therefore requires agents to inspect `model.named_modules()` and prove that configured targets exist before training.
+
+### Quantized Training
+
+QLoRA workflows combine 4-bit loading, `bitsandbytes`, compute dtype, device maps, and `prepare_model_for_kbit_training`. The skill covers quantization as a training contract, not an optimization afterthought:
+
+- capture `bitsandbytes`, `transformers`, `peft`, `accelerate`, and `torch` versions;
+- verify the model loads on the intended devices;
+- run a tiny training smoke before a long job;
+- keep adapter save/load separate from merged model export.
+
+### Adapter Artifacts
+
+The source workflows save adapter weights and reload them with `PeftModel.from_pretrained`. The skill therefore requires:
+
+- base model id and revision;
+- tokenizer and chat template notes;
+- adapter config and checkpoint path;
+- fresh-process reload;
+- generation or prediction before and after merge when `merge_and_unload` is used.
+
+### Nonstandard LoRA
+
+Mined examples include non-transformer models and saved heads/modules. The skill must teach agents to identify when `modules_to_save`, classifier heads, embeddings, or output projections need to stay trainable.
+
+## Review Standard
+
+Reject PEFT/LoRA changes that only set a config. A useful workflow must prove trainable parameters, target-module match, dataset/tokenizer compatibility, adapter save/reload, and artifact ancestry. Version capture is required because PEFT, Transformers, bitsandbytes, and Accelerate interactions are version-sensitive.

--- a/skills/.curated/peft-lora/references/workflows.md
+++ b/skills/.curated/peft-lora/references/workflows.md
@@ -1,0 +1,97 @@
+# PEFT and LoRA Workflows
+
+Use this reference to complete adapter work end to end.
+
+## Base and Adapter Contract
+
+Record:
+
+```text
+base model id/path:
+base revision:
+adapter path or output path:
+tokenizer/chat template:
+task type:
+quantization:
+peft/transformers/torch/accelerate/bitsandbytes:
+```
+
+Adapters are not standalone unless merged. Treat the base model revision as part of the artifact.
+
+## Target Module Discovery
+
+List candidate modules:
+
+```python
+for name, module in model.named_modules():
+    if "Linear" in type(module).__name__:
+        print(name)
+```
+
+Choose target modules that match the architecture. Common LLM choices include attention projections and MLP projections, but names differ by model family.
+
+## Dataset and Tokenization
+
+Before training:
+
+- Print one raw example.
+- Print one formatted prompt.
+- Tokenize and print `input_ids`, `attention_mask`, and `labels`.
+- Confirm prompt/user tokens are masked when doing supervised instruction tuning.
+- Confirm pad/eos settings match inference.
+
+## Tiny Training Run
+
+Run the smallest real training command:
+
+```bash
+python train.py --max_steps 2 --per_device_train_batch_size 1
+```
+
+Adapt to TRL, Accelerate, Axolotl, Unsloth, or the repo launcher. The run must save an adapter and reload it.
+
+## QLoRA Checks
+
+Check:
+
+- `bitsandbytes` import works.
+- compute dtype is explicit.
+- quantization type is intentional.
+- device map is compatible with training.
+- the model is prepared for k-bit training when required.
+
+## Merge and Export
+
+Fresh process:
+
+```python
+from peft import PeftModel
+base = AutoModelForCausalLM.from_pretrained(base_model)
+model = PeftModel.from_pretrained(base, adapter_path)
+model.eval()
+```
+
+If merging:
+
+```python
+merged = model.merge_and_unload()
+merged.save_pretrained("merged-output")
+tokenizer.save_pretrained("merged-output")
+```
+
+Run one sample before and after merge and preserve the unmerged adapter unless the user explicitly wants only merged weights.
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+base model and revision:
+adapter config:
+target modules:
+trainable parameter count:
+tiny run command:
+reload command:
+merge status:
+upload/privacy constraints:
+```


### PR DESCRIPTION
## Summary

Adds the `peft-lora` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined PEFT 0.18.0 source evidence and Transformers version boundaries that affect adapter behavior.

## Validation

- Ran the local skill validator against `skills/.curated/peft-lora`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.