### PR TITLE
Add PowerPoint and Excel authoring skill

### DIFF
--- a/skills/.curated/powerpoint-excel-authoring/LICENSE.txt
+++ b/skills/.curated/powerpoint-excel-authoring/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/powerpoint-excel-authoring/SKILL.md
+++ b/skills/.curated/powerpoint-excel-authoring/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: powerpoint-excel-authoring
+description: Create, edit, inspect, validate, or automate PowerPoint decks and Excel workbooks. Use when working with .pptx or .xlsx files, python-pptx, openpyxl, financial models, charts, tables, slide templates, speaker notes, workbook formulas, named ranges, or model-backed presentation outputs.
+---
+
+# PowerPoint and Excel Authoring
+
+Use this skill for generated or edited Office artifacts. Treat decks and workbooks as inspectable files with structure, not screenshots; validate the actual document after writing it.
+
+## Validated Version Evidence
+
+This guidance was checked against mined environments using `python-pptx` 1.0.2 and `openpyxl` 3.1.5. Office file rendering still varies by viewer, fonts, and chart support, so capture library versions before debugging generated files:
+
+```bash
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["python-pptx", "openpyxl", "xlsxwriter", "pandas"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+If the project has no package manager or the required Office libraries are missing, install only the packages needed for the requested artifact:
+
+```bash
+python -m pip install python-pptx openpyxl
+```
+
+Add `xlsxwriter` or `pandas` only when the workbook workflow needs charts, styled report generation, or dataframe export.
+
+## What This Skill Delivers
+
+Use this skill to create or modify Office files that remain editable and auditable. A complete run produces:
+
+- The source template/input files and library versions.
+- A deterministic script or notebook cell that writes the output artifact.
+- A structural validation of slides/sheets/text/formulas/named ranges.
+- A visual or rendered check when layout matters.
+- A final note listing assumptions, live data, manual edits, and any formulas intentionally overwritten.
+
+## Standalone Quick Start
+
+If there is no existing template, create a minimal editable deck:
+
+```python
+from pptx import Presentation
+
+prs = Presentation()
+slide = prs.slides.add_slide(prs.slide_layouts[0])
+slide.shapes.title.text = "Status Update"
+slide.placeholders[1].text = "Generated with python-pptx"
+prs.save("output.pptx")
+```
+
+Create a minimal workbook with formulas preserved:
+
+```python
+from openpyxl import Workbook
+
+wb = Workbook()
+ws = wb.active
+ws.title = "Model"
+ws["A1"] = "Revenue"
+ws["B1"] = 100
+ws["A2"] = "Growth"
+ws["B2"] = 0.10
+ws["A3"] = "Next"
+ws["B3"] = "=B1*(1+B2)"
+wb.save("output.xlsx")
+```
+
+Immediately prove the files reopen and preserve editable content:
+
+```python
+from pptx import Presentation
+from openpyxl import load_workbook
+
+prs = Presentation("output.pptx")
+assert len(prs.slides) >= 1
+assert prs.slides[0].shapes.title.text
+
+wb = load_workbook("output.xlsx", data_only=False)
+assert wb["Model"]["B3"].value == "=B1*(1+B2)"
+```
+
+For user work, prefer editing their template instead of starting from blank files.
+
+## Workflow
+
+1. Identify the artifact: presentation, workbook, or model-backed deck.
+2. Inspect existing files before editing:
+   - For `.pptx`, inspect slide count, layouts, placeholders, notes, images, and charts.
+   - For `.xlsx`, inspect sheet names, dimensions, formulas, named ranges, merged cells, and charts.
+3. Preserve templates, styles, and formulas unless the user asks to redesign.
+4. Make deterministic edits with `python-pptx`, `openpyxl`, or the repo's existing tooling.
+5. Reopen the output and verify structure, text, formulas, and key visual elements.
+
+## PowerPoint
+
+- Use existing slide masters and layouts when available.
+- Keep titles, labels, and notes editable as text.
+- Avoid placing important content only in raster images.
+- Check that text fits in its shape and does not overlap other elements.
+- Use speaker notes for narration, assumptions, or source detail when appropriate.
+- For charts, preserve data provenance or include the source workbook when possible.
+
+## Excel
+
+- Prefer formulas over hardcoded outputs when a workbook is meant to be auditable.
+- Use named ranges for key assumptions and outputs.
+- Keep inputs, calculations, and outputs visually distinct.
+- Validate workbook links, formulas, and sheet references after edits.
+- Avoid overwriting formulas with values unless explicitly requested.
+- For financial models, include balance checks, sensitivity tables, and clear assumptions when in scope.
+
+## Model-Backed Decks
+
+- Build or update the workbook first, then populate slides from workbook outputs.
+- Keep every deck number traceable to a workbook cell, table, or source.
+- Add a concise source or timestamp note when using live or unstable data.
+- Re-run deck generation after workbook changes instead of manually patching derived numbers.
+
+## References
+
+Open `references/workflows.md` for detailed PowerPoint template editing, layout checks, Excel formulas/named ranges/charts, model-backed decks, validation, and review artifacts.
+
+Open `references/mastery.md` for Office artifact mental models, editability/auditability rules, formula and chart risks, model-backed deck design, and review standards.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in mined/source repository evidence.
+
+Traceability contract for generated numbers:
+
+```text
+slide:
+visible number:
+workbook sheet/cell or source row:
+formula or transformation:
+timestamp/source:
+```
+
+## Validation
+
+Useful checks include:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+print(Path("output.pptx").stat().st_size)
+print(Path("output.xlsx").stat().st_size)
+PY
+```
+
+Reopen PowerPoint outputs and inspect editable structure:
+
+```bash
+python - <<'PY'
+from pptx import Presentation
+
+prs = Presentation("output.pptx")
+print("slides", len(prs.slides))
+for i, slide in enumerate(prs.slides, 1):
+    texts = [shape.text for shape in slide.shapes if hasattr(shape, "text") and shape.text.strip()]
+    print(i, texts[:3])
+PY
+```
+
+Reopen Excel outputs with formulas preserved:
+
+```bash
+python - <<'PY'
+from openpyxl import load_workbook
+
+wb = load_workbook("output.xlsx", data_only=False)
+print(wb.sheetnames)
+for ws in wb.worksheets:
+    formulas = [cell.coordinate for row in ws.iter_rows() for cell in row if isinstance(cell.value, str) and cell.value.startswith("=")]
+    print(ws.title, ws.max_row, ws.max_column, formulas[:10])
+PY
+```
+
+If visual fidelity matters, render or preview the document and check for clipping, overlap, missing fonts, and chart sizing.
+
+## Done Criteria
+
+- The file opens with the expected slide/sheet structure.
+- Key text, formulas, charts, and generated numbers are verified.
+- Any assumptions, live data sources, or manual edits are called out.
+- The final notes include output paths and the validation commands used.

--- a/skills/.curated/powerpoint-excel-authoring/agents/openai.yaml
+++ b/skills/.curated/powerpoint-excel-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PowerPoint and Excel"
+  short_description: "Create and edit decks and workbooks"
+  default_prompt: "Use $powerpoint-excel-authoring to create, edit, or validate this deck or workbook."

--- a/skills/.curated/powerpoint-excel-authoring/references/mastery.md
+++ b/skills/.curated/powerpoint-excel-authoring/references/mastery.md
@@ -1,0 +1,44 @@
+# PowerPoint and Excel Authoring Mastery Notes
+
+## Mental Model
+
+Office artifacts are structured documents, not screenshots. A good generated deck or workbook remains editable, auditable, and traceable after the agent finishes.
+
+## PowerPoint Principles
+
+- Reuse slide masters and layouts.
+- Keep titles, labels, tables, and notes as editable objects.
+- Preserve speaker notes when updating decks.
+- Avoid rasterizing data unless the user asks for an image.
+- Validate visual layout after structural validation.
+
+## Excel Principles
+
+- Preserve formulas when auditability matters.
+- Separate inputs, calculations, and outputs.
+- Use named ranges for key assumptions.
+- Avoid overwriting formulas with values.
+- Treat `data_only=True` carefully because it reads cached values.
+
+## Model-Backed Decks
+
+Deck numbers should trace to workbook cells or source rows. The workbook is the source of truth; regenerate slides after workbook changes instead of manually patching derived numbers.
+
+## Common Risks
+
+- formulas broken by row/column insertions
+- chart references not updated
+- merged cells hiding data
+- missing fonts changing layout
+- text overflow in placeholders
+- stale cached formula values
+
+## Review Standard
+
+A complete Office artifact change proves:
+
+- output files open structurally
+- key text/formulas/named ranges are present
+- generated numbers are traceable
+- visual preview is checked when layout matters
+- assumptions and live data sources are documented

--- a/skills/.curated/powerpoint-excel-authoring/references/source-evidence.md
+++ b/skills/.curated/powerpoint-excel-authoring/references/source-evidence.md
@@ -1,0 +1,41 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. Office automation must produce editable, inspectable artifacts rather than screenshots or brittle one-off files.
+
+## Retrieved Sources
+
+- `deepset-ai/haystack`: `PPTXToDocument`, `XLSXToDocument`, multi-file conversion docs, and dependencies on `python-pptx`, `openpyxl`, `pandas`, and `tabulate`.
+- `OpenHands/OpenHands`: lock evidence for `openpyxl` 3.1.5 and `python-pptx` 1.0.2.
+- `letta-ai/letta`: lock evidence for `python-pptx` 1.0.2.
+- `MetaGPT`: `.xlsx` document-store fixtures and spreadsheet-backed retrieval examples.
+
+## Workflows Reflected In The Skill
+
+### Editable Office Artifacts
+
+Haystack converter evidence treats `.pptx` and `.xlsx` as structured files with extractable document content. The skill therefore requires agents to preserve editability:
+
+- use real PowerPoint shapes, placeholders, notes, and layouts instead of flat images;
+- use workbook cells, formulas, named ranges, tables, and charts instead of static screenshots;
+- keep source data and generated outputs auditable.
+
+### Template-Preserving PowerPoint Work
+
+PowerPoint workflows must respect slide masters, existing layouts, brand fonts/colors, and placeholders. The skill covers template inspection, slide generation, notes/speaker context, and validation by reopening the file.
+
+### Excel Modeling And Reporting
+
+Spreadsheet workflows must preserve formulas and workbook semantics. The skill requires:
+
+- formula and named-range checks;
+- chart source-range validation;
+- table formatting and sheet protection when relevant;
+- recalculation/openability notes when generated outside Excel.
+
+### Document Conversion And Retrieval Use Cases
+
+Haystack and MetaGPT evidence shows Office files used as inputs to document pipelines and retrieval stores. The skill therefore covers both authoring and extraction-oriented checks: generated files should be readable by common libraries and retain meaningful text/table content.
+
+## Review Standard
+
+Reject Office automation that only creates visually plausible files. A useful workflow must prove the artifact opens, content remains editable, formulas and chart ranges are inspectable, and extraction/reload checks pass for the target use case.

--- a/skills/.curated/powerpoint-excel-authoring/references/workflows.md
+++ b/skills/.curated/powerpoint-excel-authoring/references/workflows.md
@@ -1,0 +1,87 @@
+# PowerPoint and Excel Authoring Workflows
+
+Use this reference to produce Office files that are editable, auditable, and validated.
+
+## PowerPoint Workflow
+
+1. Inspect template slide layouts and placeholders.
+2. Reuse slide masters when possible.
+3. Keep text as editable text.
+4. Avoid rasterizing tables or key numbers.
+5. Validate slide count, text, notes, images, and chart objects.
+6. Render or preview when layout fidelity matters.
+
+Inspect:
+
+```python
+from pptx import Presentation
+prs = Presentation("deck.pptx")
+for i, slide in enumerate(prs.slides, 1):
+    print(i, [shape.text for shape in slide.shapes if hasattr(shape, "text") and shape.text.strip()])
+```
+
+## Excel Workflow
+
+1. Inspect sheets, named ranges, formulas, charts, merged cells, and workbook links.
+2. Preserve formulas unless the user asks for values.
+3. Keep inputs, calculations, and outputs distinct.
+4. Use named ranges for important assumptions.
+5. Validate formulas with `data_only=False`; inspect calculated values with `data_only=True` only if Excel or another engine has recalculated.
+
+Inspect formulas:
+
+```python
+from openpyxl import load_workbook
+wb = load_workbook("model.xlsx", data_only=False)
+for ws in wb.worksheets:
+    formulas = [cell.coordinate for row in ws.iter_rows() for cell in row if isinstance(cell.value, str) and cell.value.startswith("=")]
+    print(ws.title, formulas[:20])
+```
+
+## Model-Backed Decks
+
+Build order:
+
+1. Update workbook assumptions and formulas.
+2. Validate workbook checks.
+3. Extract slide-ready tables/numbers.
+4. Generate deck from workbook outputs.
+5. Reopen deck and verify every generated number.
+
+Trace every visible number:
+
+```text
+slide:
+shape/table:
+visible value:
+workbook sheet/cell:
+source:
+timestamp:
+```
+
+## Layout Validation
+
+Check:
+
+- text overflow or clipping
+- overlapping shapes
+- missing fonts
+- chart label collisions
+- wide table fit
+- speaker notes preservation
+
+Use LibreOffice, PowerPoint, or another renderer when visual fidelity matters.
+
+## Final Artifact
+
+Final notes should include:
+
+```text
+input/template files:
+output files:
+library versions:
+validation commands:
+formula/named-range checks:
+visual preview status:
+assumptions or manual edits:
+```


### PR DESCRIPTION
## Summary

Adds the `powerpoint-excel-authoring` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents mined python-pptx 1.0.2 and openpyxl 3.1.5 evidence.

## Validation

- Ran the local skill validator against `skills/.curated/powerpoint-excel-authoring`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands so users can identify incompatible local versions before applying version-sensitive guidance.