### PR TITLE
Add repo skill miner skill

### DIFF
--- a/skills/.curated/repo-skill-miner/LICENSE.txt
+++ b/skills/.curated/repo-skill-miner/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don\'t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/.curated/repo-skill-miner/SKILL.md
+++ b/skills/.curated/repo-skill-miner/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: repo-skill-miner
+description: Crawl, index, analyze, and export reusable skill candidates from source repositories using repo-skills-miner. Use when the user wants to mine a codebase for OpenAI/Codex skills, build a repository skill dataset, find skill-worthy workflows in one or many repos, generate skill cards, compare mined skills against an existing skill catalog, or prepare candidate SKILL.md pull requests.
+---
+
+# Repo Skill Miner
+
+Use this skill to turn source repositories into reviewed skill candidates. The goal is not to blindly convert every function into a skill; it is to extract evidence, rank useful workflows, and draft small OpenAI-compatible `SKILL.md` folders for the highest-value capabilities.
+
+## Validated Version Evidence
+
+This guidance was checked against `https://github.com/peytontolbert/repository-skill-miner` at commit `98ef6f8b75dc351f01c7ab71c4651f177c82846d`. The miner's dependency file lists `transformers`, `torch`, and `pyarrow`, but the actual annotation/export behavior depends on model, Parquet, and CLI versions.
+
+Capture the active miner and data stack before comparing results across runs:
+
+```bash
+git -C repository-skill-miner rev-parse HEAD
+python - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+for package in ["transformers", "torch", "pyarrow", "pandas", "typer", "rich"]:
+    try:
+        print(package, version(package))
+    except PackageNotFoundError:
+        print(package, "not installed")
+PY
+```
+
+## What This Skill Delivers
+
+Use this skill to take a user from "I have repositories" to a ranked set of skill candidates with evidence. A complete run produces:
+
+- A miner checkout or a clear install blocker.
+- A database/store containing the ingested target repo revisions.
+- Search results or cards showing candidate workflows.
+- A ranked table of recommended skills with source evidence, overlap, risk, and PR scope.
+- Draft `SKILL.md` folders only for candidates that are broad, safe, and distinct from existing skills.
+
+Do not assume the user knows the miner. If it is not present, introduce it as the repository skill miner project and set it up from source.
+
+## Install or Locate the Miner
+
+If the user provides an existing checkout, use it after recording its remote and commit:
+
+```bash
+git -C repository-skill-miner remote -v
+git -C repository-skill-miner rev-parse HEAD
+```
+
+If no checkout exists, clone the GitHub repository and pin the validated commit before running commands:
+
+```bash
+git clone https://github.com/peytontolbert/repository-skill-miner.git
+cd repository-skill-miner
+git checkout 98ef6f8b75dc351f01c7ab71c4651f177c82846d
+```
+
+Install with the package manager the repo provides. If there is no pinned environment, use an isolated virtualenv:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install -U pip
+python -m pip install -r requirements.txt
+```
+
+If installation fails, stop with the failing package and Python version; do not continue with guessed commands.
+
+## Reusable Workflow Value
+
+The miner is useful only when it turns repository evidence into reusable agent procedures. Do not summarize a library. For each candidate, extract:
+
+- The repeated workflow a user wants completed.
+- The files, commands, or APIs that prove the workflow exists.
+- The version or commit where that workflow was observed.
+- The portable instructions an agent can follow in another repo.
+- The validation command or artifact proving completion.
+- The risks: secrets, license, private infra, huge artifacts, or duplicate OpenAI skills.
+
+Score candidates before drafting:
+
+| score | question |
+|---|---|
+| 0-3 | How many users/repos would benefit? |
+| 0-3 | Is this a repeatable workflow rather than a concept summary? |
+| 0-2 | Is there concrete source evidence and validation? |
+| 0-2 | Is it safe and license-clean to describe? |
+
+Only draft skills with a total score of 7 or higher unless the user explicitly wants exploratory drafts.
+
+## References
+
+Open `references/workflows.md` for detailed install checks, ingestion manifests, evidence review, candidate scoring, dataset export, OpenAI skill drafting, and review artifacts.
+
+Open `references/mastery.md` when deciding what counts as a skill-worthy workflow, how to avoid dataset-to-PR mistakes, how to audit evidence, and how to turn mined candidates into complete reusable skills.
+
+Open `references/source-evidence.md` when checking whether this skill covers workflows observed in the repository-skill-miner source and mined dataset evidence.
+
+## First Steps
+
+1. Locate or clone `https://github.com/peytontolbert/repository-skill-miner`; do not assume it is installed globally.
+2. Confirm the target repositories to mine and whether they are public, private, or sensitive.
+3. Create a dedicated output directory for the run, preferably outside the source repo being mined.
+4. Do not publish mined outputs until secrets, licenses, and source provenance have been reviewed.
+5. Write a run manifest with miner commit, target repo remotes/commits, excludes, annotation model, output directory, and timestamp.
+
+## Safety Rules
+
+- Treat repository crawling as data extraction. It may copy source snippets, docs, config, and generated artifacts into SQLite, CAS blobs, JSONL, or Parquet.
+- Before mining private repos, ask whether secrets/config files should be excluded.
+- Exclude or redact `.env`, private keys, credentials, local caches, build outputs, dependency directories, and user data.
+- Do not include large artifacts, mined datasets, or source snippets in an OpenAI skills PR unless the user explicitly asks and licensing allows it.
+- Prefer generated skill instructions and provenance summaries over copied code.
+
+Useful excludes:
+
+```bash
+--exclude ".git,node_modules,.venv,venv,env,dist,build,__pycache__,.pytest_cache,.mypy_cache,.env,.secrets"
+```
+
+## Mine One Repository
+
+From the miner checkout:
+
+```bash
+python -m skill_engine --db skill_engine.db --store skill_engine_store init
+
+python -m skill_engine --db skill_engine.db --store skill_engine_store ingest \
+  --repo "$TARGET_REPO" \
+  --workers 4 \
+  --exclude ".git,node_modules,.venv,venv,env,dist,build,__pycache__,.pytest_cache,.mypy_cache,.env,.secrets"
+```
+
+Capture the `revision_id` from the `ingest_repo_ok` JSON log. Most follow-up commands use it.
+
+Expected result: a SQLite DB, a content-addressed store directory, and an `ingest_repo_ok` log line containing the target repo path and `revision_id`. If ingest emits secret-like files, stop and tighten excludes before building cards.
+
+Record the run in a small manifest:
+
+```json
+{
+  "miner_repo": "https://github.com/peytontolbert/repository-skill-miner",
+  "miner_commit": "98ef6f8b75dc351f01c7ab71c4651f177c82846d",
+  "target_repo": "<git remote, checkout, or archive source>",
+  "target_commit": "<commit sha>",
+  "revision_id": "<miner revision id>",
+  "excludes": [".git", "node_modules", ".env"],
+  "outputs": ["skill_engine.db", "skill_engine_store"]
+}
+```
+
+## Inspect Mined Skills
+
+Search by capability, framework, file type, or workflow:
+
+```bash
+python -m skill_engine --db skill_engine.db --store skill_engine_store agent-search \
+  --query "mcp OR fastmcp OR tools OR resources" \
+  --topk 20 \
+  --include-annotation
+```
+
+Fetch evidence for a candidate:
+
+```bash
+python -m skill_engine --db skill_engine.db --store skill_engine_store agent-get \
+  --skill-id <SKILL_ID> \
+  --include-doc \
+  --include-snippet \
+  --include-annotation
+```
+
+Emit skill cards for review:
+
+```bash
+python -m skill_engine --db skill_engine.db --store skill_engine_store cards \
+  --revision-id <REVISION_ID> \
+  --limit 2000 \
+  > skill_cards.jsonl
+```
+
+Expected result: `skill_cards.jsonl` where each line is a candidate with source path, evidence text, and metadata. If the file is empty, inspect whether the repo was ingested, whether excludes were too broad, and whether the query is too narrow.
+
+## Optional Annotation
+
+Annotation is expensive and may require local model setup. Use it only when deterministic metadata and source evidence are not enough.
+
+```bash
+python -m skill_engine --db skill_engine.db --store skill_engine_store annotate \
+  --revision-id <REVISION_ID> \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --cache-dir "$MODEL_CACHE" \
+  --offline \
+  --temperature 0
+```
+
+If the model is not already available, do not download large model weights without confirming cost, time, and disk use. Prefer deterministic metadata and search before adding LLM annotation.
+
+## Build a Dataset
+
+For HF-style Parquet datasets, use the repository's dataset builder only after card and annotation locations are known:
+
+```bash
+python scripts/build_hf_skills_dataset.py \
+  --source "label|$CARDS_PARQUET|$SOURCE_REPO|$ANNOTATION_DIR" \
+  --out-dir artifacts/hf_label_skills \
+  --max-excerpt-chars 12000
+```
+
+Review `dataset_summary.json` before treating the export as canonical.
+
+## Rank Candidates for OpenAI Skills
+
+Prefer candidates that are:
+
+- Broadly useful across many repositories or users.
+- Workflow-oriented, not single-function wrappers.
+- Safe to describe without copying sensitive implementation details.
+- Backed by enough source evidence to write reliable instructions.
+- Distinct from skills already present in `openai/skills`.
+- Small enough to review as one focused PR.
+
+Before proposing top candidates, compare against the existing skills catalog:
+
+```bash
+find "$OPENAI_SKILLS_REPO/skills/.curated" -maxdepth 2 -name SKILL.md -print \
+  | sort \
+  | sed 's#/SKILL.md$##'
+```
+
+Report ranked candidates in a table with `candidate`, `source repo(s)`, `evidence path or skill id`, `existing-skill overlap`, `risk`, and `recommended PR scope`.
+
+Minimum ranking output:
+
+| candidate | source repo(s) | evidence | overlap | risk | PR scope |
+|---|---|---|---|---|---|
+| short skill name | repo and revision | skill id/path/card line | existing skill names or none | secrets/license/version concerns | one focused skill folder |
+
+Each recommendation must explain reusable workflow value in one sentence:
+
+```text
+This is worth a skill because it lets an agent repeatedly <do workflow> across <repo/user class>, with validation via <command/artifact>.
+```
+
+Avoid candidates that are:
+
+- Repo-specific maintenance procedures.
+- Thin wrappers around a private CLI or local-only service.
+- Mostly copied code or huge reference dumps.
+- Dependent on secrets, private infrastructure, or unreviewed user data.
+- Already covered by an existing OpenAI skill.
+
+## Draft OpenAI Skill PRs
+
+For each selected candidate:
+
+1. Create one branch per skill.
+2. Add `skills/.curated/<skill-name>/SKILL.md`.
+3. Add `skills/.curated/<skill-name>/LICENSE.txt`.
+4. Add `skills/.curated/<skill-name>/agents/openai.yaml` when appropriate.
+5. Keep the skill concise; move large details into references only if they are necessary.
+6. Validate with the local skill validator if available.
+7. For review-first workflows, keep branches local until the user approves pushing.
+
+The draft must stand alone for someone who has never seen the mined repo. Include install or prerequisite checks, version capture, a happy-path command loop, failure modes, and done criteria. Do not ship only a topic overview.
+
+## Review Checklist
+
+- The source repos and dataset paths are recorded.
+- License and provenance are acceptable.
+- Secret-bearing files were excluded or redacted.
+- The candidate is not a duplicate of an existing skill.
+- The ranking explains why this skill provides reusable workflow value beyond a library summary.
+- The `description` frontmatter clearly states when the skill should trigger.
+- The body describes an actionable workflow with validation and failure modes.
+- The PR contains one logical skill, not a dataset dump.

--- a/skills/.curated/repo-skill-miner/agents/openai.yaml
+++ b/skills/.curated/repo-skill-miner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Skill Miner"
+  short_description: "Mine codebases for reusable skill candidates"
+  default_prompt: "Use $repo-skill-miner to mine this repository for high-value OpenAI skill candidates."

--- a/skills/.curated/repo-skill-miner/references/mastery.md
+++ b/skills/.curated/repo-skill-miner/references/mastery.md
@@ -1,0 +1,150 @@
+# Repository Skill Miner Mastery Notes
+
+This reference explains how to use repository mining to produce useful skills, not just data.
+
+## Contents
+
+- [What Counts as Skill-Worthy](#what-counts-as-skill-worthy)
+- [Evidence Quality](#evidence-quality)
+- [Mining Strategy](#mining-strategy)
+- [Candidate Clustering](#candidate-clustering)
+- [Existing Skill Overlap](#existing-skill-overlap)
+- [Skill Drafting Standard](#skill-drafting-standard)
+- [Safety and Licensing](#safety-and-licensing)
+- [Review Report Template](#review-report-template)
+- [Common Mistakes](#common-mistakes)
+
+## What Counts as Skill-Worthy
+
+A mined candidate is worth turning into a skill when it helps an agent repeatedly complete a workflow that appears across projects or users.
+
+Good candidates:
+
+- have a clear user goal
+- require procedural domain knowledge
+- have source evidence from real repositories
+- can be validated with commands or artifacts
+- are safe to describe without copying proprietary implementation
+- are distinct from existing skills
+
+Weak candidates:
+
+- describe a library at a high level
+- wrap one function
+- only apply to one private repo
+- require hidden credentials or infrastructure
+- depend on copying large code snippets
+- duplicate an accepted OpenAI skill
+
+## Evidence Quality
+
+Rank evidence by strength:
+
+1. working scripts, tests, CLIs, or configs
+2. docs that match working code
+3. repeated patterns across repos
+4. comments or README notes
+5. inferred behavior from isolated snippets
+
+Do not draft a skill from weak evidence unless the user explicitly asks for exploratory work.
+
+## Mining Strategy
+
+For one repo:
+
+1. Ingest with safe excludes.
+2. Search broad framework/workflow terms.
+3. Fetch candidate evidence.
+4. Cluster related candidates manually.
+5. Score candidates.
+6. Draft only the top workflows.
+
+For many repos:
+
+1. Normalize target repo names and commits.
+2. Build per-repo cards.
+3. Group by workflow class.
+4. Rank by breadth and validation strength.
+5. Check against existing skills.
+6. Draft one PR per skill.
+
+## Candidate Clustering
+
+Merge candidates when they serve one workflow:
+
+- setup + validation + troubleshooting for one tool
+- file format authoring + validation for one output class
+- model training + export for one framework
+
+Split candidates when they require different users, tools, or success criteria.
+
+## Existing Skill Overlap
+
+Before drafting, compare:
+
+- frontmatter descriptions
+- skill titles
+- reference topics
+- scripts/assets
+- accepted workflows
+
+If overlap exists, propose an update to the existing skill instead of a new skill unless the new workflow is clearly distinct.
+
+## Skill Drafting Standard
+
+Every drafted skill should answer:
+
+```text
+When should this trigger?
+What concrete outcome should the agent produce?
+What must be checked before work starts?
+What is the happy path?
+What are the main branches/variants?
+How is success validated?
+What can go wrong?
+What version or source evidence supports it?
+What deeper references should be loaded only when needed?
+```
+
+## Safety and Licensing
+
+Repository mining may copy data into intermediate artifacts. Always treat outputs as sensitive until reviewed.
+
+Reject or redact:
+
+- secrets
+- API keys
+- private URLs
+- credentials
+- personal data
+- large copied code blocks
+- license-incompatible content
+
+Prefer paraphrased workflows and provenance summaries over copied implementation.
+
+## Review Report Template
+
+```text
+miner source:
+miner commit:
+target repos:
+target commits:
+dataset outputs:
+candidate count:
+top 10 candidates:
+accepted candidates:
+rejected candidates:
+existing skill overlap:
+license/safety notes:
+recommended PRs:
+```
+
+## Common Mistakes
+
+- Treating frequency as value. A common pattern is not automatically a good skill.
+- Drafting a skill before checking existing accepted skills.
+- Copying too much source evidence into the PR.
+- Ignoring versions and commits.
+- Writing a library summary instead of a workflow.
+- Skipping validation commands.
+- Combining unrelated workflows into one broad skill.

--- a/skills/.curated/repo-skill-miner/references/source-evidence.md
+++ b/skills/.curated/repo-skill-miner/references/source-evidence.md
@@ -1,0 +1,50 @@
+# Source Evidence
+
+Use this file as the evidence anchor for the workflow coverage in this skill. This skill must make repository-skill-miner useful to a user who has never seen the project before.
+
+## Retrieved Sources
+
+- `https://github.com/peytontolbert/repository-skill-miner` at commit `98ef6f8b75dc351f01c7ab71c4651f177c82846d`.
+- Source modules for ingestion, storage, skill cards, semantic search, evidence scheduling, pattern distillation, server routes, and Parquet/card export.
+- Mined datasets containing source repository, source revision, source path, excerpt, annotations, and workflow-card style records.
+
+## Workflows Reflected In The Skill
+
+### Reproducible Mining Run
+
+The source stores repository revisions and source metadata, so the skill requires a run manifest with:
+
+- miner repository URL and commit;
+- target repository remote and commit;
+- excludes and permission assumptions;
+- annotation model and confidence threshold;
+- output dataset location;
+- timestamp and validation commands.
+
+The skill must never depend on a user-specific local checkout path.
+
+### Evidence And Card Review
+
+The source exposes revision-scoped skills, cards, evidence runs, signals, repository fingerprints, and pattern cards. The skill therefore teaches agents to inspect candidate skills against evidence:
+
+- source repo/revision/path;
+- excerpt and symbol context;
+- side effects and permissions;
+- verification artifacts where available;
+- transferability beyond one repository.
+
+### Search And Retrieval
+
+The source includes semantic search and server routes for searching skills/cards/signals. The skill requires agents to search candidates, cluster them by workflow value, and retrieve supporting evidence before drafting a skill.
+
+### Dataset Export
+
+Tests and CLI paths cover writing card outputs, including Parquet. The skill requires schema inspection and sample-row review before using exported datasets for PRs.
+
+### OpenAI Skill Drafting
+
+The mined output is not itself an OpenAI skill. The skill therefore requires a transformation step: select a real reusable workflow, write complete instructions, add validation and done criteria, and cite evidence by repository/commit rather than local paths.
+
+## Review Standard
+
+Reject repo-skill-miner outputs that are only lists of libraries or symbols. A useful workflow must produce a reproducible manifest, evidence-backed candidates, a transferability argument, and complete OpenAI skill content that a fresh agent can run without knowing the miner author's local environment.

--- a/skills/.curated/repo-skill-miner/references/workflows.md
+++ b/skills/.curated/repo-skill-miner/references/workflows.md
@@ -1,0 +1,141 @@
+# Repository Skill Miner Workflows
+
+Use this reference to run repeatable repository-mining projects and produce skill candidates with evidence.
+
+## Contents
+
+- [Source Setup](#source-setup)
+- [Run Manifest](#run-manifest)
+- [Ingestion Workflow](#ingestion-workflow)
+- [Evidence Review](#evidence-review)
+- [Candidate Scoring](#candidate-scoring)
+- [Dataset Export Review](#dataset-export-review)
+- [Skill Drafting](#skill-drafting)
+- [Review Artifact](#review-artifact)
+
+## Source Setup
+
+Use the GitHub source:
+
+```bash
+git clone https://github.com/peytontolbert/repository-skill-miner.git
+cd repository-skill-miner
+git checkout 98ef6f8b75dc351f01c7ab71c4651f177c82846d
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install -U pip
+python -m pip install -r requirements.txt
+```
+
+Record the actual commit even if the user chooses a newer revision.
+
+## Run Manifest
+
+Create a manifest before mining:
+
+```json
+{
+  "miner_repo": "https://github.com/peytontolbert/repository-skill-miner",
+  "miner_commit": "98ef6f8b75dc351f01c7ab71c4651f177c82846d",
+  "targets": [
+    {
+      "repo": "<remote or source>",
+      "commit": "<sha>",
+      "sensitivity": "public|private|sensitive"
+    }
+  ],
+  "excludes": [".git", "node_modules", ".env"],
+  "annotation": {
+    "enabled": false,
+    "model": null
+  },
+  "outputs": {}
+}
+```
+
+## Ingestion Workflow
+
+1. Initialize DB/store.
+2. Ingest with excludes.
+3. Capture `revision_id`.
+4. Spot-check stored docs/snippets for secrets.
+5. Only then build cards or annotations.
+
+Expected outputs:
+
+```text
+skill_engine.db
+skill_engine_store/
+ingest log with revision_id
+manifest updated with revision_id
+```
+
+## Evidence Review
+
+For each candidate, collect:
+
+- source repo and commit
+- file paths or skill IDs
+- doc evidence
+- code snippet evidence
+- observed commands or APIs
+- version constraints
+- safety/license concerns
+
+Reject candidates that require private credentials, copied source code, or undocumented local infrastructure.
+
+## Candidate Scoring
+
+Score 0-10:
+
+```text
+breadth:
+workflow specificity:
+source evidence:
+validation path:
+safety/license:
+overlap with existing skills:
+```
+
+Recommended threshold: 7+ for PR drafts.
+
+## Dataset Export Review
+
+Before treating a dataset as canonical:
+
+- Open `dataset_summary.json`.
+- Check row counts.
+- Check missing annotations.
+- Check source labels and paths.
+- Sample records from the Parquet file.
+- Verify excerpts do not contain secrets or huge copied code.
+
+## Skill Drafting
+
+A mined candidate becomes a real skill only after adding:
+
+- trigger-specific frontmatter description
+- setup/prerequisite checks
+- version evidence
+- happy-path workflow
+- troubleshooting
+- validation artifacts
+- done criteria
+- references for deeper workflows when needed
+
+Do not submit topic summaries.
+
+## Review Artifact
+
+Final mining report should include:
+
+```text
+miner repo/commit:
+target repos/commits:
+outputs:
+top candidates:
+rejected candidates:
+existing-skill overlap:
+license/safety notes:
+recommended PR branches:
+```


### PR DESCRIPTION
## Summary

Adds the `repo-skill-miner` Codex skill as a focused curated skill folder with:

- `SKILL.md` workflow guidance
- Apache license file matching existing curated skill structure
- `agents/openai.yaml` trigger metadata
- detailed `references/` workflow, mastery, and source-evidence files

## Version Evidence

Documents `https://github.com/peytontolbert/repository-skill-miner` at commit `98ef6f8b75dc351f01c7ab71c4651f177c82846d` and the active package stack needed for comparable mining/export runs.

## Validation

- Ran the local skill validator against `skills/.curated/repo-skill-miner`.
- Audited `SKILL.md` and references for machine-specific local path leakage.

## Review Notes

Ready for review. The skill includes version-capture commands, GitHub clone/setup instructions, a run manifest, candidate scoring, and required ranking output so users can produce reusable skill candidates rather than library summaries.