### PR TITLE
Add Docker and Kubernetes DevOps skill

### DIFF
--- a/skills/.curated/docker-kubernetes-devops/LICENSE.txt
+++ b/skills/.curated/docker-kubernetes-devops/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/docker-kubernetes-devops/SKILL.md
+++ b/skills/.curated/docker-kubernetes-devops/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: docker-kubernetes-devops
+description: Build, run, debug, harden, or deploy containerized applications with Docker, Docker Compose, Kubernetes, kubectl, Helm, or KIND. Use when working on Dockerfiles, Compose stacks, image builds, container logs, local clusters, manifests, services, ingress, secrets, health checks, or deployment failures.
+---
+
+# Docker and Kubernetes DevOps
+
+Use this skill for container and Kubernetes work. Preserve the user's environment: inspect before pruning, deleting, restarting services, or changing cluster state.
+
+## Validated Version Evidence
+
+This guidance was checked against mined repositories using Docker Python SDK 7.1.0 and Kubernetes Python clients 33.1.0 and 35.0.0. The operational workflow depends primarily on installed Docker, Compose, kubectl, Helm, and cluster versions, so capture those before applying version-sensitive advice:
+
+```bash
+docker version
+docker compose version
+kubectl version --client
+helm version --short
+```
+
+For Kubernetes API-client code, also record package versions:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["docker", "kubernetes"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to make a container or Kubernetes workload build, start, and prove readiness without damaging the user's environment. A complete run produces:
+
+- The active Docker/Kubernetes/Helm context and versions.
+- The exact build/run/apply command used.
+- Logs, describe output, health check, or request output proving the workload state.
+- A minimal manifest/Dockerfile/Compose/Helm values change when code changes are needed.
+- A final note calling out any destructive or cluster-mutating command.
+
+## Standalone Quick Start
+
+For Docker-only apps, prefer the smallest local proof:
+
+```bash
+docker build -t local/app-check .
+docker run --rm --detach --name app-check -p 8080:8080 local/app-check
+docker logs --tail=100 app-check
+curl -f http://localhost:8080/health || curl -f http://localhost:8080/
+docker stop app-check
+```
+
+For Compose apps:
+
+```bash
+docker compose config
+docker compose up --build
+docker compose ps
+docker compose logs --tail=100
+```
+
+For Kubernetes apps, inspect before changing and prefer a local KIND/minikube context unless the user explicitly targets a remote cluster.
+
+## Workflow
+
+1. Identify the target: local Docker, Compose, local Kubernetes, or remote Kubernetes.
+2. Inspect current state before acting:
+
+```bash
+docker ps
+docker compose ps
+kubectl config current-context
+kubectl get pods -A
+```
+
+3. Read the Dockerfile, Compose files, manifests, Helm chart, and deployment docs.
+4. Reproduce with the smallest local command before changing deployment configuration.
+5. Validate the running service with logs, health checks, and an actual request.
+
+For Kubernetes, treat the active context as a safety boundary. If `kubectl config current-context` points at a shared or production-like cluster, ask before applying, restarting, scaling, or deleting anything.
+
+## Docker
+
+- Keep image layers deterministic and cache-friendly.
+- Use `.dockerignore` to avoid copying secrets, build artifacts, virtualenvs, and large data.
+- Prefer non-root runtime users when the app supports it.
+- Separate build-time and runtime dependencies with multi-stage builds when useful.
+- Add health checks only when they reflect real readiness.
+- Do not run broad cleanup commands unless the user asks or disk pressure requires it.
+
+## Docker Compose
+
+- Check service names, ports, volumes, environment variables, and dependency readiness.
+- Use `docker compose logs --tail=100 <service>` and `docker compose exec <service> ...` for targeted debugging.
+- Distinguish container start order from application readiness.
+- Keep development-only services and production settings separate.
+
+## Kubernetes
+
+- Confirm context and namespace before applying or deleting resources.
+- Use `kubectl describe` and events before changing manifests.
+- For a failing pod, start with `kubectl describe pod <pod> -n <namespace>`, `kubectl logs <pod> -n <namespace> --previous` when it is restarting, and `kubectl get events -n <namespace> --sort-by=.lastTimestamp`.
+- Check probes, resource requests/limits, image pull secrets, config maps, secrets, service selectors, and ingress routing.
+- For local testing, KIND is appropriate when the task needs Kubernetes semantics rather than just containers.
+- Prefer declarative changes to manifests or Helm values over imperative cluster drift.
+
+## References
+
+Open `references/workflows.md` for detailed Dockerfile, Compose, Kubernetes, Helm, rollout, networking, storage, security, and incident-debugging workflows.
+
+Open `references/mastery.md` for container/Kubernetes mental models, safety boundaries, deployment failure diagnosis, and review standards.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in mined/source repository evidence.
+
+Kubernetes proof loop:
+
+```bash
+kubectl get deploy,po,svc,ingress -n <namespace>
+kubectl describe pod <pod> -n <namespace>
+kubectl logs <pod> -n <namespace> --tail=100
+kubectl port-forward svc/<service> 8080:<service-port> -n <namespace>
+curl -f http://localhost:8080/health || curl -f http://localhost:8080/
+```
+
+## Debugging Checklist
+
+- Image build fails: inspect build context, base image, package manager cache, and platform.
+- Container exits: inspect command, env vars, working directory, permissions, and logs.
+- Service unreachable: inspect port mapping, service selector, readiness, ingress, and network policy.
+- Pod pending: inspect resources, node selectors, taints, PVCs, and image pull status.
+- CrashLoopBackOff: inspect previous logs and startup probes.
+
+## Done Criteria
+
+- The relevant container or workload starts.
+- Logs and health/readiness checks support the result.
+- Any destructive or state-changing command is called out in the final notes.
+- The final notes include context, namespace, image tag, and proof command output.

--- a/skills/.curated/docker-kubernetes-devops/agents/openai.yaml
+++ b/skills/.curated/docker-kubernetes-devops/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docker and Kubernetes"
+  short_description: "Build and debug container deployments"
+  default_prompt: "Use $docker-kubernetes-devops to build, run, or debug this container setup."

--- a/skills/.curated/docker-kubernetes-devops/references/mastery.md
+++ b/skills/.curated/docker-kubernetes-devops/references/mastery.md
@@ -1,0 +1,41 @@
+# Docker and Kubernetes DevOps Mastery Notes
+
+## Mental Model
+
+Docker packages a process and filesystem. Compose coordinates local services. Kubernetes reconciles desired state through controllers. Debug by finding which layer owns the failure.
+
+## Layer Map
+
+```text
+source code
+Dockerfile/image
+container process
+Compose service
+Kubernetes pod
+service/endpoints
+ingress/gateway
+external client
+```
+
+## Safety Boundaries
+
+Always know the active context before mutating state. Treat remote clusters as shared until proven otherwise. Ask before deleting, pruning, restarting production workloads, scaling down, or rolling back.
+
+## Failure Diagnosis
+
+- Build failure: context, base image, package install, platform.
+- Start failure: command, env, filesystem, permissions.
+- Readiness failure: probes, startup time, dependencies.
+- Traffic failure: ports, selectors, endpoints, ingress, DNS.
+- Scheduling failure: resources, taints, PVCs.
+
+## Review Standard
+
+A complete DevOps change proves:
+
+- versions/context captured
+- build/render/apply command recorded
+- logs or health request prove state
+- manifests remain declarative
+- secrets are not embedded
+- destructive actions are disclosed

--- a/skills/.curated/docker-kubernetes-devops/references/source-evidence.md
+++ b/skills/.curated/docker-kubernetes-devops/references/source-evidence.md
@@ -1,0 +1,43 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. Container and cluster work is operationally risky, so the skill emphasizes inspection, minimal reproduction, and proof of readiness.
+
+## Retrieved Sources
+
+- `OpenHands/OpenHands`: Docker development workflows, dev containers, runtime images, Docker runtime configuration, Kubernetes config template fields, Helm compatibility notes, and lock evidence for Docker SDK / Kubernetes client versions.
+- `meta-llama/llama-stack`: Docker distribution images, local-to-production deployment framing, health endpoint usage, and Kubernetes client lock evidence.
+- `letta-ai/letta`: Docker SDK dependency evidence.
+- `openai/openai-agents-python`: sandbox/container agent references.
+
+## Workflows Reflected In The Skill
+
+### Environment Inspection
+
+OpenHands development docs and runtime configuration show Docker and Kubernetes as active developer/runtime environments. The skill therefore requires version/context capture and state inspection before mutation:
+
+- Docker and Compose versions;
+- active Kubernetes context and namespace;
+- current containers, pods, services, ingress, and events;
+- explicit warning before acting on shared or production-like contexts.
+
+### Container Build And Runtime Proof
+
+Source repos use Docker for development containers, runtime sandboxes, and distribution images. The skill requires agents to prove a container starts and responds:
+
+- build with the project Dockerfile;
+- run the smallest local command;
+- inspect logs;
+- hit a health endpoint or root endpoint;
+- avoid broad cleanup commands unless requested.
+
+### Kubernetes Diagnosis
+
+OpenHands configuration includes ingress domains, image pull secrets, resource requests/limits, node selectors, tolerations, and privileged runtime settings. The skill covers these as first-class diagnosis points for failing pods and unreachable services.
+
+### Deployment Review
+
+Llama Stack distribution docs emphasize deployment choices without application API changes. The skill therefore requires final notes that include context, namespace, image tag, applied command, logs/health evidence, and any state-changing action.
+
+## Review Standard
+
+Reject Docker/Kubernetes guidance that jumps straight to `apply`, `delete`, `restart`, or cleanup. A useful workflow must inspect the environment, reproduce locally where possible, make minimal declarative changes, and prove readiness with logs plus a request or health check.

--- a/skills/.curated/docker-kubernetes-devops/references/workflows.md
+++ b/skills/.curated/docker-kubernetes-devops/references/workflows.md
@@ -1,0 +1,117 @@
+# Docker and Kubernetes DevOps Workflows
+
+Use this reference for complete container and cluster workflows.
+
+## Contents
+
+- [Dockerfile Review](#dockerfile-review)
+- [Compose Workflow](#compose-workflow)
+- [Kubernetes Debugging](#kubernetes-debugging)
+- [Rollout Workflow](#rollout-workflow)
+- [Helm Workflow](#helm-workflow)
+- [Security Checks](#security-checks)
+- [Final Artifact](#final-artifact)
+
+## Dockerfile Review
+
+Check:
+
+- base image and platform
+- lockfile/package install order
+- `.dockerignore`
+- non-root user
+- build vs runtime dependencies
+- exposed port
+- health/readiness command
+- secret handling
+
+Build proof:
+
+```bash
+docker build --progress=plain -t local/app-check .
+docker run --rm local/app-check <smoke command>
+```
+
+## Compose Workflow
+
+```bash
+docker compose config
+docker compose build
+docker compose up
+docker compose ps
+docker compose logs --tail=100 <service>
+docker compose exec <service> <health command>
+```
+
+If a service depends on another, verify application readiness, not just container start order.
+
+## Kubernetes Debugging
+
+Inspect in this order:
+
+```bash
+kubectl config current-context
+kubectl get pods -n <namespace>
+kubectl describe pod <pod> -n <namespace>
+kubectl logs <pod> -n <namespace> --tail=100
+kubectl logs <pod> -n <namespace> --previous
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+```
+
+Failure map:
+
+- `ImagePullBackOff`: image name, tag, registry auth, platform.
+- `CrashLoopBackOff`: command, env, config, startup probe, previous logs.
+- `Pending`: resources, PVC, taints, node selectors.
+- No traffic: selectors, endpoints, readiness, ingress, DNS, network policy.
+
+## Rollout Workflow
+
+```bash
+kubectl apply -f manifest.yaml
+kubectl rollout status deploy/<name> -n <namespace>
+kubectl get deploy,rs,po,svc,ingress -n <namespace>
+```
+
+If rollout fails:
+
+```bash
+kubectl rollout history deploy/<name> -n <namespace>
+kubectl rollout undo deploy/<name> -n <namespace>
+```
+
+Ask before undoing in shared or production-like contexts.
+
+## Helm Workflow
+
+```bash
+helm lint chart/
+helm template release chart/ -f values.yaml
+helm upgrade --install release chart/ -f values.yaml --namespace <namespace>
+helm status release -n <namespace>
+```
+
+For review, prefer values changes over rendered manifest edits.
+
+## Security Checks
+
+- Avoid privileged containers unless required.
+- Avoid hostPath unless required.
+- Use secrets/config maps intentionally.
+- Set resource requests/limits.
+- Use read-only root filesystem when practical.
+- Keep production secrets out of images and Compose files.
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+context/namespace:
+image tag:
+build command:
+deploy/apply command:
+logs/health proof:
+destructive commands:
+remaining risks:
+```


### PR DESCRIPTION
## Summary

Adds the `docker-kubernetes-devops` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined Docker Python SDK 7.1.0 and Kubernetes Python client 33.1.0/35.0.0 evidence, plus CLI version capture.

## Validation

- Ran the local skill validator against `skills/.curated/docker-kubernetes-devops`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.