### PR TITLE
Add RAG and vector search skill

### DIFF
--- a/skills/.curated/rag-vector-search/LICENSE.txt
+++ b/skills/.curated/rag-vector-search/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/rag-vector-search/SKILL.md
+++ b/skills/.curated/rag-vector-search/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: rag-vector-search
+description: Build, debug, evaluate, or optimize retrieval-augmented generation and vector search systems. Use when working with embeddings, chunking, hybrid search, reranking, FAISS, Qdrant, Chroma, Pinecone, pgvector, sentence-transformers, retrieval evals, or production RAG pipelines.
+---
+
+# RAG and Vector Search
+
+Use this skill for retrieval systems. Optimize retrieval before changing generation prompts; bad context cannot be fixed reliably by a stronger answer prompt.
+
+## Validated Version Evidence
+
+This guidance was checked against mined retrieval repositories including `llama-index` 0.14.22, downstream locks with `llama-index` 0.14.10, `sentence-transformers` 5.2.0.dev0 and 5.2.2, and Haystack requirements using `transformers[torch, sentencepiece]>=4.57` and `sentence-transformers>=5.0.0`. Vector-store APIs move quickly, so capture exact versions before changing ingestion or query code:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["llama-index", "haystack-ai", "sentence-transformers", "transformers", "qdrant-client", "chromadb", "pinecone", "faiss-cpu", "pgvector"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to build or debug retrieval with measurable evidence. A complete run produces:
+
+- A pipeline map: parser, chunker, embedding model, vector store, filters, retriever, reranker, and generator.
+- A small gold set of queries with expected source IDs.
+- Inspectable retrieved chunks with source metadata.
+- Separate retrieval metrics before any answer-generation judgment.
+- A recommendation that names the failing stage when quality is poor.
+
+## Standalone Quick Start
+
+If no framework is already present, prove the retrieval loop with a tiny corpus before adding infrastructure:
+
+```python
+import math
+import re
+from collections import Counter
+
+def tokens(text):
+    return re.findall(r"[a-z0-9_]+", text.lower())
+
+def vector(text):
+    return Counter(tokens(text))
+
+def cosine(a, b):
+    numerator = sum(a[k] * b.get(k, 0) for k in a)
+    denom = math.sqrt(sum(v * v for v in a.values())) * math.sqrt(sum(v * v for v in b.values()))
+    return numerator / denom if denom else 0.0
+
+docs = [
+    {"id": "install", "text": "Install with pip and configure environment variables."},
+    {"id": "auth", "text": "Credentials and API keys belong in the secret store."},
+]
+queries = [{"query": "where do I put credentials?", "expected": "auth"}]
+doc_vectors = [vector(d["text"]) for d in docs]
+for item in queries:
+    query_vector = vector(item["query"])
+    scores = [cosine(query_vector, doc_vector) for doc_vector in doc_vectors]
+    ranked = [docs[i]["id"] for i in sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)]
+    print(item["query"], ranked, "hit@1", ranked[0] == item["expected"])
+```
+
+Then replace the toy vectorizer with the repo's embedding/index stack while keeping the same gold-set output shape.
+
+## Workflow
+
+1. Identify the retrieval objective: semantic search, QA grounding, recommendations, deduplication, or memory lookup.
+2. Map the pipeline: ingestion, parsing, chunking, embedding, indexing, filtering, retrieval, reranking, answer generation, and evaluation.
+3. Create a tiny repeatable test corpus with known relevant answers before tuning.
+4. Inspect retrieved chunks directly before judging generated answers.
+5. Add evaluation that measures retrieval quality separately from answer quality.
+
+## Ingestion and Chunking
+
+- Preserve source IDs, document titles, section paths, timestamps, and permissions as metadata.
+- Chunk by semantic boundaries when possible: headings, paragraphs, functions, classes, or pages.
+- Keep chunks small enough for precise retrieval but large enough to preserve local context.
+- Store stable checksums to avoid duplicate re-ingestion.
+- Respect access control at query time, not only during ingestion.
+
+## Embeddings and Indexes
+
+- Use the same embedding model and preprocessing at ingestion and query time.
+- Record embedding model name, dimension, normalization, distance metric, and index type.
+- For FAISS, verify index metric and vector normalization.
+- For Qdrant, Chroma, Pinecone, or pgvector, verify collection schema, metadata filters, and payload persistence.
+- Rebuild the index when embedding dimensions, model, or normalization change.
+
+## References
+
+Open `references/workflows.md` for detailed ingestion design, chunking strategies, vector-store checks, hybrid search, reranking, evaluation metrics, and production review artifacts.
+
+Open `references/mastery.md` for retrieval mental models, failure diagnosis, evaluation philosophy, access-control risks, and review standards.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in mined/source repository evidence.
+
+## Retrieval Quality
+
+- Evaluate recall with known query-document pairs before adding complex reranking.
+- Keep a small gold set table with `query`, `expected_source_id`, `retrieved_source_ids`, `hit@k`, and `rank` so regressions are visible in code review.
+- Inspect false positives and false negatives; adjust chunking and metadata filters first.
+- Use hybrid lexical + vector search when exact names, IDs, errors, or code symbols matter.
+- Add reranking when top-k recall is good but ordering is weak.
+- Avoid stuffing too many retrieved chunks into the answer context.
+
+For a first useful eval, five to twenty representative queries are enough if they cover exact identifiers, paraphrased concepts, negative/permission-filtered cases, and recently changed documents.
+
+Recommended debug order:
+
+1. Print retrieved chunks before reading generated answers.
+2. Check metadata filters and permissions.
+3. Check chunk boundaries and source IDs.
+4. Check embedding model/dimension/normalization/index metric.
+5. Add hybrid search or reranking only after top-k recall is acceptable.
+
+## Debugging
+
+- Empty results: check filters, collection name, embedding dimension, and ingestion success.
+- Irrelevant results: check chunk boundaries, query rewriting, metric choice, and normalization.
+- Duplicate results: check document IDs and chunk checksums.
+- Slow queries: inspect index type, payload filters, top-k, network latency, and reranker cost.
+- Hallucinated answers: verify retrieved context contains the answer before changing the generation model.
+
+## Done Criteria
+
+- A small gold set or smoke queries exercise retrieval.
+- Retrieved chunks are inspectable with source metadata.
+- Retrieval metrics are reported separately from answer-generation quality.
+- Index configuration and embedding model assumptions are documented.
+- The final notes include the top retrieved source IDs for at least one representative query.

--- a/skills/.curated/rag-vector-search/agents/openai.yaml
+++ b/skills/.curated/rag-vector-search/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RAG and Vector Search"
+  short_description: "Build and evaluate retrieval pipelines"
+  default_prompt: "Use $rag-vector-search to build, debug, or evaluate this retrieval system."

--- a/skills/.curated/rag-vector-search/references/mastery.md
+++ b/skills/.curated/rag-vector-search/references/mastery.md
@@ -1,0 +1,46 @@
+# RAG and Vector Search Mastery Notes
+
+## Mental Model
+
+RAG quality is bounded by retrieval quality. Generation can only answer from context that was retrieved, ranked, and passed through correctly.
+
+## Core Contracts
+
+- ingestion preserves source identity
+- chunks preserve meaning
+- embeddings match query preprocessing
+- index metric matches vector normalization
+- filters enforce permissions
+- reranking improves ordering, not missing recall
+- generated answers cite retrieved sources
+
+## Evaluation Philosophy
+
+Separate:
+
+- retrieval recall
+- ranking quality
+- context packing
+- answer faithfulness
+- answer usefulness
+
+Do not tune prompts before proving the answer exists in retrieved context.
+
+## Failure Diagnosis
+
+- Empty results: filters, collection name, ingestion.
+- Wrong results: chunking, embeddings, metric.
+- Good docs but bad order: reranking.
+- Good context but bad answer: prompt/generator.
+- Unauthorized docs: query-time permission bug.
+
+## Review Standard
+
+A complete RAG change proves:
+
+- pipeline map exists
+- gold set exists
+- source metadata is inspectable
+- retrieval metrics are reported
+- at least one false positive/negative is analyzed
+- access control is considered

--- a/skills/.curated/rag-vector-search/references/source-evidence.md
+++ b/skills/.curated/rag-vector-search/references/source-evidence.md
@@ -1,0 +1,42 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. The skill should train an agent to build and debug an inspectable retrieval system with measured retrieval behavior.
+
+## Retrieved Sources
+
+- `run-llama/llama_index`: mined node parsing, metadata-aware splitting, node construction, and parser loading evidence.
+- `deepset-ai/haystack`: pipeline docs and components for converters, preprocessors, retrievers, joiners, and RAG pipeline visualization.
+- `UKPLab/sentence-transformers`: dense embedding, CrossEncoder reranking, SparseEncoder, semantic search, hybrid retrieval, and FAISS quantization evidence.
+- Mined package evidence: `llama-index` 0.14.x, `sentence-transformers` 5.2.x, and Haystack stacks with `transformers` / `sentence-transformers` version constraints.
+
+## Workflows Reflected In The Skill
+
+### Ingestion And Chunking
+
+LlamaIndex evidence emphasizes node construction, source relationships, metadata strings, and metadata-aware text splitting. The skill therefore requires:
+
+- source IDs and section metadata;
+- chunk boundaries that preserve document structure;
+- stable checksums or IDs for re-ingestion;
+- explicit parser and chunker mapping before index changes.
+
+### Retrieval Before Generation
+
+Haystack and LlamaIndex pipelines separate conversion, preprocessing, retrieval, prompt construction, and answer generation. The skill requires agents to inspect retrieved chunks before reading generated answers and to report retrieval metrics separately from answer quality.
+
+### Embeddings, Sparse Retrieval, And Reranking
+
+Sentence Transformers evidence includes dense embeddings, sparse encoders, CrossEncoder reranking, semantic search, and FAISS-backed search. The skill covers:
+
+- embedding model and dimension capture;
+- distance metric and vector normalization;
+- hybrid lexical/vector search for exact IDs and code symbols;
+- reranking only after top-k recall is good enough.
+
+### Production RAG Boundaries
+
+The mined workflows show retrieval pipelines as multi-stage systems, so this skill requires a pipeline map and a small gold set. Agents must identify which stage failed: parsing, chunking, embedding, filtering, vector-store schema, retriever, reranker, or generation.
+
+## Review Standard
+
+Reject RAG changes that only tune prompts or swap models. A useful workflow must include inspectable source metadata, test queries with expected source IDs, retrieval metrics, and a diagnosis that names the failing retrieval stage before changing generation.

--- a/skills/.curated/rag-vector-search/references/workflows.md
+++ b/skills/.curated/rag-vector-search/references/workflows.md
@@ -1,0 +1,119 @@
+# RAG and Vector Search Workflows
+
+Use this reference to make retrieval systems measurable and repeatable.
+
+## Contents
+
+- [Pipeline Map](#pipeline-map)
+- [Ingestion](#ingestion)
+- [Index Validation](#index-validation)
+- [Gold Set](#gold-set)
+- [Debugging Order](#debugging-order)
+- [Production Review](#production-review)
+- [Final Artifact](#final-artifact)
+
+## Pipeline Map
+
+Document each stage:
+
+```text
+sources:
+parser:
+chunker:
+metadata:
+embedding model:
+vector dimension:
+normalization:
+index/store:
+filters:
+retriever:
+reranker:
+generator:
+eval set:
+```
+
+## Ingestion
+
+Required metadata:
+
+- stable source ID
+- title/path/section
+- timestamp or revision
+- permissions/access group
+- checksum
+
+Chunking strategy:
+
+- Docs: headings and paragraphs.
+- Code: functions/classes/files.
+- PDFs/slides: page plus heading when available.
+- Tables: preserve row/column labels.
+
+## Index Validation
+
+After ingestion, check:
+
+- document count
+- chunk count
+- embedding dimension
+- distance metric
+- sample payload metadata
+- duplicate checksum count
+
+Never mix embeddings from different models or dimensions in one collection unless the store explicitly supports it.
+
+## Gold Set
+
+Create 5-20 queries covering:
+
+- exact names/IDs/errors
+- paraphrased concepts
+- negative cases
+- permission-filtered cases
+- recently changed documents
+
+Evaluate:
+
+```text
+hit@1
+hit@3
+hit@5
+MRR
+false positives
+false negatives
+```
+
+## Debugging Order
+
+1. Print raw retrieved chunks.
+2. Remove generator from the loop.
+3. Disable filters temporarily to identify filter bugs.
+4. Compare lexical vs vector retrieval for exact terms.
+5. Inspect chunk boundaries.
+6. Check metric/normalization.
+7. Add reranking only when top-k recall is acceptable.
+
+## Production Review
+
+Check:
+
+- access control at query time
+- deletion/reindex behavior
+- source refresh schedule
+- observability for empty/low-confidence results
+- citation/source display
+- cost and latency of embeddings and reranker
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+pipeline map:
+index config:
+gold queries:
+retrieval metrics:
+sample retrieved chunks:
+answer quality result, if generation was tested:
+remaining retrieval risks:
+```


### PR DESCRIPTION
## Summary

Adds the `rag-vector-search` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined retrieval evidence from llama-index 0.14.x, sentence-transformers 5.2.x, and Haystack requirements around Transformers 4.57+.

## Validation

- Ran the local skill validator against `skills/.curated/rag-vector-search`.
- Audited `SKILL.md` and references for machine-specific local path leakage.
- Executed the standalone pure-Python retrieval smoke example and confirmed `hit@1` passes.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.