### PR TITLE
Add tokenizers skill

### DIFF
--- a/skills/.curated/tokenizers/LICENSE.txt
+++ b/skills/.curated/tokenizers/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/tokenizers/SKILL.md
+++ b/skills/.curated/tokenizers/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: tokenizers
+description: Build, train, inspect, debug, or migrate text tokenizers for LLM and NLP projects. Use when working with Hugging Face Tokenizers, BPE, byte-level BPE, WordPiece, Unigram, SentencePiece, special tokens, chat templates, tokenizer JSON files, vocabulary/merge files, offset mappings, or tokenizer/model compatibility bugs.
+---
+
+# Tokenizers
+
+Use this skill for tokenizer work. Tokenizer changes are compatibility changes: preserve reproducibility and test old/new encodings before replacing artifacts.
+
+## Validated Version Evidence
+
+This guidance was checked against a mined Hugging Face `tokenizers` source checkout at `tokenizers` 0.22.2-dev.0, with Python bindings requiring Python >=3.9. Related mined environments locked `tokenizers` 0.22.1 and 0.22.2, and the mined `transformers` source expected `tokenizers>=0.22.0,<=0.23.0`.
+
+Before modifying tokenizer artifacts, capture the active versions:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["tokenizers", "transformers", "sentencepiece", "huggingface-hub"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to make tokenizer behavior explicit and reproducible. A complete run produces:
+
+- The tokenizer artifact paths and package versions.
+- Old/new encodings for representative prompts.
+- Special token IDs, chat template, vocab size, padding/truncation settings, and max length.
+- A save/reload check in a fresh process.
+- A compatibility statement for the target model embedding size or resize step.
+
+## Standalone Quick Start
+
+When there is no existing tokenizer test, run this baseline before editing artifacts:
+
+```bash
+python - <<'PY'
+from transformers import AutoTokenizer
+
+path = "."
+t = AutoTokenizer.from_pretrained(path)
+samples = ["hello world", " hello", "<|endoftext|>", "def foo(x): return x + 1"]
+print("vocab", len(t))
+print("special", t.special_tokens_map)
+print("chat_template", bool(getattr(t, "chat_template", None)))
+for s in samples:
+    ids = t.encode(s)
+    print(repr(s), ids, t.decode(ids))
+PY
+```
+
+If `AutoTokenizer.from_pretrained(".")` does not apply, replace `path` with the tokenizer directory or model id used by the repo.
+
+## Workflow
+
+1. Identify tokenizer type and artifacts: `tokenizer.json`, vocab, merges, SentencePiece model, special token maps, chat template, and model config.
+2. Encode a few representative strings before changing anything:
+
+```bash
+python - <<'PY'
+from transformers import AutoTokenizer
+t = AutoTokenizer.from_pretrained(".")
+for s in ["hello world", " hello", "<|endoftext|>"]:
+    print(repr(s), t.encode(s), t.decode(t.encode(s)))
+PY
+```
+
+3. Check vocabulary size, special token IDs, padding side, truncation, and max length.
+4. Make changes in one place and save all dependent tokenizer files together.
+5. Compare old and new token IDs for representative prompts.
+
+After saving artifacts, reload them in a fresh process instead of relying on the in-memory tokenizer:
+
+```bash
+python - <<'PY'
+from transformers import AutoTokenizer
+saved_tokenizer = "<saved-tokenizer-dir-or-model-id>"
+t = AutoTokenizer.from_pretrained(saved_tokenizer)
+print(len(t), t.special_tokens_map)
+print(t.encode("The saved tokenizer reloads."))
+PY
+```
+
+## Training and Conversion
+
+- Choose the algorithm for the data and model family: BPE, byte-level BPE, WordPiece, or Unigram.
+- Normalize text deliberately; case folding, Unicode normalization, and whitespace handling affect every downstream result.
+- Include domain-specific tokens only when they occur often enough to justify vocabulary slots.
+- Reserve special tokens before training or add them consistently after training.
+- When converting formats, verify both encoding IDs and decoded text.
+
+## References
+
+Open `references/workflows.md` for detailed tokenizer training, conversion, compatibility, chat-template, offset-mapping, and model-resize workflows.
+
+Open `references/mastery.md` for tokenizer mental models, algorithm choices, artifact contracts, prompt-format risks, and review standards.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in mined/source repository evidence.
+
+## Compatibility Checks
+
+- Tokenizer vocab size must match model embedding size unless the model is resized and saved.
+- Chat templates must produce exactly the prompt format expected by the trained model.
+- `pad_token_id`, `eos_token_id`, `bos_token_id`, and `unk_token_id` should be explicit.
+- Offset mappings matter for extraction, highlighting, NER, and evaluation.
+- Byte-level tokenizers may preserve leading spaces in ways that affect tests.
+- Fast and slow tokenizer implementations should agree for representative inputs when both are supported.
+
+Model compatibility check:
+
+```python
+embedding_rows = model.get_input_embeddings().weight.shape[0]
+assert len(tokenizer) == embedding_rows, (len(tokenizer), embedding_rows)
+```
+
+If the tokenizer is intentionally expanded, resize embeddings and save the model/config together with the tokenizer.
+
+## Debugging
+
+- If generation never stops, inspect EOS token IDs and stop sequences.
+- If fine-tuning labels are wrong, inspect masked label positions after tokenization.
+- If prompts get much longer, compare token counts and whitespace normalization.
+- If model loading warns about size mismatch, compare tokenizer vocab and embedding shape.
+- If multilingual text breaks, inspect normalization, pre-tokenization, unknown tokens, and byte fallback.
+
+## Done Criteria
+
+- Old/new encodings are compared for representative text.
+- Special tokens and chat templates are verified.
+- The tokenizer artifact can be loaded in a fresh process with the target model or training script.
+- The final notes include whether model embeddings were unchanged, resized, or not checked.

--- a/skills/.curated/tokenizers/agents/openai.yaml
+++ b/skills/.curated/tokenizers/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tokenizers"
+  short_description: "Build and debug model tokenizers"
+  default_prompt: "Use $tokenizers to train, inspect, or debug this tokenizer."

--- a/skills/.curated/tokenizers/references/mastery.md
+++ b/skills/.curated/tokenizers/references/mastery.md
@@ -1,0 +1,46 @@
+# Tokenizers Mastery Notes
+
+## Mental Model
+
+A tokenizer is part of the model contract. Changing tokenization changes sequence length, special-token behavior, labels, offsets, and embedding compatibility.
+
+## Algorithm Choices
+
+- BPE: common for GPT-style models.
+- Byte-level BPE: robust to arbitrary bytes and whitespace-sensitive text.
+- WordPiece: common for BERT-style models.
+- Unigram/SentencePiece: common for multilingual and seq2seq families.
+
+Choose based on the model family and training data, not convenience.
+
+## Artifact Contract
+
+Tokenizer artifacts should be saved and versioned together:
+
+```text
+tokenizer.json
+tokenizer_config.json
+special_tokens_map.json
+vocab/merges or sentencepiece model
+model config when embedding size changes
+```
+
+## High-Risk Changes
+
+- adding/removing special tokens
+- changing chat templates
+- changing normalization
+- changing padding side
+- changing max length/truncation
+- replacing tokenizer without resizing embeddings
+
+## Review Standard
+
+A complete tokenizer change proves:
+
+- old/new encodings are compared
+- special tokens are explicit
+- chat template is rendered
+- save/reload works
+- model embedding compatibility is checked
+- offset mappings are checked when relevant

--- a/skills/.curated/tokenizers/references/source-evidence.md
+++ b/skills/.curated/tokenizers/references/source-evidence.md
@@ -1,0 +1,37 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. Tokenizer work is compatibility work; the skill must guide an agent through reproducible artifact changes and behavior checks.
+
+## Retrieved Sources
+
+- `huggingface/tokenizers`: Rust/Python/Node source and tests covering BPE, WordPiece, Unigram, normalizers, pre-tokenizers, post-processors, encoders, decoders, offsets, truncation, and save/load behavior.
+- `huggingface/transformers`: `PreTrainedTokenizerFast` integration, trainer mapping for BPE/Unigram/WordLevel/WordPiece, `tokenizer.json` save behavior, special token handling, offsets, and retraining-from-existing-tokenizer behavior.
+- Related mined environments: `tokenizers` 0.22.x and `transformers` constraints expecting `tokenizers>=0.22.0,<=0.23.0`.
+
+## Workflows Reflected In The Skill
+
+### Artifact Inventory
+
+Transformers source treats fast tokenizer state as a `tokenizer.json` artifact while slow/tokenizer-specific formats may also require vocab, merges, SentencePiece model files, added-token maps, and special-token maps. The skill therefore requires agents to inventory every tokenizer artifact before editing.
+
+### Behavior Comparison
+
+Tokenizers tests exercise encode/decode, batch encode/decode, truncation, pair inputs, offsets, and special token behavior. The skill requires old/new behavior tables for representative strings, including:
+
+- leading spaces and Unicode;
+- special tokens;
+- code-like text;
+- chat-template formatted examples;
+- offset mappings when alignment matters.
+
+### Training And Conversion
+
+Transformers maps model types to trainer classes for BPE, Unigram, WordLevel, and WordPiece. The skill requires algorithm selection, normalization choices, special-token reservation, and save/reload checks rather than one-off artifact edits.
+
+### Model Compatibility
+
+Tokenizer length and special-token IDs affect model embeddings and prompt formatting. The skill requires agents to state whether model embeddings need resizing and whether chat templates or generation stop tokens changed.
+
+## Review Standard
+
+Reject tokenizer changes without behavior evidence. A useful workflow must show installed versions, artifact inventory, representative old/new encodings, special token IDs, save/reload results, and model compatibility notes.

--- a/skills/.curated/tokenizers/references/workflows.md
+++ b/skills/.curated/tokenizers/references/workflows.md
@@ -1,0 +1,113 @@
+# Tokenizers Workflows
+
+Use this reference when tokenizer changes need to be safe across training and inference.
+
+## Contents
+
+- [Artifact Inventory](#artifact-inventory)
+- [Baseline Comparison](#baseline-comparison)
+- [Training a Tokenizer](#training-a-tokenizer)
+- [Chat Template Checks](#chat-template-checks)
+- [Offset Mapping Checks](#offset-mapping-checks)
+- [Model Resize](#model-resize)
+- [Final Artifact](#final-artifact)
+
+## Artifact Inventory
+
+Record:
+
+```text
+tokenizer.json:
+vocab/merges/model files:
+special_tokens_map.json:
+tokenizer_config.json:
+chat_template:
+model config:
+model embedding rows:
+```
+
+## Baseline Comparison
+
+Before editing, save encodings for:
+
+- leading-space examples
+- code snippets
+- chat prompts
+- multilingual text
+- special tokens
+- long input near max length
+
+Output format:
+
+```text
+sample:
+old ids:
+new ids:
+old decoded:
+new decoded:
+token count delta:
+```
+
+## Training a Tokenizer
+
+1. Choose BPE, byte-level BPE, WordPiece, or Unigram based on the model family.
+2. Decide normalization and pre-tokenization.
+3. Reserve special tokens before training.
+4. Train on representative data with deduplication.
+5. Save all artifacts together.
+6. Reload in a fresh process.
+
+Do not replace a production tokenizer without comparing downstream prompt formatting and model embedding size.
+
+## Chat Template Checks
+
+Render one conversation:
+
+```python
+text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+ids = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True)
+print(text)
+print(ids)
+```
+
+Confirm the output matches the format used during training.
+
+## Offset Mapping Checks
+
+For extraction, NER, highlighting, or eval alignment:
+
+```python
+encoded = tokenizer("Alice lives in Paris", return_offsets_mapping=True)
+print(encoded.tokens())
+print(encoded["offset_mapping"])
+```
+
+If offsets are wrong, inspect normalization and pre-tokenization.
+
+## Model Resize
+
+If tokens are added:
+
+```python
+num_added = tokenizer.add_tokens(["<NEW_TOKEN>"])
+if num_added:
+    model.resize_token_embeddings(len(tokenizer))
+    model.save_pretrained("resized-model")
+    tokenizer.save_pretrained("resized-model")
+```
+
+Reload the pair in a fresh process and assert tokenizer length equals embedding rows.
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+tokenizer source:
+old/new vocab size:
+special token IDs:
+chat template status:
+representative old/new encodings:
+model embedding compatibility:
+save/reload path:
+```


### PR DESCRIPTION
## Summary

Adds the `tokenizers` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined tokenizers 0.22.x evidence and the related Transformers tokenizers compatibility range.

## Validation

- Ran the local skill validator against `skills/.curated/tokenizers`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.